### PR TITLE
improve docker compose setup

### DIFF
--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -14,6 +14,9 @@ services:
 
   test:
     image: swift-cassandra-client:20.04-5.4
+    environment: []
+      #- SANITIZER_ARG: "--sanitize=thread"
+      #- TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
 
   shell:
     image: swift-cassandra-client:20.04-5.4

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -14,6 +14,9 @@ services:
 
   test:
     image: swift-cassandra-client:20.04-5.5
+    environment: []
+      #- SANITIZER_ARG: "--sanitize=thread"
+      #- TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
 
   shell:
     image: swift-cassandra-client:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -14,6 +14,9 @@ services:
 
   test:
     image: swift-cassandra-client:20.04-5.6
+    environment: []
+      #- SANITIZER_ARG: "--sanitize=thread"
+      #- TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
 
   shell:
     image: swift-cassandra-client:20.04-5.6

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -13,6 +13,9 @@ services:
 
   test:
     image: swift-cassandra-client:20.04-5.7
+    environment: []
+      #- SANITIZER_ARG: "--sanitize=thread"
+      #- TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
 
   shell:
     image: swift-cassandra-client:20.04-5.7

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -13,6 +13,9 @@ services:
 
   test:
     image: swift-cassandra-client:20.04-main
+    environment: []
+      #- SANITIZER_ARG: "--sanitize=thread"
+      #- TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
 
   shell:
     image: swift-cassandra-client:20.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,8 +11,10 @@ services:
       CASSANDRA_USER: cassandra
       CASSANDRA_PASSWORD: cassandra
       CASSANDRA_KEYSPACE: cassandra
+    networks:
+      - cassandra
     ports:
-      - 9042:9042
+      - 9042
 
   runtime-setup:
     image: swift-cassandra-client:default
@@ -37,10 +39,8 @@ services:
 
   build:
     <<: *common
-    environment:
-      SANITIZER_ARG: "--sanitize=thread"
-      TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
-    command: /bin/bash -xcl "swift build $${SANITIZER_ARG-}"
+    environment: []
+    command: /bin/bash -cl "swift build"
 
   test:
     <<: *common
@@ -51,21 +51,27 @@ services:
       CASSANDRA_USER: cassandra
       CASSANDRA_PASSWORD: cassandra
       CASSANDRA_KEYSPACE: cassandra
-      SANITIZER_ARG: "--sanitize=thread"
-      TSAN_OPTIONS: "no_huge_pages_for_shadow=0 suppressions=/code/tsan_suppressions.txt"
     command: >
       /bin/bash -xcl "
-        while ! nc -z cassandra 9042;
-        do
+        swift build --build-tests $${SANITIZER_ARG-} && \
+
+        while ! nc -z cassandra 9042; do
           echo Waiting for Cassandra...;
-        sleep 3;
+          sleep 3;
         done;
 
-        swift test --enable-test-discovery $${SANITIZER_ARG-}
+        swift test $${SANITIZER_ARG-}
       "
+    networks:
+     - cassandra
 
   # util
 
   shell:
     <<: *common
     entrypoint: /bin/bash
+
+# dedicated network
+
+networks:
+  cassandra:


### PR DESCRIPTION
motivation: ci setup

changes:
* use custom network
* remove external port mapping
* call build-tests prior to starting cassandra wait loop to get early feedback on build failures
* move TSAN argument to version specific files
* remove --enable-test discovery as it the default already