### PR TITLE
Add .spi.yml for Swift Package Index DocC support

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [CassandraClient]


### PR DESCRIPTION
Setting up DocC doc on [Swift Package Index](https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/)