### PR TITLE
Add support to list type

### DIFF
--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -172,18 +172,29 @@ extension CassandraClient {
     }
 }
 
+// MARK: - Utils
+
+private func toString(cassValue: OpaquePointer) -> String? {
+    var value: UnsafePointer<CChar>?
+    var valueSize = 0
+    let error = cass_value_get_string(cassValue, &value, &valueSize)
+    guard let definiteValue = value, error == CASS_OK else {
+        return nil
+    }
+    let stringBuffer = UnsafeBufferPointer(start: definiteValue, count: valueSize)
+    return stringBuffer.withMemoryRebound(to: UInt8.self) {
+        String(decoding: $0, as: UTF8.self)
+    }
+}
+
 // MARK: - Int8
 
 extension CassandraClient.Column {
     /// Get column value as `Int8`.
     public var int8: Int8? {
         var value: Int8 = 0
-        let error = cass_value_get_int8(rawPointer, &value)
-        if error == CASS_OK {
-            return value
-        } else {
-            return nil
-        }
+        let error = cass_value_get_int8(self.rawPointer, &value)
+        return error == CASS_OK ? value : nil
     }
 }
 
@@ -205,7 +216,7 @@ extension CassandraClient.Column {
     /// Get column value as `Int16`.
     public var int16: Int16? {
         var value: Int16 = 0
-        let error = cass_value_get_int16(rawPointer, &value)
+        let error = cass_value_get_int16(self.rawPointer, &value)
         return error == CASS_OK ? value : nil
     }
 }
@@ -228,7 +239,7 @@ extension CassandraClient.Column {
     /// Get column value as `Int32`.
     public var int32: Int32? {
         var value: Int32 = 0
-        let error = cass_value_get_int32(rawPointer, &value)
+        let error = cass_value_get_int32(self.rawPointer, &value)
         return error == CASS_OK ? value : nil
     }
 }
@@ -251,7 +262,7 @@ extension CassandraClient.Column {
     /// Get column value as `UInt32`.
     public var uint32: UInt32? {
         var value: UInt32 = 0
-        let error = cass_value_get_uint32(rawPointer, &value)
+        let error = cass_value_get_uint32(self.rawPointer, &value)
         return error == CASS_OK ? value : nil
     }
 }
@@ -274,7 +285,7 @@ extension CassandraClient.Column {
     /// Get column value as `Int64`.
     public var int64: Int64? {
         var value: cass_int64_t = 0
-        let error = cass_value_get_int64(rawPointer, &value)
+        let error = cass_value_get_int64(self.rawPointer, &value)
         return error == CASS_OK ? Int64(value) : nil
     }
 }
@@ -297,7 +308,7 @@ extension CassandraClient.Column {
     /// Get column value as `Float32`.
     public var float32: Float32? {
         var value: Float32 = 0
-        let error = cass_value_get_float(rawPointer, &value)
+        let error = cass_value_get_float(self.rawPointer, &value)
         return error == CASS_OK ? value : nil
     }
 }
@@ -320,7 +331,7 @@ extension CassandraClient.Column {
     /// Get column value as `Double`.
     public var double: Double? {
         var value: Double = 0
-        let error = cass_value_get_double(rawPointer, &value)
+        let error = cass_value_get_double(self.rawPointer, &value)
         return error == CASS_OK ? value : nil
     }
 }
@@ -343,7 +354,7 @@ extension CassandraClient.Column {
     /// Get column value as `Bool`.
     public var bool: Bool? {
         var value = cass_bool_t(0)
-        let error = cass_value_get_bool(rawPointer, &value)
+        let error = cass_value_get_bool(self.rawPointer, &value)
         return error == CASS_OK ? value == cass_true : nil
     }
 }
@@ -365,16 +376,7 @@ extension CassandraClient.Row {
 extension CassandraClient.Column {
     /// Get column value as `String`.
     public var string: String? {
-        var value: UnsafePointer<CChar>?
-        var valueSize = 0
-        let error = cass_value_get_string(rawPointer, &value, &valueSize)
-        guard let definiteValue = value, error == CASS_OK else {
-            return nil
-        }
-        let stringBuffer = UnsafeBufferPointer(start: definiteValue, count: valueSize)
-        return stringBuffer.withMemoryRebound(to: UInt8.self) {
-            String(decoding: $0, as: UTF8.self)
-        }
+        toString(cassValue: self.rawPointer)
     }
 }
 
@@ -444,7 +446,7 @@ extension CassandraClient.Column {
     /// Get column value as `UUID`.
     public var uuid: Foundation.UUID? {
         var value = CassUuid()
-        let error = cass_value_get_uuid(rawPointer, &value)
+        let error = cass_value_get_uuid(self.rawPointer, &value)
         guard error == CASS_OK else {
             return nil
         }
@@ -454,7 +456,7 @@ extension CassandraClient.Column {
     /// Get column value as ``TimeBasedUUID``.
     public var timeuuid: TimeBasedUUID? {
         var value = CassUuid()
-        let error = cass_value_get_uuid(rawPointer, &value)
+        let error = cass_value_get_uuid(self.rawPointer, &value)
         guard error == CASS_OK else {
             return nil
         }
@@ -548,7 +550,7 @@ extension CassandraClient.Column {
     /// Get column date value as `UInt32`.
     public var date: UInt32? {
         var value: UInt32 = 0
-        let error = cass_value_get_uint32(rawPointer, &value)
+        let error = cass_value_get_uint32(self.rawPointer, &value)
         return error == CASS_OK ? value : nil
     }
 }
@@ -569,7 +571,7 @@ extension CassandraClient.Column {
     public var bytes: [UInt8]? {
         var value: UnsafePointer<UInt8>?
         var size = 0
-        let error = cass_value_get_bytes(rawPointer, &value, &size)
+        let error = cass_value_get_bytes(self.rawPointer, &value, &size)
         return error == CASS_OK ? Array(UnsafeBufferPointer(start: value, count: size)) : nil
     }
 }
@@ -593,11 +595,168 @@ extension CassandraClient.Column {
     public func withUnsafeBuffer<R>(closure: (UnsafeBufferPointer<UInt8>?) throws -> R) rethrows -> R {
         var value: UnsafePointer<UInt8>?
         var valueSize = Int()
-        let error = cass_value_get_bytes(rawPointer, &value, &valueSize)
+        let error = cass_value_get_bytes(self.rawPointer, &value, &valueSize)
         if error == CASS_OK {
             return try closure(UnsafeBufferPointer(start: value, count: valueSize))
         } else {
             return try closure(nil)
         }
+    }
+}
+
+// MARK: - Arrays
+
+extension CassandraClient.Column {
+    /// Get column value as `[Int8]`.
+    public var int8Array: [Int8]? {
+        self.toArray(type: Int8.self)
+    }
+
+    /// Get column value as `[Int16]`.
+    public var int16Array: [Int16]? {
+        self.toArray(type: Int16.self)
+    }
+
+    /// Get column value as `[Int32]`.
+    public var int32Array: [Int32]? {
+        self.toArray(type: Int32.self)
+    }
+
+    /// Get column value as `[Int64]`.
+    public var int64Array: [Int64]? {
+        self.toArray(type: Int64.self)
+    }
+
+    /// Get column value as `[Float32]`.
+    public var float32Array: [Float32]? {
+        self.toArray(type: Float32.self)
+    }
+
+    /// Get column value as `[Double]`.
+    public var doubleArray: [Double]? {
+        self.toArray(type: Double.self)
+    }
+
+    /// Get column value as `[String]`.
+    public var stringArray: [String]? {
+        self.toArray(type: String.self)
+    }
+
+    private func toArray<T>(type: T.Type) -> [T]? {
+        var array: [T] = []
+
+        let iterator = cass_iterator_from_collection(self.rawPointer)
+        while cass_iterator_next(iterator) == cass_true {
+            let valuePointer = cass_iterator_get_value(iterator)
+            let value: T?
+            switch type {
+            case is Int8.Type:
+                var v: Int8 = 0
+                let error = cass_value_get_int8(valuePointer, &v)
+                value = error == CASS_OK ? v as! T? : nil
+            case is Int16.Type:
+                var v: Int16 = 0
+                let error = cass_value_get_int16(valuePointer, &v)
+                value = error == CASS_OK ? v as! T? : nil
+            case is Int32.Type:
+                var v: Int32 = 0
+                let error = cass_value_get_int32(valuePointer, &v)
+                value = error == CASS_OK ? v as! T? : nil
+            case is Int64.Type:
+                var v: Int64 = 0
+                let error = cass_value_get_int64(valuePointer, &v)
+                value = error == CASS_OK ? v as! T? : nil
+            case is Float32.Type:
+                var v: Float32 = 0
+                let error = cass_value_get_float(valuePointer, &v)
+                value = error == CASS_OK ? v as! T? : nil
+            case is Double.Type:
+                var v: Double = 0
+                let error = cass_value_get_double(valuePointer, &v)
+                value = error == CASS_OK ? v as! T? : nil
+            case is String.Type:
+                value = valuePointer.flatMap { toString(cassValue: $0) as! T? }
+            default:
+                value = nil
+            }
+            guard let value = value else {
+                continue
+            }
+            array.append(value)
+        }
+
+        return array
+    }
+}
+
+extension CassandraClient.Row {
+    /// Get column value as `[Int8]`.
+    public func column(_ name: String) -> [Int8]? {
+        self.column(name)?.int8Array
+    }
+
+    /// Get column value as `[Int8]`.
+    public func column(_ index: Int) -> [Int8]? {
+        self.column(index)?.int8Array
+    }
+
+    /// Get column value as `[Int16]`.
+    public func column(_ name: String) -> [Int16]? {
+        self.column(name)?.int16Array
+    }
+
+    /// Get column value as `[Int16]`.
+    public func column(_ index: Int) -> [Int16]? {
+        self.column(index)?.int16Array
+    }
+
+    /// Get column value as `[Int32]`.
+    public func column(_ name: String) -> [Int32]? {
+        self.column(name)?.int32Array
+    }
+
+    /// Get column value as `[Int32]`.
+    public func column(_ index: Int) -> [Int32]? {
+        self.column(index)?.int32Array
+    }
+
+    /// Get column value as `[Int64]`.
+    public func column(_ name: String) -> [Int64]? {
+        self.column(name)?.int64Array
+    }
+
+    /// Get column value as `[Int64]`.
+    public func column(_ index: Int) -> [Int64]? {
+        self.column(index)?.int64Array
+    }
+
+    /// Get column value as `[Float32]`.
+    public func column(_ name: String) -> [Float32]? {
+        self.column(name)?.float32Array
+    }
+
+    /// Get column value as `[Float32]`.
+    public func column(_ index: Int) -> [Float32]? {
+        self.column(index)?.float32Array
+    }
+
+    /// Get column value as `[Double]`.
+    public func column(_ name: String) -> [Double]? {
+        self.column(name)?.doubleArray
+    }
+
+    /// Get column value as `[Double]`.
+    public func column(_ index: Int) -> [Double]? {
+        self.column(index)?.doubleArray
+    }
+
+    /// Get column value as `[String]`.
+    public func column(_ name: String) -> [String]? {
+        self.column(name)?.stringArray
+    }
+
+    /// Get column value as `[String]`.
+    public func column(_ index: Int) -> [String]? {
+        self.column(index)?.stringArray
     }
 }

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -653,29 +653,29 @@ extension CassandraClient.Column {
             case is Int8.Type:
                 var v: Int8 = 0
                 let error = cass_value_get_int8(valuePointer, &v)
-                value = error == CASS_OK ? v as! T? : nil
+                value = error == CASS_OK ? v as? T : nil
             case is Int16.Type:
                 var v: Int16 = 0
                 let error = cass_value_get_int16(valuePointer, &v)
-                value = error == CASS_OK ? v as! T? : nil
+                value = error == CASS_OK ? v as? T : nil
             case is Int32.Type:
                 var v: Int32 = 0
                 let error = cass_value_get_int32(valuePointer, &v)
-                value = error == CASS_OK ? v as! T? : nil
+                value = error == CASS_OK ? v as? T : nil
             case is Int64.Type:
                 var v: Int64 = 0
                 let error = cass_value_get_int64(valuePointer, &v)
-                value = error == CASS_OK ? v as! T? : nil
+                value = error == CASS_OK ? v as? T : nil
             case is Float32.Type:
                 var v: Float32 = 0
                 let error = cass_value_get_float(valuePointer, &v)
-                value = error == CASS_OK ? v as! T? : nil
+                value = error == CASS_OK ? v as? T : nil
             case is Double.Type:
                 var v: Double = 0
                 let error = cass_value_get_double(valuePointer, &v)
-                value = error == CASS_OK ? v as! T? : nil
+                value = error == CASS_OK ? v as? T : nil
             case is String.Type:
-                value = valuePointer.flatMap { toString(cassValue: $0) as! T? }
+                value = valuePointer.flatMap { toString(cassValue: $0) as? T }
             default:
                 value = nil
             }

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Cassandra Client open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift Cassandra Client project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift Cassandra Client project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -166,6 +166,41 @@ extension CassandraClient {
                 return value as! T
             } else if type == TimeBasedUUID.self {
                 guard let value: TimeBasedUUID = row.column(key.stringValue)?.timeuuid else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [Int8].self {
+                guard let value: [Int8] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [Int16].self {
+                guard let value: [Int16] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [Int32].self {
+                guard let value: [Int32] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [Int64].self {
+                guard let value: [Int64] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [Float32].self {
+                guard let value: [Float32] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [Double].self {
+                guard let value: [Double] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
+                }
+                return value as! T
+            } else if type == [String].self {
+                guard let value: [String] = row.column(key.stringValue) else {
                     throw DecodingError.typeMismatch("value for \(key.stringValue) not found or of incorrect data type.")
                 }
                 return value as! T

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -382,6 +382,33 @@ final class Tests: XCTestCase {
         #endif
     }
 
+    func testSelectIn() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);").wait())
+
+        let count = Int.random(in: 0 ... 100)
+        var futures = [EventLoopFuture<Void>]()
+        (0 ..< count).forEach { index in
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)]
+                )
+            )
+        }
+
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        let selectIDs: [Int32] = (0 ... Int.random(in: 1 ... 5)).map { _ in Int32.random(in: 0 ..< Int32(count)) }
+        let rows = try self.cassandraClient.query(
+            "select id, data from \(tableName) where id in ?;",
+            parameters: [.int32Array(selectIDs)]
+        ).wait()
+        XCTAssertEqual(Set(rows.compactMap { row in row.column(0)?.int32 }), Set(selectIDs), "result should match")
+    }
+
     func testDecoding() {
         struct Model: Codable, Equatable {
             let col1: Int8
@@ -397,6 +424,13 @@ final class Tests: XCTestCase {
             let col11: [UInt8]
             let col12: Bool
             let col13: String?
+            let col14: [Int8]
+            let col15: [Int16]
+            let col16: [Int32]
+            let col17: [Int64]
+            let col18: [Float32]
+            let col19: [Double]
+            let col20: [String]
             let doesNotExist: Bool?
         }
 
@@ -415,6 +449,13 @@ final class Tests: XCTestCase {
                 col11: randomBytes(size: Int.random(in: 10 ... 1024 * 1024)),
                 col12: Bool.random(),
                 col13: nil,
+                col14: (0 ... Int.random(in: 1 ... 3)).map { _ in Int8.random(in: Int8.min ... Int8.max) },
+                col15: (0 ... Int.random(in: 1 ... 3)).map { _ in Int16.random(in: Int16.min ... Int16.max) },
+                col16: (0 ... Int.random(in: 1 ... 3)).map { _ in Int32.random(in: Int32.min ... Int32.max) },
+                col17: (0 ... Int.random(in: 1 ... 3)).map { _ in Int64.random(in: Int64.min ... Int64.max) },
+                col18: (0 ... Int.random(in: 1 ... 3)).map { _ in Float32.random(in: Float(Int32.min) ... Float(Int32.max)) },
+                col19: (0 ... Int.random(in: 1 ... 3)).map { _ in Double.random(in: Double(Int64.min) ... Double(Int64.max)) },
+                col20: (0 ... Int.random(in: 1 ... 3)).map { _ in UUID().uuidString },
                 doesNotExist: nil
             )
         }
@@ -437,7 +478,14 @@ final class Tests: XCTestCase {
             col10 timeuuid,
             col11 blob,
             col12 boolean,
-            col13 text
+            col13 text,
+            col14 list<tinyint>,
+            col15 list<smallint>,
+            col16 list<int>,
+            col17 list<bigint>,
+            col18 list<float>,
+            col19 list<double>,
+            col20 list<text>
             );
             """
         ).wait())
@@ -456,14 +504,21 @@ final class Tests: XCTestCase {
                                                                  .timeuuid(model.col10),
                                                                  .bytes(model.col11),
                                                                  .bool(model.col12),
-                                                                 .null]
+                                                                 .null,
+                                                                 .int8Array(model.col14),
+                                                                 .int16Array(model.col15),
+                                                                 .int32Array(model.col16),
+                                                                 .int64Array(model.col17),
+                                                                 .float32Array(model.col18),
+                                                                 .doubleArray(model.col19),
+                                                                 .stringArray(model.col20)]
             futures.append(
                 self.cassandraClient.run(
                     """
                     insert into \(tableName)
-                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13)
+                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20)
                     values
-                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     parameters: parameters
                 )
@@ -490,6 +545,13 @@ final class Tests: XCTestCase {
             XCTAssertEqual(item.col11, data[index].col11, "results should match")
             XCTAssertEqual(item.col12, data[index].col12, "results should match")
             XCTAssertEqual(item.col13, data[index].col13, "results should match")
+            XCTAssertEqual(item.col14, data[index].col14, "results should match")
+            XCTAssertEqual(item.col15, data[index].col15, "results should match")
+            XCTAssertEqual(item.col16, data[index].col16, "results should match")
+            XCTAssertEqual(item.col17, data[index].col17, "results should match")
+            XCTAssertEqual(item.col18, data[index].col18, "results should match")
+            XCTAssertEqual(item.col19, data[index].col19, "results should match")
+            XCTAssertEqual(item.col20, data[index].col20, "results should match")
         }
     }
 
@@ -539,6 +601,13 @@ final class Tests: XCTestCase {
         col14 blob,
         col15 boolean,
         col16 text,
+        col17 list<tinyint>,
+        col18 list<smallint>,
+        col19 list<int>,
+        col20 list<bigint>,
+        col21 list<float>,
+        col22 list<double>,
+        col23 list<text>,
         )
         """).wait())
 
@@ -559,6 +628,13 @@ final class Tests: XCTestCase {
             let blob = self.randomBytes(size: Int.random(in: 10 ... 1024 * 1024))
             let bool = Bool.random()
             let null: String? = nil
+            let int8List = (0 ... Int.random(in: 1 ... 3)).map { _ in Int8.random(in: Int8.min ... Int8.max) }
+            let int16List = (0 ... Int.random(in: 1 ... 3)).map { _ in Int16.random(in: Int16.min ... Int16.max) }
+            let int32List = (0 ... Int.random(in: 1 ... 3)).map { _ in Int32.random(in: Int32.min ... Int32.max) }
+            let int64List = (0 ... Int.random(in: 1 ... 3)).map { _ in Int64.random(in: Int64.min ... Int64.max) }
+            let float32List = (0 ... Int.random(in: 1 ... 3)).map { _ in Float32.random(in: Float(Int32.min) ... Float(Int32.max)) }
+            let doubleList = (0 ... Int.random(in: 1 ... 3)).map { _ in Double.random(in: Double(Int64.min) ... Double(Int64.max)) }
+            let textList = (0 ... Int.random(in: 1 ... 3)).map { _ in UUID().uuidString }
 
             let parameters: [CassandraClient.Statement.Value] = [
                 .int8(index), // tinyint
@@ -577,13 +653,20 @@ final class Tests: XCTestCase {
                 .bytes(blob), // bytes
                 .bool(bool),
                 .null,
+                .int8Array(int8List), // list<tinyint>
+                .int16Array(int16List), // list<smallint>
+                .int32Array(int32List), // list<int>
+                .int64Array(int64List), // list<bigint>
+                .float32Array(float32List), // list<float>
+                .doubleArray(doubleList), // list<double>
+                .stringArray(textList), // list<text>
             ]
 
             XCTAssertNoThrow(try self.cassandraClient.run("""
             insert into \(tableName)
-            (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16)
+            (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21, col22, col23)
             values
-            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, parameters: parameters).wait())
 
             let result = try! self.cassandraClient.query("select * from \(tableName);").wait()
@@ -605,6 +688,13 @@ final class Tests: XCTestCase {
             XCTAssertEqual(row.column("col14"), blob, "expected value to match")
             XCTAssertEqual(row.column("col15"), bool, "expected value to match")
             XCTAssertEqual(row.column("col16"), null, "expected value to match")
+            XCTAssertEqual(row.column("col17"), int8List, "expected value to match")
+            XCTAssertEqual(row.column("col18"), int16List, "expected value to match")
+            XCTAssertEqual(row.column("col19"), int32List, "expected value to match")
+            XCTAssertEqual(row.column("col20"), int64List, "expected value to match")
+            XCTAssertEqual(row.column("col21"), float32List, "expected value to match")
+            XCTAssertEqual(row.column("col22"), doubleList, "expected value to match")
+            XCTAssertEqual(row.column("col23"), textList, "expected value to match")
         }
     }
 

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -386,7 +386,7 @@ final class Tests: XCTestCase {
         let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
         XCTAssertNoThrow(try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);").wait())
 
-        let count = Int.random(in: 0 ... 100)
+        let count = Int.random(in: 5 ... 100)
         var futures = [EventLoopFuture<Void>]()
         (0 ..< count).forEach { index in
             futures.append(


### PR DESCRIPTION
- Add support for read/write collection `list` column
- Add support for querying with parameter of array type (e.g., `select ... in <array>`)

Currently `[Int8]`, `[Int16]`, `[Int32]`, `[Int64]`, `[Float32]`, `[Double]`, and `[String]` are supported.

Resolves https://github.com/apple/swift-cassandra-client/issues/24
