### PR TITLE
Add Hashable to Configuration & Consistency enums

### DIFF
--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -51,12 +51,12 @@ extension CassandraClient {
         /// Sets the cluster's consistency level. Default is `.localOne`.
         public var consistency: CassandraClient.Consistency?
 
-        public enum SpeculativeExecutionPolicy {
+        public enum SpeculativeExecutionPolicy: Hashable {
             case constant(delayInMillseconds: Int64, maxExecutions: Int32)
             case disabled
         }
 
-        public enum PrepareStrategy {
+        public enum PrepareStrategy: Hashable {
             case allHosts
             case upOrAddHost
         }

--- a/Sources/CassandraClient/Consistency.swift
+++ b/Sources/CassandraClient/Consistency.swift
@@ -16,7 +16,7 @@
 
 extension CassandraClient {
     /// Consistency levels
-    public enum Consistency {
+    public enum Consistency: Hashable {
         case any
         case one
         case two


### PR DESCRIPTION
There are a few simple public enums which I think it would be convenient if they were equatable, and if Equatable why not Hashable.

### Motivation:

I think it would be useful if these simple enums e.g `SpeculativeExecutionPolicy` were `Equatable` to allow things like assertions to operate on them conveniently.

### Modifications:

Add `Hashable` conformance to some simple enums.
* `Configuration.SpeculativeExecutionPolicy`
* `Configuration.PrepareStrategy`
* `Consistency`

### Result:

More ergonomic comparison and use of enums.
