### PR TITLE
Symlink header files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,6 @@ let package = Package(
                 "./datastax-cpp-driver/src",
                 "./custom/src",
             ],
-            publicHeadersPath: "./datastax-cpp-driver/include",
             cxxSettings: [
                 .headerSearchPath("./custom/include"),
                 .headerSearchPath("./extras"),

--- a/Sources/CDataStaxDriver/include/cassandra.h
+++ b/Sources/CDataStaxDriver/include/cassandra.h
@@ -1,0 +1,1 @@
+../datastax-cpp-driver/include/cassandra.h

--- a/Sources/CDataStaxDriver/include/dse.h
+++ b/Sources/CDataStaxDriver/include/dse.h
@@ -1,0 +1,1 @@
+../datastax-cpp-driver/include/dse.h

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the Swift Cassandra Client open source project
 ##
-## Copyright (c) 2022-2023 Apple Inc. and the Swift Cassandra Client project authors
+## Copyright (c) 2022-2024 Apple Inc. and the Swift Cassandra Client project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2022-2023/YEARS/' -e 's/202[23]/YEARS/'
+    sed -e 's/202[23]-202[34]/YEARS/' -e 's/202[234]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "
@@ -60,7 +60,7 @@ for language in swift-or-c bash dtrace; do
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)
-        exceptions=( -path '*Sources/CDataStaxDriver/datastax-cpp-driver/*' -o -path '*Sources/Clibuv/libuv/*' -o -name uv.h -o -name Package.swift -o -name 'Package@*.swift' )
+        exceptions=( -path '*Sources/CDataStaxDriver/datastax-cpp-driver/*' -o -path '*Sources/CDataStaxDriver/include/*' -o -path '*Sources/Clibuv/libuv/*' -o -name uv.h -o -name Package.swift -o -name 'Package@*.swift' )
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Motivation:
On some platforms `swift build` is failing with error:

```
 public headers ("include") directory path for 'CDataStaxDriver' is invalid or not contained in the target
```

Modifications:
Copying https://github.com/swift-server/swift-kafka-client's structure, adding `CDataStaxDriver/include` and symlinks to header files under `datastax-cpp-driver/include`.

rdar://123389483
