### PR TITLE
Make Statement.setPagingSize method public

### DIFF
--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -342,7 +342,7 @@ extension CassandraClient {
             let eventLoop = eventLoop ?? self.eventLoopGroup.next()
 
             do {
-                try statement.setPagingSize(pageSize)
+                try statement.setPagingSize(Int(pageSize))
             } catch {
                 return eventLoop.makeFailedFuture(error)
             }
@@ -559,7 +559,7 @@ extension CassandraClient.Session {
     )
         async throws -> CassandraClient.PaginatedRows
     {
-        try statement.setPagingSize(pageSize)
+        try statement.setPagingSize(Int(pageSize))
         return CassandraClient.PaginatedRows(session: self, statement: statement, logger: logger)
     }
 

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -146,7 +146,8 @@ extension CassandraClient {
             return cass_statement_bind_collection(self.rawPointer, index, collection)
         }
 
-        func setPagingSize(_ pagingSize: Int32) throws {
+        /// Sets the paging size of the returned paginated results.
+        public func setPagingSize(_ pagingSize: Int32) throws {
             try checkResult { cass_statement_set_paging_size(self.rawPointer, pagingSize) }
         }
 

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -147,8 +147,8 @@ extension CassandraClient {
         }
 
         /// Sets the paging size of the returned paginated results.
-        public func setPagingSize(_ pagingSize: Int32) throws {
-            try checkResult { cass_statement_set_paging_size(self.rawPointer, pagingSize) }
+        public func setPagingSize(_ pagingSize: Int) throws {
+            try checkResult { cass_statement_set_paging_size(self.rawPointer, Int32(clamping: pagingSize)) }
         }
 
         /// Sets the starting page of the returned paginated results.


### PR DESCRIPTION
Make Statement.setPagingSize method public

### Motivation:

In some cases we may need to change paging size to reduce chances of read timeouts

### Modifications:

The method setPagingSize() existed but wasn't public so was inaccessible for clients

### Result:

With this change it would become public and let a client to set custom paging sizes on per statement basis
