### PR TITLE
Config to enable release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - ⚠️ semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none


### PR DESCRIPTION
Motivation:

Allow use of standard github tooling.

Modifications:

Add configuration for patch types.

Result:

GitHub release notes generation usable