### PR TITLE
CI use 6.1 nightlies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,13 +27,13 @@ on:
         type: string
         description: "The arguments passed to swift test in the Linux 6.0 Swift version matrix job."
         default: ""
-      linux_nightly_6_0_enabled:
+      linux_nightly_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Linux nightly 6.0 Swift version matrix job. Defaults to true."
+        description: "Boolean to enable the Linux nightly 6.1 Swift version matrix job. Defaults to true."
         default: true
-      linux_nightly_6_0_arguments_override:
+      linux_nightly_6_1_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Linux nightly 6.0 Swift version matrix job."
+        description: "The arguments passed to swift test in the Linux nightly 6.1 Swift version matrix job."
         default: ""
       linux_nightly_main_enabled:
         type: boolean
@@ -46,7 +46,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit tests
+    name: Unit tests (${{ matrix.swift.swift_version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,9 +62,9 @@ jobs:
           - image: "swift:6.0-jammy"
             swift_version: "6.0"
             enabled: ${{ inputs.linux_6_0_enabled }}
-          - image: "swiftlang/swift:nightly-6.0-jammy"
-            swift_version: "nightly-6.0"
-            enabled: ${{ inputs.linux_nightly_6_0_enabled }}
+          - image: "swiftlang/swift:nightly-6.1-jammy"
+            swift_version: "nightly-6.1"
+            enabled: ${{ inputs.linux_nightly_6_1_enabled }}
           - image: "swiftlang/swift:nightly-main-jammy"
             swift_version: "nightly-main"
             enabled: ${{ inputs.linux_nightly_main_enabled }}
@@ -87,7 +87,7 @@ jobs:
           COMMAND_OVERRIDE_5_9: "swift test ${{ inputs.linux_5_9_arguments_override }}"
           COMMAND_OVERRIDE_5_10: "swift test ${{ inputs.linux_5_10_arguments_override }}"
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
-          COMMAND_OVERRIDE_NIGHTLY_6_0: "swift test ${{ inputs.linux_nightly_6_0_arguments_override }}"
+          COMMAND_OVERRIDE_NIGHTLY_6_1: "swift test ${{ inputs.linux_nightly_6_1_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_MAIN: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
           CASSANDRA_HOST: cassandra
           CASSANDRA_CQL_PORT: 9042


### PR DESCRIPTION
CI use 6.1 nightlies now that Swift development is happening in the 6.1 branch
