### PR TITLE
Partially disable macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,3 +26,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-cassandra-client
+      swift_test_enabled: false  # requires running Cassandra server
+      watchos_xcode_build_enabled: false  # posix API availability
+      tvos_xcode_build_enabled: false  # posix API availability
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,3 @@ jobs:
       swift_test_enabled: false  # requires running Cassandra server
       watchos_xcode_build_enabled: false  # posix API availability
       tvos_xcode_build_enabled: false  # posix API availability
-


### PR DESCRIPTION
Partially disable macOS tests
* Disable unit tests because they don't have a running Cassandra server to test against
* Disable watchOS and tvOS builds due to issue with `libuv` on these platforms: 'posix_spawn' has been explicitly marked unavailable`
