### PR TITLE
Enable macOS CI on pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,3 +25,13 @@ jobs:
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  macos-tests:
+    name: macOS tests
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    with:
+      build_scheme: swift-cassandra-client
+      swift_test_enabled: false # requires running Cassandra server
+      watchos_xcode_build_enabled: false # posix API availability
+      tvos_xcode_build_enabled: false # posix API availability
+      runner_pool: general

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-cassandra-client
-      swift_test_enabled: false # requires running Cassandra server
-      watchos_xcode_build_enabled: false # posix API availability
-      tvos_xcode_build_enabled: false # posix API availability
+      swift_test_enabled: false  # requires running Cassandra server
+      watchos_xcode_build_enabled: false  # posix API availability
+      tvos_xcode_build_enabled: false  # posix API availability
       runner_pool: general


### PR DESCRIPTION
Motivation:

* Improve test coverage

Modifications:

Enable macOS CI to be run on pull request commits and make the use of the nightly runner pool for main.yml jobs explicit.

Result:

Improved test coverage.
