### PR TITLE
Lock an exact swift-nio-ssl dependency version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,7 +101,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.41.1")),
-        .package(url: "https://github.com/apple/swift-nio-ssl", .upToNextMajor(from: "2.29.3")),
+        .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.32.0"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
     ],


### PR DESCRIPTION
### Motivation:

The Cassandra client uses parts of Swift NIOSSL that aren't technically API, so to avoid breakages between minor/patch versions, we should depend on exactly the last qualified version of the dependency.

### Modifications:

Updated the dependency version constraint type, and specified the latest released version.

### Result:

No more breaks when Swift NIOSSL releases a new version.
