### PR TITLE
Update internal typealias misspelling

### DIFF
--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -21,7 +21,7 @@ import NIOConcurrencyHelpers
 /// `CassandraClient` is a wrapper around the [Datastax Cassandra C++ Driver](https://github.com/datastax/cpp-driver)
 ///  and can be used to run queries against a Cassandra database.
 public class CassandraClient: CassandraSession {
-    private let eventLoopGroupContainer: EventLoopGroupConainer
+    private let eventLoopGroupContainer: EventLoopGroupContainer
     public var eventLoopGroup: EventLoopGroup {
         self.eventLoopGroupContainer.value
     }
@@ -306,4 +306,4 @@ extension CassandraClient {
     }
 }
 
-internal typealias EventLoopGroupConainer = (value: EventLoopGroup, managed: Bool)
+internal typealias EventLoopGroupContainer = (value: EventLoopGroup, managed: Bool)

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -222,7 +222,7 @@ extension CassandraSession {
 
 extension CassandraClient {
     internal final class Session: CassandraSession {
-        private let eventLoopGroupContainer: EventLoopGroupConainer
+        private let eventLoopGroupContainer: EventLoopGroupContainer
         public var eventLoopGroup: EventLoopGroup {
             self.eventLoopGroupContainer.value
         }
@@ -245,7 +245,7 @@ extension CassandraClient {
         internal init(
             configuration: Configuration,
             logger: Logger,
-            eventLoopGroupContainer: EventLoopGroupConainer
+            eventLoopGroupContainer: EventLoopGroupContainer
         ) {
             self.configuration = configuration
             self.logger = logger


### PR DESCRIPTION
### Motivation:

Noticed a misspelling for EventLoopGroupContainer as EventLoopGroupConainer in CassandraClient.swift

### Modifications:

Updated the misspelling from EventLoopGroupConainer to EventLoopGroupContainer