### PR TITLE
Add map data type support for Cassandra

### DIFF
--- a/Sources/CassandraClient/Data+Maps.swift
+++ b/Sources/CassandraClient/Data+Maps.swift
@@ -1,0 +1,856 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import CDataStaxDriver
+import Foundation
+
+public extension CassandraClient.Column {
+    var int8Int8Map: [Int8: Int8]? {
+        self.toMap(keyType: Int8.self, valueType: Int8.self)
+    }
+
+    var int8Int16Map: [Int8: Int16]? {
+        self.toMap(keyType: Int8.self, valueType: Int16.self)
+    }
+
+    var int8Int32Map: [Int8: Int32]? {
+        self.toMap(keyType: Int8.self, valueType: Int32.self)
+    }
+
+    var int8Int64Map: [Int8: Int64]? {
+        self.toMap(keyType: Int8.self, valueType: Int64.self)
+    }
+
+    var int8Float32Map: [Int8: Float32]? {
+        self.toMap(keyType: Int8.self, valueType: Float32.self)
+    }
+
+    var int8DoubleMap: [Int8: Double]? {
+        self.toMap(keyType: Int8.self, valueType: Double.self)
+    }
+
+    var int8BoolMap: [Int8: Bool]? {
+        self.toMap(keyType: Int8.self, valueType: Bool.self)
+    }
+
+    var int8StringMap: [Int8: String]? {
+        self.toMap(keyType: Int8.self, valueType: String.self)
+    }
+
+    var int8UUIDMap: [Int8: Foundation.UUID]? {
+        self.toMap(keyType: Int8.self, valueType: Foundation.UUID.self)
+    }
+
+    var int16Int8Map: [Int16: Int8]? {
+        self.toMap(keyType: Int16.self, valueType: Int8.self)
+    }
+
+    var int16Int16Map: [Int16: Int16]? {
+        self.toMap(keyType: Int16.self, valueType: Int16.self)
+    }
+
+    var int16Int32Map: [Int16: Int32]? {
+        self.toMap(keyType: Int16.self, valueType: Int32.self)
+    }
+
+    var int16Int64Map: [Int16: Int64]? {
+        self.toMap(keyType: Int16.self, valueType: Int64.self)
+    }
+
+    var int16Float32Map: [Int16: Float32]? {
+        self.toMap(keyType: Int16.self, valueType: Float32.self)
+    }
+
+    var int16DoubleMap: [Int16: Double]? {
+        self.toMap(keyType: Int16.self, valueType: Double.self)
+    }
+
+    var int16BoolMap: [Int16: Bool]? {
+        self.toMap(keyType: Int16.self, valueType: Bool.self)
+    }
+
+    var int16StringMap: [Int16: String]? {
+        self.toMap(keyType: Int16.self, valueType: String.self)
+    }
+
+    var int16UUIDMap: [Int16: Foundation.UUID]? {
+        self.toMap(keyType: Int16.self, valueType: Foundation.UUID.self)
+    }
+
+    var int32Int8Map: [Int32: Int8]? {
+        self.toMap(keyType: Int32.self, valueType: Int8.self)
+    }
+
+    var int32Int16Map: [Int32: Int16]? {
+        self.toMap(keyType: Int32.self, valueType: Int16.self)
+    }
+
+    var int32Int32Map: [Int32: Int32]? {
+        self.toMap(keyType: Int32.self, valueType: Int32.self)
+    }
+
+    var int32Int64Map: [Int32: Int64]? {
+        self.toMap(keyType: Int32.self, valueType: Int64.self)
+    }
+
+    var int32Float32Map: [Int32: Float32]? {
+        self.toMap(keyType: Int32.self, valueType: Float32.self)
+    }
+
+    var int32DoubleMap: [Int32: Double]? {
+        self.toMap(keyType: Int32.self, valueType: Double.self)
+    }
+
+    var int32BoolMap: [Int32: Bool]? {
+        self.toMap(keyType: Int32.self, valueType: Bool.self)
+    }
+
+    var int32StringMap: [Int32: String]? {
+        self.toMap(keyType: Int32.self, valueType: String.self)
+    }
+
+    var int32UUIDMap: [Int32: Foundation.UUID]? {
+        self.toMap(keyType: Int32.self, valueType: Foundation.UUID.self)
+    }
+
+    var int64Int8Map: [Int64: Int8]? {
+        self.toMap(keyType: Int64.self, valueType: Int8.self)
+    }
+
+    var int64Int16Map: [Int64: Int16]? {
+        self.toMap(keyType: Int64.self, valueType: Int16.self)
+    }
+
+    var int64Int32Map: [Int64: Int32]? {
+        self.toMap(keyType: Int64.self, valueType: Int32.self)
+    }
+
+    var int64Int64Map: [Int64: Int64]? {
+        self.toMap(keyType: Int64.self, valueType: Int64.self)
+    }
+
+    var int64Float32Map: [Int64: Float32]? {
+        self.toMap(keyType: Int64.self, valueType: Float32.self)
+    }
+
+    var int64DoubleMap: [Int64: Double]? {
+        self.toMap(keyType: Int64.self, valueType: Double.self)
+    }
+
+    var int64BoolMap: [Int64: Bool]? {
+        self.toMap(keyType: Int64.self, valueType: Bool.self)
+    }
+
+    var int64StringMap: [Int64: String]? {
+        self.toMap(keyType: Int64.self, valueType: String.self)
+    }
+
+    var int64UUIDMap: [Int64: Foundation.UUID]? {
+        self.toMap(keyType: Int64.self, valueType: Foundation.UUID.self)
+    }
+
+    var stringInt8Map: [String: Int8]? {
+        self.toMap(keyType: String.self, valueType: Int8.self)
+    }
+
+    var stringInt16Map: [String: Int16]? {
+        self.toMap(keyType: String.self, valueType: Int16.self)
+    }
+
+    var stringInt32Map: [String: Int32]? {
+        self.toMap(keyType: String.self, valueType: Int32.self)
+    }
+
+    var stringInt64Map: [String: Int64]? {
+        self.toMap(keyType: String.self, valueType: Int64.self)
+    }
+
+    var stringFloat32Map: [String: Float32]? {
+        self.toMap(keyType: String.self, valueType: Float32.self)
+    }
+
+    var stringDoubleMap: [String: Double]? {
+        self.toMap(keyType: String.self, valueType: Double.self)
+    }
+
+    var stringBoolMap: [String: Bool]? {
+        self.toMap(keyType: String.self, valueType: Bool.self)
+    }
+
+    var stringStringMap: [String: String]? {
+        self.toMap(keyType: String.self, valueType: String.self)
+    }
+
+    var stringUUIDMap: [String: Foundation.UUID]? {
+        self.toMap(keyType: String.self, valueType: Foundation.UUID.self)
+    }
+
+    var uuidInt8Map: [Foundation.UUID: Int8]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Int8.self)
+    }
+
+    var uuidInt16Map: [Foundation.UUID: Int16]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Int16.self)
+    }
+
+    var uuidInt32Map: [Foundation.UUID: Int32]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Int32.self)
+    }
+
+    var uuidInt64Map: [Foundation.UUID: Int64]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Int64.self)
+    }
+
+    var uuidFloat32Map: [Foundation.UUID: Float32]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Float32.self)
+    }
+
+    var uuidDoubleMap: [Foundation.UUID: Double]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Double.self)
+    }
+
+    var uuidBoolMap: [Foundation.UUID: Bool]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Bool.self)
+    }
+
+    var uuidStringMap: [Foundation.UUID: String]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: String.self)
+    }
+
+    var uuidUUIDMap: [Foundation.UUID: Foundation.UUID]? {
+        self.toMap(keyType: Foundation.UUID.self, valueType: Foundation.UUID.self)
+    }
+
+    var timeuuidInt8Map: [TimeBasedUUID: Int8]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Int8.self)
+    }
+
+    var timeuuidInt16Map: [TimeBasedUUID: Int16]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Int16.self)
+    }
+
+    var timeuuidInt32Map: [TimeBasedUUID: Int32]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Int32.self)
+    }
+
+    var timeuuidInt64Map: [TimeBasedUUID: Int64]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Int64.self)
+    }
+
+    var timeuuidFloat32Map: [TimeBasedUUID: Float32]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Float32.self)
+    }
+
+    var timeuuidDoubleMap: [TimeBasedUUID: Double]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Double.self)
+    }
+
+    var timeuuidBoolMap: [TimeBasedUUID: Bool]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Bool.self)
+    }
+
+    var timeuuidStringMap: [TimeBasedUUID: String]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: String.self)
+    }
+
+    var timeuuidUUIDMap: [TimeBasedUUID: Foundation.UUID]? {
+        self.toMap(keyType: TimeBasedUUID.self, valueType: Foundation.UUID.self)
+    }
+
+    private func toMap<K: Hashable, V>(keyType _: K.Type, valueType _: V.Type) -> [K: V]? {
+        var map: [K: V] = [:]
+
+        let iterator = cass_iterator_from_map(self.rawPointer)
+        defer { cass_iterator_free(iterator) }
+
+        while cass_iterator_next(iterator) == cass_true {
+            let keyPointer = cass_iterator_get_map_key(iterator)
+            let valuePointer = cass_iterator_get_map_value(iterator)
+
+            guard let key = self.extractValue(from: keyPointer, as: K.self),
+                  let value = self.extractValue(from: valuePointer, as: V.self)
+            else {
+                continue
+            }
+
+            map[key] = value
+        }
+
+        return map.isEmpty ? nil : map
+    }
+
+    private func extractValue<T>(from pointer: OpaquePointer?, as type: T.Type) -> T? {
+        guard let pointer = pointer else {
+            return nil
+        }
+
+        switch type {
+        case is Int8.Type:
+            var value: Int8 = 0
+            let error = cass_value_get_int8(pointer, &value)
+            return error == CASS_OK ? value as? T : nil
+        case is Int16.Type:
+            var value: Int16 = 0
+            let error = cass_value_get_int16(pointer, &value)
+            return error == CASS_OK ? value as? T : nil
+        case is Int32.Type:
+            var value: Int32 = 0
+            let error = cass_value_get_int32(pointer, &value)
+            return error == CASS_OK ? value as? T : nil
+        case is Int64.Type:
+            var value: Int64 = 0
+            let error = cass_value_get_int64(pointer, &value)
+            return error == CASS_OK ? value as? T : nil
+        case is Float32.Type:
+            var value: Float32 = 0
+            let error = cass_value_get_float(pointer, &value)
+            return error == CASS_OK ? value as? T : nil
+        case is Double.Type:
+            var value: Double = 0
+            let error = cass_value_get_double(pointer, &value)
+            return error == CASS_OK ? value as? T : nil
+        case is Bool.Type:
+            var value = cass_bool_t(0)
+            let error = cass_value_get_bool(pointer, &value)
+            return error == CASS_OK ? (value == cass_true) as? T : nil
+        case is String.Type:
+            var stringPtr: UnsafePointer<CChar>?
+            var stringSize = 0
+            let error = cass_value_get_string(pointer, &stringPtr, &stringSize)
+            guard let ptr = stringPtr, error == CASS_OK else {
+                return nil
+            }
+            let buffer = UnsafeBufferPointer(start: ptr, count: stringSize)
+            return buffer.withMemoryRebound(to: UInt8.self) {
+                String(decoding: $0, as: UTF8.self) as? T
+            }
+        case is Foundation.UUID.Type:
+            var value = CassUuid()
+            let error = cass_value_get_uuid(pointer, &value)
+            return error == CASS_OK ? value.uuid() as? T : nil
+        case is TimeBasedUUID.Type:
+            var value = CassUuid()
+            let error = cass_value_get_uuid(pointer, &value)
+            return error == CASS_OK ? TimeBasedUUID(uuid: value) as? T : nil
+        default:
+            return nil
+        }
+    }
+}
+
+public extension CassandraClient.Row {
+    func column(_ name: String) -> [Int8: Int8]? {
+        self.column(name)?.int8Int8Map
+    }
+
+    func column(_ index: Int) -> [Int8: Int8]? {
+        self.column(index)?.int8Int8Map
+    }
+
+    func column(_ name: String) -> [Int8: Int16]? {
+        self.column(name)?.int8Int16Map
+    }
+
+    func column(_ index: Int) -> [Int8: Int16]? {
+        self.column(index)?.int8Int16Map
+    }
+
+    func column(_ name: String) -> [Int8: Int32]? {
+        self.column(name)?.int8Int32Map
+    }
+
+    func column(_ index: Int) -> [Int8: Int32]? {
+        self.column(index)?.int8Int32Map
+    }
+
+    func column(_ name: String) -> [Int8: Int64]? {
+        self.column(name)?.int8Int64Map
+    }
+
+    func column(_ index: Int) -> [Int8: Int64]? {
+        self.column(index)?.int8Int64Map
+    }
+
+    func column(_ name: String) -> [Int8: Float32]? {
+        self.column(name)?.int8Float32Map
+    }
+
+    func column(_ index: Int) -> [Int8: Float32]? {
+        self.column(index)?.int8Float32Map
+    }
+
+    func column(_ name: String) -> [Int8: Double]? {
+        self.column(name)?.int8DoubleMap
+    }
+
+    func column(_ index: Int) -> [Int8: Double]? {
+        self.column(index)?.int8DoubleMap
+    }
+
+    func column(_ name: String) -> [Int8: Bool]? {
+        self.column(name)?.int8BoolMap
+    }
+
+    func column(_ index: Int) -> [Int8: Bool]? {
+        self.column(index)?.int8BoolMap
+    }
+
+    func column(_ name: String) -> [Int8: String]? {
+        self.column(name)?.int8StringMap
+    }
+
+    func column(_ index: Int) -> [Int8: String]? {
+        self.column(index)?.int8StringMap
+    }
+
+    func column(_ name: String) -> [Int8: Foundation.UUID]? {
+        self.column(name)?.int8UUIDMap
+    }
+
+    func column(_ index: Int) -> [Int8: Foundation.UUID]? {
+        self.column(index)?.int8UUIDMap
+    }
+
+    func column(_ name: String) -> [Int16: Int8]? {
+        self.column(name)?.int16Int8Map
+    }
+
+    func column(_ index: Int) -> [Int16: Int8]? {
+        self.column(index)?.int16Int8Map
+    }
+
+    func column(_ name: String) -> [Int16: Int16]? {
+        self.column(name)?.int16Int16Map
+    }
+
+    func column(_ index: Int) -> [Int16: Int16]? {
+        self.column(index)?.int16Int16Map
+    }
+
+    func column(_ name: String) -> [Int16: Int32]? {
+        self.column(name)?.int16Int32Map
+    }
+
+    func column(_ index: Int) -> [Int16: Int32]? {
+        self.column(index)?.int16Int32Map
+    }
+
+    func column(_ name: String) -> [Int16: Int64]? {
+        self.column(name)?.int16Int64Map
+    }
+
+    func column(_ index: Int) -> [Int16: Int64]? {
+        self.column(index)?.int16Int64Map
+    }
+
+    func column(_ name: String) -> [Int16: Float32]? {
+        self.column(name)?.int16Float32Map
+    }
+
+    func column(_ index: Int) -> [Int16: Float32]? {
+        self.column(index)?.int16Float32Map
+    }
+
+    func column(_ name: String) -> [Int16: Double]? {
+        self.column(name)?.int16DoubleMap
+    }
+
+    func column(_ index: Int) -> [Int16: Double]? {
+        self.column(index)?.int16DoubleMap
+    }
+
+    func column(_ name: String) -> [Int16: Bool]? {
+        self.column(name)?.int16BoolMap
+    }
+
+    func column(_ index: Int) -> [Int16: Bool]? {
+        self.column(index)?.int16BoolMap
+    }
+
+    func column(_ name: String) -> [Int16: String]? {
+        self.column(name)?.int16StringMap
+    }
+
+    func column(_ index: Int) -> [Int16: String]? {
+        self.column(index)?.int16StringMap
+    }
+
+    func column(_ name: String) -> [Int16: Foundation.UUID]? {
+        self.column(name)?.int16UUIDMap
+    }
+
+    func column(_ index: Int) -> [Int16: Foundation.UUID]? {
+        self.column(index)?.int16UUIDMap
+    }
+
+    func column(_ name: String) -> [Int32: Int8]? {
+        self.column(name)?.int32Int8Map
+    }
+
+    func column(_ index: Int) -> [Int32: Int8]? {
+        self.column(index)?.int32Int8Map
+    }
+
+    func column(_ name: String) -> [Int32: Int16]? {
+        self.column(name)?.int32Int16Map
+    }
+
+    func column(_ index: Int) -> [Int32: Int16]? {
+        self.column(index)?.int32Int16Map
+    }
+
+    func column(_ name: String) -> [Int32: Int32]? {
+        self.column(name)?.int32Int32Map
+    }
+
+    func column(_ index: Int) -> [Int32: Int32]? {
+        self.column(index)?.int32Int32Map
+    }
+
+    func column(_ name: String) -> [Int32: Int64]? {
+        self.column(name)?.int32Int64Map
+    }
+
+    func column(_ index: Int) -> [Int32: Int64]? {
+        self.column(index)?.int32Int64Map
+    }
+
+    func column(_ name: String) -> [Int32: Float32]? {
+        self.column(name)?.int32Float32Map
+    }
+
+    func column(_ index: Int) -> [Int32: Float32]? {
+        self.column(index)?.int32Float32Map
+    }
+
+    func column(_ name: String) -> [Int32: Double]? {
+        self.column(name)?.int32DoubleMap
+    }
+
+    func column(_ index: Int) -> [Int32: Double]? {
+        self.column(index)?.int32DoubleMap
+    }
+
+    func column(_ name: String) -> [Int32: Bool]? {
+        self.column(name)?.int32BoolMap
+    }
+
+    func column(_ index: Int) -> [Int32: Bool]? {
+        self.column(index)?.int32BoolMap
+    }
+
+    func column(_ name: String) -> [Int32: String]? {
+        self.column(name)?.int32StringMap
+    }
+
+    func column(_ index: Int) -> [Int32: String]? {
+        self.column(index)?.int32StringMap
+    }
+
+    func column(_ name: String) -> [Int32: Foundation.UUID]? {
+        self.column(name)?.int32UUIDMap
+    }
+
+    func column(_ index: Int) -> [Int32: Foundation.UUID]? {
+        self.column(index)?.int32UUIDMap
+    }
+
+    func column(_ name: String) -> [Int64: Int8]? {
+        self.column(name)?.int64Int8Map
+    }
+
+    func column(_ index: Int) -> [Int64: Int8]? {
+        self.column(index)?.int64Int8Map
+    }
+
+    func column(_ name: String) -> [Int64: Int16]? {
+        self.column(name)?.int64Int16Map
+    }
+
+    func column(_ index: Int) -> [Int64: Int16]? {
+        self.column(index)?.int64Int16Map
+    }
+
+    func column(_ name: String) -> [Int64: Int32]? {
+        self.column(name)?.int64Int32Map
+    }
+
+    func column(_ index: Int) -> [Int64: Int32]? {
+        self.column(index)?.int64Int32Map
+    }
+
+    func column(_ name: String) -> [Int64: Int64]? {
+        self.column(name)?.int64Int64Map
+    }
+
+    func column(_ index: Int) -> [Int64: Int64]? {
+        self.column(index)?.int64Int64Map
+    }
+
+    func column(_ name: String) -> [Int64: Float32]? {
+        self.column(name)?.int64Float32Map
+    }
+
+    func column(_ index: Int) -> [Int64: Float32]? {
+        self.column(index)?.int64Float32Map
+    }
+
+    func column(_ name: String) -> [Int64: Double]? {
+        self.column(name)?.int64DoubleMap
+    }
+
+    func column(_ index: Int) -> [Int64: Double]? {
+        self.column(index)?.int64DoubleMap
+    }
+
+    func column(_ name: String) -> [Int64: Bool]? {
+        self.column(name)?.int64BoolMap
+    }
+
+    func column(_ index: Int) -> [Int64: Bool]? {
+        self.column(index)?.int64BoolMap
+    }
+
+    func column(_ name: String) -> [Int64: String]? {
+        self.column(name)?.int64StringMap
+    }
+
+    func column(_ index: Int) -> [Int64: String]? {
+        self.column(index)?.int64StringMap
+    }
+
+    func column(_ name: String) -> [Int64: Foundation.UUID]? {
+        self.column(name)?.int64UUIDMap
+    }
+
+    func column(_ index: Int) -> [Int64: Foundation.UUID]? {
+        self.column(index)?.int64UUIDMap
+    }
+
+    func column(_ name: String) -> [String: Int8]? {
+        self.column(name)?.stringInt8Map
+    }
+
+    func column(_ index: Int) -> [String: Int8]? {
+        self.column(index)?.stringInt8Map
+    }
+
+    func column(_ name: String) -> [String: Int16]? {
+        self.column(name)?.stringInt16Map
+    }
+
+    func column(_ index: Int) -> [String: Int16]? {
+        self.column(index)?.stringInt16Map
+    }
+
+    func column(_ name: String) -> [String: Int32]? {
+        self.column(name)?.stringInt32Map
+    }
+
+    func column(_ index: Int) -> [String: Int32]? {
+        self.column(index)?.stringInt32Map
+    }
+
+    func column(_ name: String) -> [String: Int64]? {
+        self.column(name)?.stringInt64Map
+    }
+
+    func column(_ index: Int) -> [String: Int64]? {
+        self.column(index)?.stringInt64Map
+    }
+
+    func column(_ name: String) -> [String: Float32]? {
+        self.column(name)?.stringFloat32Map
+    }
+
+    func column(_ index: Int) -> [String: Float32]? {
+        self.column(index)?.stringFloat32Map
+    }
+
+    func column(_ name: String) -> [String: Double]? {
+        self.column(name)?.stringDoubleMap
+    }
+
+    func column(_ index: Int) -> [String: Double]? {
+        self.column(index)?.stringDoubleMap
+    }
+
+    func column(_ name: String) -> [String: Bool]? {
+        self.column(name)?.stringBoolMap
+    }
+
+    func column(_ index: Int) -> [String: Bool]? {
+        self.column(index)?.stringBoolMap
+    }
+
+    func column(_ name: String) -> [String: String]? {
+        self.column(name)?.stringStringMap
+    }
+
+    func column(_ index: Int) -> [String: String]? {
+        self.column(index)?.stringStringMap
+    }
+
+    func column(_ name: String) -> [String: Foundation.UUID]? {
+        self.column(name)?.stringUUIDMap
+    }
+
+    func column(_ index: Int) -> [String: Foundation.UUID]? {
+        self.column(index)?.stringUUIDMap
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Int8]? {
+        self.column(name)?.uuidInt8Map
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Int8]? {
+        self.column(index)?.uuidInt8Map
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Int16]? {
+        self.column(name)?.uuidInt16Map
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Int16]? {
+        self.column(index)?.uuidInt16Map
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Int32]? {
+        self.column(name)?.uuidInt32Map
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Int32]? {
+        self.column(index)?.uuidInt32Map
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Int64]? {
+        self.column(name)?.uuidInt64Map
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Int64]? {
+        self.column(index)?.uuidInt64Map
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Float32]? {
+        self.column(name)?.uuidFloat32Map
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Float32]? {
+        self.column(index)?.uuidFloat32Map
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Double]? {
+        self.column(name)?.uuidDoubleMap
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Double]? {
+        self.column(index)?.uuidDoubleMap
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Bool]? {
+        self.column(name)?.uuidBoolMap
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Bool]? {
+        self.column(index)?.uuidBoolMap
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: String]? {
+        self.column(name)?.uuidStringMap
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: String]? {
+        self.column(index)?.uuidStringMap
+    }
+
+    func column(_ name: String) -> [Foundation.UUID: Foundation.UUID]? {
+        self.column(name)?.uuidUUIDMap
+    }
+
+    func column(_ index: Int) -> [Foundation.UUID: Foundation.UUID]? {
+        self.column(index)?.uuidUUIDMap
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Int8]? {
+        self.column(name)?.timeuuidInt8Map
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Int8]? {
+        self.column(index)?.timeuuidInt8Map
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Int16]? {
+        self.column(name)?.timeuuidInt16Map
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Int16]? {
+        self.column(index)?.timeuuidInt16Map
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Int32]? {
+        self.column(name)?.timeuuidInt32Map
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Int32]? {
+        self.column(index)?.timeuuidInt32Map
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Int64]? {
+        self.column(name)?.timeuuidInt64Map
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Int64]? {
+        self.column(index)?.timeuuidInt64Map
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Float32]? {
+        self.column(name)?.timeuuidFloat32Map
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Float32]? {
+        self.column(index)?.timeuuidFloat32Map
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Double]? {
+        self.column(name)?.timeuuidDoubleMap
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Double]? {
+        self.column(index)?.timeuuidDoubleMap
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Bool]? {
+        self.column(name)?.timeuuidBoolMap
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Bool]? {
+        self.column(index)?.timeuuidBoolMap
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: String]? {
+        self.column(name)?.timeuuidStringMap
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: String]? {
+        self.column(index)?.timeuuidStringMap
+    }
+
+    func column(_ name: String) -> [TimeBasedUUID: Foundation.UUID]? {
+        self.column(name)?.timeuuidUUIDMap
+    }
+
+    func column(_ index: Int) -> [TimeBasedUUID: Foundation.UUID]? {
+        self.column(index)?.timeuuidUUIDMap
+    }
+}

--- a/Sources/CassandraClient/Statement+Maps.swift
+++ b/Sources/CassandraClient/Statement+Maps.swift
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import CDataStaxDriver
+import Foundation
+
+extension CassandraClient.Statement {
+    func bindMapCases(_ parameter: Value, _ index: Int) throws -> CassError {
+        switch parameter {
+        case .int8Int8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int8Int16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int8Int32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int8Int64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int8Float32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int8DoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int8BoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int8StringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int8UUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        case .int16Int8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int16Int16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int16Int32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int16Int64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int16Float32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int16DoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int16BoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int16StringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int16UUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        case .int32Int8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int32Int16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int32Int32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int32Int64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int32Float32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int32DoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int32BoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int32StringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int32UUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        case .int64Int8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int64Int16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int64Int32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int64Int64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int64Float32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .int64DoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int64BoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int64StringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .int64UUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        case .stringInt8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .stringInt16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .stringInt32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .stringInt64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .stringFloat32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .stringDoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .stringBoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .stringStringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .stringUUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        case .uuidInt8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidInt16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidInt32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidInt64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidFloat32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidDoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidBoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidStringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .uuidUUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        case .timeuuidInt8Map(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidInt16Map(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidInt32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidInt64Map(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidFloat32Map(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidDoubleMap(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidBoolMap(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidStringMap(let map):
+            return try self.bindMap(map, at: index)
+        case .timeuuidUUIDMap(let map):
+            return try self.bindMap(map, at: index)
+
+        default:
+            fatalError("Not a map case")
+        }
+    }
+
+    private func bindMap<K, V>(_ map: [K: V], at index: Int) throws -> CassError {
+        let collection = cass_collection_new(CASS_COLLECTION_TYPE_MAP, map.count * 2)
+        defer { cass_collection_free(collection) }
+
+        for (key, value) in map {
+            let keyResult = try appendToCollection(collection, element: key)
+            guard keyResult == CASS_OK else {
+                throw CassandraClient.Error(keyResult)
+            }
+
+            let valueResult = try appendToCollection(collection, element: value)
+            guard valueResult == CASS_OK else {
+                throw CassandraClient.Error(valueResult)
+            }
+        }
+
+        return cass_statement_bind_collection(self.rawPointer, index, collection)
+    }
+
+    private func appendToCollection<T>(_ collection: OpaquePointer?, element: T) throws -> CassError {
+        switch element {
+        case let value as Int8:
+            return cass_collection_append_int8(collection, value)
+        case let value as Int16:
+            return cass_collection_append_int16(collection, value)
+        case let value as Int32:
+            return cass_collection_append_int32(collection, value)
+        case let value as Int64:
+            return cass_collection_append_int64(collection, value)
+        case let value as Float32:
+            return cass_collection_append_float(collection, value)
+        case let value as Double:
+            return cass_collection_append_double(collection, value)
+        case let value as Bool:
+            return cass_collection_append_bool(collection, value ? cass_true : cass_false)
+        case let value as String:
+            return cass_collection_append_string(collection, value)
+        case let value as Foundation.UUID:
+            let uuid = CassUuid(value.uuid)
+            return cass_collection_append_uuid(collection, uuid)
+        case let value as TimeBasedUUID:
+            let timeuuid = CassUuid(value.uuid)
+            return cass_collection_append_uuid(collection, timeuuid)
+        default:
+            throw CassandraClient.Error.badParams("Map element of type \(T.self) is not supported")
+        }
+    }
+}

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -94,6 +94,8 @@ extension CassandraClient {
                     result = try self.bindArray(array, at: index)
                 case .stringArray(let array):
                     result = try self.bindArray(array, at: index)
+                default:
+                    result = try self.bindMapCases(parameter, index)
                 }
 
                 guard result == CASS_OK else {
@@ -201,6 +203,76 @@ extension CassandraClient {
             case float32Array([Float32])
             case doubleArray([Double])
             case stringArray([String])
+
+            case int8Int8Map([Int8: Int8])
+            case int8Int16Map([Int8: Int16])
+            case int8Int32Map([Int8: Int32])
+            case int8Int64Map([Int8: Int64])
+            case int8Float32Map([Int8: Float32])
+            case int8DoubleMap([Int8: Double])
+            case int8BoolMap([Int8: Bool])
+            case int8StringMap([Int8: String])
+            case int8UUIDMap([Int8: Foundation.UUID])
+
+            case int16Int8Map([Int16: Int8])
+            case int16Int16Map([Int16: Int16])
+            case int16Int32Map([Int16: Int32])
+            case int16Int64Map([Int16: Int64])
+            case int16Float32Map([Int16: Float32])
+            case int16DoubleMap([Int16: Double])
+            case int16BoolMap([Int16: Bool])
+            case int16StringMap([Int16: String])
+            case int16UUIDMap([Int16: Foundation.UUID])
+
+            case int32Int8Map([Int32: Int8])
+            case int32Int16Map([Int32: Int16])
+            case int32Int32Map([Int32: Int32])
+            case int32Int64Map([Int32: Int64])
+            case int32Float32Map([Int32: Float32])
+            case int32DoubleMap([Int32: Double])
+            case int32BoolMap([Int32: Bool])
+            case int32StringMap([Int32: String])
+            case int32UUIDMap([Int32: Foundation.UUID])
+
+            case int64Int8Map([Int64: Int8])
+            case int64Int16Map([Int64: Int16])
+            case int64Int32Map([Int64: Int32])
+            case int64Int64Map([Int64: Int64])
+            case int64Float32Map([Int64: Float32])
+            case int64DoubleMap([Int64: Double])
+            case int64BoolMap([Int64: Bool])
+            case int64StringMap([Int64: String])
+            case int64UUIDMap([Int64: Foundation.UUID])
+
+            case stringInt8Map([String: Int8])
+            case stringInt16Map([String: Int16])
+            case stringInt32Map([String: Int32])
+            case stringInt64Map([String: Int64])
+            case stringFloat32Map([String: Float32])
+            case stringDoubleMap([String: Double])
+            case stringBoolMap([String: Bool])
+            case stringStringMap([String: String])
+            case stringUUIDMap([String: Foundation.UUID])
+
+            case uuidInt8Map([Foundation.UUID: Int8])
+            case uuidInt16Map([Foundation.UUID: Int16])
+            case uuidInt32Map([Foundation.UUID: Int32])
+            case uuidInt64Map([Foundation.UUID: Int64])
+            case uuidFloat32Map([Foundation.UUID: Float32])
+            case uuidDoubleMap([Foundation.UUID: Double])
+            case uuidBoolMap([Foundation.UUID: Bool])
+            case uuidStringMap([Foundation.UUID: String])
+            case uuidUUIDMap([Foundation.UUID: Foundation.UUID])
+
+            case timeuuidInt8Map([TimeBasedUUID: Int8])
+            case timeuuidInt16Map([TimeBasedUUID: Int16])
+            case timeuuidInt32Map([TimeBasedUUID: Int32])
+            case timeuuidInt64Map([TimeBasedUUID: Int64])
+            case timeuuidFloat32Map([TimeBasedUUID: Float32])
+            case timeuuidDoubleMap([TimeBasedUUID: Double])
+            case timeuuidBoolMap([TimeBasedUUID: Bool])
+            case timeuuidStringMap([TimeBasedUUID: String])
+            case timeuuidUUIDMap([TimeBasedUUID: Foundation.UUID])
         }
 
         public struct Options: CustomStringConvertible {

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -803,6 +803,318 @@ final class Tests: XCTestCase {
         }
     }
 
+    func testMapTypes() {
+        let tableName = "test_maps_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run(
+                """
+                create table \(tableName) (
+                col1 int primary key,
+                col2 map<tinyint, tinyint>,
+                col3 map<tinyint, smallint>,
+                col4 map<tinyint, int>,
+                col5 map<tinyint, bigint>,
+                col6 map<tinyint, float>,
+                col7 map<tinyint, double>,
+                col8 map<tinyint, boolean>,
+                col9 map<tinyint, text>,
+                col10 map<tinyint, uuid>,
+                col11 map<smallint, tinyint>,
+                col12 map<smallint, smallint>,
+                col13 map<smallint, int>,
+                col14 map<smallint, bigint>,
+                col15 map<smallint, float>,
+                col16 map<smallint, double>,
+                col17 map<smallint, boolean>,
+                col18 map<smallint, text>,
+                col19 map<smallint, uuid>,
+                col20 map<int, tinyint>,
+                col21 map<int, smallint>,
+                col22 map<int, int>,
+                col23 map<int, bigint>,
+                col24 map<int, float>,
+                col25 map<int, double>,
+                col26 map<int, boolean>,
+                col27 map<int, text>,
+                col28 map<int, uuid>,
+                col29 map<bigint, tinyint>,
+                col30 map<bigint, smallint>,
+                col31 map<bigint, int>,
+                col32 map<bigint, bigint>,
+                col33 map<bigint, float>,
+                col34 map<bigint, double>,
+                col35 map<bigint, boolean>,
+                col36 map<bigint, text>,
+                col37 map<bigint, uuid>,
+                col38 map<text, tinyint>,
+                col39 map<text, smallint>,
+                col40 map<text, int>,
+                col41 map<text, bigint>,
+                col42 map<text, float>,
+                col43 map<text, double>,
+                col44 map<text, boolean>,
+                col45 map<text, text>,
+                col46 map<text, uuid>,
+                col47 map<uuid, tinyint>,
+                col48 map<uuid, smallint>,
+                col49 map<uuid, int>,
+                col50 map<uuid, bigint>,
+                col51 map<uuid, float>,
+                col52 map<uuid, double>,
+                col53 map<uuid, boolean>,
+                col54 map<uuid, text>,
+                col55 map<uuid, uuid>,
+                col56 map<timeuuid, tinyint>,
+                col57 map<timeuuid, smallint>,
+                col58 map<timeuuid, int>,
+                col59 map<timeuuid, bigint>,
+                col60 map<timeuuid, float>,
+                col61 map<timeuuid, double>,
+                col62 map<timeuuid, boolean>,
+                col63 map<timeuuid, text>,
+                col64 map<timeuuid, uuid>
+                )
+                """
+            ).wait()
+        )
+
+        for index in Int32(0)..<Int32(3) {
+            let int8Int8Map = [Int8(1): Int8(10), Int8(2): Int8(20)]
+            let int8Int16Map = [Int8(1): Int16(100), Int8(2): Int16(200)]
+            let int8Int32Map = [Int8(1): Int32(1000), Int8(2): Int32(2000)]
+            let int8Int64Map = [Int8(1): Int64(10000), Int8(2): Int64(20000)]
+            let int8Float32Map = [Int8(1): Float32(1.5), Int8(2): Float32(2.5)]
+            let int8DoubleMap = [Int8(1): Double(10.5), Int8(2): Double(20.5)]
+            let int8BoolMap = [Int8(1): true, Int8(2): false]
+            let int8StringMap = [Int8(1): "value1", Int8(2): "value2"]
+            let int8UUIDMap = [Int8(1): UUID(), Int8(2): UUID()]
+
+            let int16Int8Map = [Int16(10): Int8(1), Int16(20): Int8(2)]
+            let int16Int16Map = [Int16(10): Int16(100), Int16(20): Int16(200)]
+            let int16Int32Map = [Int16(10): Int32(1000), Int16(20): Int32(2000)]
+            let int16Int64Map = [Int16(10): Int64(10000), Int16(20): Int64(20000)]
+            let int16Float32Map = [Int16(10): Float32(1.5), Int16(20): Float32(2.5)]
+            let int16DoubleMap = [Int16(10): Double(10.5), Int16(20): Double(20.5)]
+            let int16BoolMap = [Int16(10): true, Int16(20): false]
+            let int16StringMap = [Int16(10): "value1", Int16(20): "value2"]
+            let int16UUIDMap = [Int16(10): UUID(), Int16(20): UUID()]
+
+            let int32Int8Map = [Int32(100): Int8(1), Int32(200): Int8(2)]
+            let int32Int16Map = [Int32(100): Int16(10), Int32(200): Int16(20)]
+            let int32Int32Map = [Int32(100): Int32(1000), Int32(200): Int32(2000)]
+            let int32Int64Map = [Int32(100): Int64(10000), Int32(200): Int64(20000)]
+            let int32Float32Map = [Int32(100): Float32(1.5), Int32(200): Float32(2.5)]
+            let int32DoubleMap = [Int32(100): Double(10.5), Int32(200): Double(20.5)]
+            let int32BoolMap = [Int32(100): true, Int32(200): false]
+            let int32StringMap = [Int32(100): "value1", Int32(200): "value2"]
+            let int32UUIDMap = [Int32(100): UUID(), Int32(200): UUID()]
+
+            let int64Int8Map = [Int64(1000): Int8(1), Int64(2000): Int8(2)]
+            let int64Int16Map = [Int64(1000): Int16(10), Int64(2000): Int16(20)]
+            let int64Int32Map = [Int64(1000): Int32(100), Int64(2000): Int32(200)]
+            let int64Int64Map = [Int64(1000): Int64(10000), Int64(2000): Int64(20000)]
+            let int64Float32Map = [Int64(1000): Float32(1.5), Int64(2000): Float32(2.5)]
+            let int64DoubleMap = [Int64(1000): Double(10.5), Int64(2000): Double(20.5)]
+            let int64BoolMap = [Int64(1000): true, Int64(2000): false]
+            let int64StringMap = [Int64(1000): "value1", Int64(2000): "value2"]
+            let int64UUIDMap = [Int64(1000): UUID(), Int64(2000): UUID()]
+
+            let stringInt8Map = ["key1": Int8(1), "key2": Int8(2)]
+            let stringInt16Map = ["key1": Int16(10), "key2": Int16(20)]
+            let stringInt32Map = ["key1": Int32(100), "key2": Int32(200)]
+            let stringInt64Map = ["key1": Int64(1000), "key2": Int64(2000)]
+            let stringFloat32Map = ["key1": Float32(1.5), "key2": Float32(2.5)]
+            let stringDoubleMap = ["key1": Double(10.5), "key2": Double(20.5)]
+            let stringBoolMap = ["key1": true, "key2": false]
+            let stringStringMap = ["key1": "value1", "key2": "value2"]
+            let stringUUIDMap = ["key1": UUID(), "key2": UUID()]
+
+            let uuid1 = UUID()
+            let uuid2 = UUID()
+            let uuidInt8Map = [uuid1: Int8(1), uuid2: Int8(2)]
+            let uuidInt16Map = [uuid1: Int16(10), uuid2: Int16(20)]
+            let uuidInt32Map = [uuid1: Int32(100), uuid2: Int32(200)]
+            let uuidInt64Map = [uuid1: Int64(1000), uuid2: Int64(2000)]
+            let uuidFloat32Map = [uuid1: Float32(1.5), uuid2: Float32(2.5)]
+            let uuidDoubleMap = [uuid1: Double(10.5), uuid2: Double(20.5)]
+            let uuidBoolMap = [uuid1: true, uuid2: false]
+            let uuidStringMap = [uuid1: "value1", uuid2: "value2"]
+            let uuidUUIDMap = [uuid1: UUID(), uuid2: UUID()]
+
+            let timeuuid1 = TimeBasedUUID()
+            let timeuuid2 = TimeBasedUUID()
+            let timeuuidInt8Map = [timeuuid1: Int8(1), timeuuid2: Int8(2)]
+            let timeuuidInt16Map = [timeuuid1: Int16(10), timeuuid2: Int16(20)]
+            let timeuuidInt32Map = [timeuuid1: Int32(100), timeuuid2: Int32(200)]
+            let timeuuidInt64Map = [timeuuid1: Int64(1000), timeuuid2: Int64(2000)]
+            let timeuuidFloat32Map = [timeuuid1: Float32(1.5), timeuuid2: Float32(2.5)]
+            let timeuuidDoubleMap = [timeuuid1: Double(10.5), timeuuid2: Double(20.5)]
+            let timeuuidBoolMap = [timeuuid1: true, timeuuid2: false]
+            let timeuuidStringMap = [timeuuid1: "value1", timeuuid2: "value2"]
+            let timeuuidUUIDMap = [timeuuid1: UUID(), timeuuid2: UUID()]
+
+            let parameters: [CassandraClient.Statement.Value] = [
+                .int32(index),
+                .int8Int8Map(int8Int8Map),
+                .int8Int16Map(int8Int16Map),
+                .int8Int32Map(int8Int32Map),
+                .int8Int64Map(int8Int64Map),
+                .int8Float32Map(int8Float32Map),
+                .int8DoubleMap(int8DoubleMap),
+                .int8BoolMap(int8BoolMap),
+                .int8StringMap(int8StringMap),
+                .int8UUIDMap(int8UUIDMap),
+                .int16Int8Map(int16Int8Map),
+                .int16Int16Map(int16Int16Map),
+                .int16Int32Map(int16Int32Map),
+                .int16Int64Map(int16Int64Map),
+                .int16Float32Map(int16Float32Map),
+                .int16DoubleMap(int16DoubleMap),
+                .int16BoolMap(int16BoolMap),
+                .int16StringMap(int16StringMap),
+                .int16UUIDMap(int16UUIDMap),
+                .int32Int8Map(int32Int8Map),
+                .int32Int16Map(int32Int16Map),
+                .int32Int32Map(int32Int32Map),
+                .int32Int64Map(int32Int64Map),
+                .int32Float32Map(int32Float32Map),
+                .int32DoubleMap(int32DoubleMap),
+                .int32BoolMap(int32BoolMap),
+                .int32StringMap(int32StringMap),
+                .int32UUIDMap(int32UUIDMap),
+                .int64Int8Map(int64Int8Map),
+                .int64Int16Map(int64Int16Map),
+                .int64Int32Map(int64Int32Map),
+                .int64Int64Map(int64Int64Map),
+                .int64Float32Map(int64Float32Map),
+                .int64DoubleMap(int64DoubleMap),
+                .int64BoolMap(int64BoolMap),
+                .int64StringMap(int64StringMap),
+                .int64UUIDMap(int64UUIDMap),
+                .stringInt8Map(stringInt8Map),
+                .stringInt16Map(stringInt16Map),
+                .stringInt32Map(stringInt32Map),
+                .stringInt64Map(stringInt64Map),
+                .stringFloat32Map(stringFloat32Map),
+                .stringDoubleMap(stringDoubleMap),
+                .stringBoolMap(stringBoolMap),
+                .stringStringMap(stringStringMap),
+                .stringUUIDMap(stringUUIDMap),
+                .uuidInt8Map(uuidInt8Map),
+                .uuidInt16Map(uuidInt16Map),
+                .uuidInt32Map(uuidInt32Map),
+                .uuidInt64Map(uuidInt64Map),
+                .uuidFloat32Map(uuidFloat32Map),
+                .uuidDoubleMap(uuidDoubleMap),
+                .uuidBoolMap(uuidBoolMap),
+                .uuidStringMap(uuidStringMap),
+                .uuidUUIDMap(uuidUUIDMap),
+                .timeuuidInt8Map(timeuuidInt8Map),
+                .timeuuidInt16Map(timeuuidInt16Map),
+                .timeuuidInt32Map(timeuuidInt32Map),
+                .timeuuidInt64Map(timeuuidInt64Map),
+                .timeuuidFloat32Map(timeuuidFloat32Map),
+                .timeuuidDoubleMap(timeuuidDoubleMap),
+                .timeuuidBoolMap(timeuuidBoolMap),
+                .timeuuidStringMap(timeuuidStringMap),
+                .timeuuidUUIDMap(timeuuidUUIDMap)
+            ]
+
+            XCTAssertNoThrow(
+                try self.cassandraClient.run(
+                    """
+                    insert into \(tableName)
+                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10,
+                     col11, col12, col13, col14, col15, col16, col17, col18, col19,
+                     col20, col21, col22, col23, col24, col25, col26, col27, col28,
+                     col29, col30, col31, col32, col33, col34, col35, col36, col37,
+                     col38, col39, col40, col41, col42, col43, col44, col45, col46,
+                     col47, col48, col49, col50, col51, col52, col53, col54, col55,
+                     col56, col57, col58, col59, col60, col61, col62, col63, col64)
+                    values
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                     ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    parameters: parameters
+                ).wait()
+            )
+
+            let result = try! self.cassandraClient.query("select * from \(tableName) where col1 = ?;", parameters: [.int32(index)]).wait()
+            XCTAssertEqual(result.count, 1, "expected exactly one result")
+            let row = result.first!
+
+            XCTAssertEqual(row.column("col1"), index, "expected value to match")
+            XCTAssertEqual(row.column("col2"), int8Int8Map, "expected map to match")
+            XCTAssertEqual(row.column("col3"), int8Int16Map, "expected map to match")
+            XCTAssertEqual(row.column("col4"), int8Int32Map, "expected map to match")
+            XCTAssertEqual(row.column("col5"), int8Int64Map, "expected map to match")
+            XCTAssertEqual(row.column("col6"), int8Float32Map, "expected map to match")
+            XCTAssertEqual(row.column("col7"), int8DoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col8"), int8BoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col9"), int8StringMap, "expected map to match")
+            XCTAssertEqual(row.column("col10"), int8UUIDMap, "expected map to match")
+            XCTAssertEqual(row.column("col11"), int16Int8Map, "expected map to match")
+            XCTAssertEqual(row.column("col12"), int16Int16Map, "expected map to match")
+            XCTAssertEqual(row.column("col13"), int16Int32Map, "expected map to match")
+            XCTAssertEqual(row.column("col14"), int16Int64Map, "expected map to match")
+            XCTAssertEqual(row.column("col15"), int16Float32Map, "expected map to match")
+            XCTAssertEqual(row.column("col16"), int16DoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col17"), int16BoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col18"), int16StringMap, "expected map to match")
+            XCTAssertEqual(row.column("col19"), int16UUIDMap, "expected map to match")
+            XCTAssertEqual(row.column("col20"), int32Int8Map, "expected map to match")
+            XCTAssertEqual(row.column("col21"), int32Int16Map, "expected map to match")
+            XCTAssertEqual(row.column("col22"), int32Int32Map, "expected map to match")
+            XCTAssertEqual(row.column("col23"), int32Int64Map, "expected map to match")
+            XCTAssertEqual(row.column("col24"), int32Float32Map, "expected map to match")
+            XCTAssertEqual(row.column("col25"), int32DoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col26"), int32BoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col27"), int32StringMap, "expected map to match")
+            XCTAssertEqual(row.column("col28"), int32UUIDMap, "expected map to match")
+            XCTAssertEqual(row.column("col29"), int64Int8Map, "expected map to match")
+            XCTAssertEqual(row.column("col30"), int64Int16Map, "expected map to match")
+            XCTAssertEqual(row.column("col31"), int64Int32Map, "expected map to match")
+            XCTAssertEqual(row.column("col32"), int64Int64Map, "expected map to match")
+            XCTAssertEqual(row.column("col33"), int64Float32Map, "expected map to match")
+            XCTAssertEqual(row.column("col34"), int64DoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col35"), int64BoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col36"), int64StringMap, "expected map to match")
+            XCTAssertEqual(row.column("col37"), int64UUIDMap, "expected map to match")
+            XCTAssertEqual(row.column("col38"), stringInt8Map, "expected map to match")
+            XCTAssertEqual(row.column("col39"), stringInt16Map, "expected map to match")
+            XCTAssertEqual(row.column("col40"), stringInt32Map, "expected map to match")
+            XCTAssertEqual(row.column("col41"), stringInt64Map, "expected map to match")
+            XCTAssertEqual(row.column("col42"), stringFloat32Map, "expected map to match")
+            XCTAssertEqual(row.column("col43"), stringDoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col44"), stringBoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col45"), stringStringMap, "expected map to match")
+            XCTAssertEqual(row.column("col46"), stringUUIDMap, "expected map to match")
+            XCTAssertEqual(row.column("col47"), uuidInt8Map, "expected map to match")
+            XCTAssertEqual(row.column("col48"), uuidInt16Map, "expected map to match")
+            XCTAssertEqual(row.column("col49"), uuidInt32Map, "expected map to match")
+            XCTAssertEqual(row.column("col50"), uuidInt64Map, "expected map to match")
+            XCTAssertEqual(row.column("col51"), uuidFloat32Map, "expected map to match")
+            XCTAssertEqual(row.column("col52"), uuidDoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col53"), uuidBoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col54"), uuidStringMap, "expected map to match")
+            XCTAssertEqual(row.column("col55"), uuidUUIDMap, "expected map to match")
+            XCTAssertEqual(row.column("col56"), timeuuidInt8Map, "expected map to match")
+            XCTAssertEqual(row.column("col57"), timeuuidInt16Map, "expected map to match")
+            XCTAssertEqual(row.column("col58"), timeuuidInt32Map, "expected map to match")
+            XCTAssertEqual(row.column("col59"), timeuuidInt64Map, "expected map to match")
+            XCTAssertEqual(row.column("col60"), timeuuidFloat32Map, "expected map to match")
+            XCTAssertEqual(row.column("col61"), timeuuidDoubleMap, "expected map to match")
+            XCTAssertEqual(row.column("col62"), timeuuidBoolMap, "expected map to match")
+            XCTAssertEqual(row.column("col63"), timeuuidStringMap, "expected map to match")
+            XCTAssertEqual(row.column("col64"), timeuuidUUIDMap, "expected map to match")
+        }
+    }
+
     func testErrorMapping() {
         XCTAssertThrowsError(try self.cassandraClient.run("boom!").wait()) { error in
             XCTAssertEqual(


### PR DESCRIPTION
Motivation:

The Cassandra client previously supported scalar types and arrays, but lacked support for map types which are a fundamental Cassandra collection type. Maps are commonly used for storing key-value pairs in Cassandra schemas (e.g., user preferences, metadata, configuration settings). Without map support, users had to work around this limitation or couldn't use certain Cassandra features effectively.

Modifications:

- Created Statement+Maps.swift with map binding logic for all 63 type combinations (7 key types × 9 value types)
- Added all 63 map enum cases to Statement.Value enum
- Implemented bindMap<K,V> helper using CASS_COLLECTION_TYPE_MAP
- Created Data+Maps.swift with map reading logic for all 63 combinations
- Implemented toMap<K,V> using cass_iterator_from_map(), cass_iterator_get_map_key(), and cass_iterator_get_map_value()
- Added 63 map properties on Column and 126 convenience methods on Row
- Extended testMapTypes to comprehensively test all 63 map combinations
- Organized map-related code in separate extension files to keep codebase clean

Supported key types: Int8, Int16, Int32, Int64, String, UUID, TimeBasedUUID
Supported value types: Int8, Int16, Int32, Int64, Float32, Double, Bool, String, UUID

Result:

Users can now bind and read all Cassandra map types with full type safety. The implementation follows the same pattern as arrays, providing consistent API ergonomics. All 63 map type combinations are tested and verified to work correctly with round-trip insert/read operations.