### PR TITLE
Enhance security of GitHub workflows using least privilege principle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 8,20 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   soundness:
     name: Soundness

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   semver-label-check:
     name: Semantic version label check

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,6 +52,9 @@ on:
         description: "The arguments passed to swift test in the Linux nightly main Swift version matrix job."
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit tests (${{ matrix.swift.swift_version }})


### PR DESCRIPTION
### Motivation:
GitHub Actions workflows by default may have broader permissions than necessary, increasing the attack surface for supply chain attacks and credential theft. Explicitly scoping permissions prevents potential exploitation if workflows are compromised.

### Modifications:
Add explicit `permissions: contents: read` declaration to all workflow files:
- .github/workflows/main.yml
- .github/workflows/pull_request.yml
- .github/workflows/pull_request_label.yml
- .github/workflows/unit_tests.yml

### Result:
Workflows are restricted to read-only repository access, preventing malicious code execution from modifying repository contents, pushing commits, or escalating privileges even if the workflow is compromised.
