### PR TITLE
Fix memory leak in array binding for collections

### DIFF
--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -116,6 +116,8 @@ extension CassandraClient {
 
         private func bindArray<T>(_ array: [T], at index: Int) throws -> CassError {
             let collection = cass_collection_new(CASS_COLLECTION_TYPE_LIST, array.count)
+            defer { cass_collection_free(collection) }
+
             for element in array {
                 let appendResult: CassError
                 switch element {


### PR DESCRIPTION
### Motivation

The `bindArray` function was allocating a `cass_collection` via `cass_collection_new` but never freeing it, causing a memory leak every time an array was bound to a prepared statement.

### Modifications

Added `defer { cass_collection_free(collection) }` immediately after collection allocation to ensure proper cleanup.

### Result

Collections are now properly freed after use, eliminating the memory leak in array binding operations.
