### PR TITLE
Update swift-nio-ssl to 2.34.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,7 +101,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.41.1")),
-        .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.33.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.34.0"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
     ],


### PR DESCRIPTION
### Motivation:

Latest version of Vapor requires 2.34.0 and since we're locking to exact versions on swift-nio-ssl, we must update every time they release.

### Modifications:

Bump the dependency.

### Result:

Avoid blocking adopters from moving to newer versions of swift-nio-ssl.