### PR TITLE
Guard against null iterator in toMap to prevent SIGSEGV

### DIFF
--- a/Sources/CassandraClient/Data+Maps.swift
+++ b/Sources/CassandraClient/Data+Maps.swift
@@ -275,7 +275,9 @@ extension CassandraClient.Column {
 
         var map: [K: V] = [:]
 
-        let iterator = cass_iterator_from_map(self.rawPointer)
+        guard let iterator = cass_iterator_from_map(self.rawPointer) else {
+            return nil
+        }
         defer { cass_iterator_free(iterator) }
 
         while cass_iterator_next(iterator) == cass_true {


### PR DESCRIPTION
### Motivation:

`cass_iterator_from_map` can return NULL when the column value is non-null but not a valid map type (e.g., corrupted data or type mismatch). The existing null check on the column value (`cass_value_is_null`) does not cover this case. When `cass_iterator_next` is called with a NULL iterator, it dereferences a null pointer causing a SIGSEGV (Signal 11, exit code 139) crash.

This was observed where the server repeatedly crashed when decoding map columns from Cassandra rows with unexpected data states.

### Modifications:

Changed `let iterator = cass_iterator_from_map(self.rawPointer)` to `guard let iterator = cass_iterator_from_map(self.rawPointer) else { return nil }` in the `toMap` method. This matches the defensive pattern already used in `Data.swift` for `cass_iterator_from_collection`.

### Result:

When `cass_iterator_from_map` returns NULL, `toMap` now safely returns `nil` instead of crashing with a null pointer dereference. Callers that access map properties will get `nil` and can fall back to alternative decoding paths.