### PR TITLE
Enable Swift 6.3 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,7 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,6 +43,14 @@ on:
         type: string
         description: "The arguments passed to swift test in the Linux 6.2 Swift version matrix job."
         default: ""
+      linux_6_3_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.3 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_3_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 6.3 Swift version matrix job."
+        default: ""
       linux_nightly_next_enabled:
         type: boolean
         description: "Boolean to enable the Linux nightly next Swift version matrix job. Defaults to true."
@@ -87,6 +95,9 @@ jobs:
           - image: "swift:6.2-jammy"
             swift_version: "6.2"
             enabled: ${{ inputs.linux_6_2_enabled }}
+          - image: "swift:6.3-noble"
+            swift_version: "6.3"
+            enabled: ${{ inputs.linux_6_3_enabled }}
           - image: "swiftlang/swift:nightly-6.1-jammy"
             swift_version: "nightly-6.1"
             enabled: ${{ inputs.linux_nightly_next_enabled }}
@@ -114,6 +125,7 @@ jobs:
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
           COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"
           COMMAND_OVERRIDE_6_2: "swift test ${{ inputs.linux_6_2_arguments_override }}"
+          COMMAND_OVERRIDE_6_3: "swift test ${{ inputs.linux_6_3_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_NEXT: "swift test ${{ inputs.linux_nightly_next_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_MAIN: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
           CASSANDRA_HOST: cassandra


### PR DESCRIPTION
Motivation

* Swift 6.3 has been released, we should add it to our CI coverage.

Modifications

* Add additional Swift 6.3 jobs where appropriate in `main.yml`, `pull_request.yml`, `unit_tests.yml`

Result

* Improved test coverage.
