### PR TITLE
Add column encryption support for Swift Cassandra client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,6 +104,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.36.0"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "3.0.0")),
     ],
     targets: [
         .target(
@@ -162,6 +163,7 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Crypto", package: "swift-crypto"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -26,6 +26,11 @@ public class CassandraClient: CassandraSession {
         self.eventLoopGroupContainer.value
     }
 
+    @available(macOS 11.0, *)
+    public var encryptor: CassandraClient.Encryptor? {
+        self.configuration.encryptor
+    }
+
     private let configuration: Configuration
     private let logger: Logger
     private let defaultSession: Session

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -26,7 +26,7 @@ public class CassandraClient: CassandraSession {
         self.eventLoopGroupContainer.value
     }
 
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public var encryptor: CassandraClient.Encryptor? {
         self.configuration.encryptor
     }

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -26,7 +26,7 @@ public class CassandraClient: CassandraSession {
         self.eventLoopGroupContainer.value
     }
 
-    @available(macOS 11.0, *)
+    @available(macOS 15.0, iOS 18.0, *)
     public var encryptor: CassandraClient.Encryptor? {
         self.configuration.encryptor
     }

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -48,6 +48,17 @@ extension CassandraClient {
         public var prepareStrategy: PrepareStrategy?
         public var compact: Bool?
 
+        /// Encryptor for transparent column encryption.
+        // TODO: Add encrypted column registration (EncryptedColumnSchema, registerEncryptedColumns, isEncrypted)
+        // once prepared statement metadata integration is available for enforcement.
+        @available(macOS 11.0, *)
+        public var encryptor: Encryptor? {
+            get { self._encryptor as? Encryptor }
+            set { self._encryptor = newValue }
+        }
+
+        private var _encryptor: AnyObject?
+
         /// Sets the cluster's consistency level. Default is `.localOne`.
         public var consistency: CassandraClient.Consistency?
 

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -51,7 +51,7 @@ extension CassandraClient {
         /// Encryptor for transparent column encryption.
         // TODO: Add encrypted column registration (EncryptedColumnSchema, registerEncryptedColumns, isEncrypted)
         // once prepared statement metadata integration is available for enforcement.
-        @available(macOS 15.0, iOS 18.0, *)
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: Encryptor? {
             get { self._encryptor as? Encryptor }
             set { self._encryptor = newValue }

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -51,7 +51,7 @@ extension CassandraClient {
         /// Encryptor for transparent column encryption.
         // TODO: Add encrypted column registration (EncryptedColumnSchema, registerEncryptedColumns, isEncrypted)
         // once prepared statement metadata integration is available for enforcement.
-        @available(macOS 11.0, *)
+        @available(macOS 15.0, iOS 18.0, *)
         public var encryptor: Encryptor? {
             get { self._encryptor as? Encryptor }
             set { self._encryptor = newValue }

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -591,7 +591,7 @@ extension CassandraClient.Column {
         return error == CASS_OK ? Array(UnsafeBufferPointer(start: value, count: size)) : nil
     }
 
-    @available(macOS 11.0, *)
+    @available(macOS 15.0, iOS 18.0, *)
     func decryptedData(
         encryptor: CassandraClient.Encryptor,
         context: CassandraClient.EncryptionContext
@@ -798,7 +798,7 @@ extension CassandraClient.Row {
 
 // MARK: - Encrypted
 
-@available(macOS 11.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 extension CassandraClient.Column {
     /// Decrypt column and return as `String`.
     public func decryptedString(
@@ -873,7 +873,7 @@ extension CassandraClient.Column {
     }
 }
 
-@available(macOS 11.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 extension CassandraClient.Row {
     /// Decrypt column by name and return as `String`.
     public func decryptedString(

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -590,6 +590,17 @@ extension CassandraClient.Column {
         let error = cass_value_get_bytes(self.rawPointer, &value, &size)
         return error == CASS_OK ? Array(UnsafeBufferPointer(start: value, count: size)) : nil
     }
+
+    @available(macOS 11.0, *)
+    func decryptedData(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Data? {
+        guard !self.isNull() else { return nil }
+        guard let rawBytes = self.bytes else { return nil }
+        let envelope = Data(rawBytes)
+        return try encryptor.decrypt(envelope, context: context)
+    }
 }
 
 extension CassandraClient.Row {
@@ -782,5 +793,193 @@ extension CassandraClient.Row {
     /// Get column value as `[String]`.
     public func column(_ index: Int) -> [String]? {
         self.column(index)?.stringArray
+    }
+}
+
+// MARK: - Encrypted
+
+@available(macOS 11.0, *)
+extension CassandraClient.Column {
+    /// Decrypt column and return as `String`.
+    public func decryptedString(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> String? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw CassandraClient.Error.decryptionError("Decrypted data is not valid UTF-8")
+        }
+        return string
+    }
+
+    /// Decrypt column and return as `[UInt8]`.
+    public func decryptedBytes(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> [UInt8]? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        return Array(data)
+    }
+
+    /// Decrypt column and return as `Int32`.
+    public func decryptedInt32(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Int32? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        guard data.count == 4 else {
+            throw CassandraClient.Error.decryptionError("Expected 4 bytes for Int32, got \(data.count)")
+        }
+        return data.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+    }
+
+    /// Decrypt column and return as `Int64`.
+    public func decryptedInt64(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Int64? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        guard data.count == 8 else {
+            throw CassandraClient.Error.decryptionError("Expected 8 bytes for Int64, got \(data.count)")
+        }
+        return data.withUnsafeBytes { $0.load(as: Int64.self).bigEndian }
+    }
+
+    /// Decrypt column and return as `Double`.
+    public func decryptedDouble(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Double? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        guard data.count == 8 else {
+            throw CassandraClient.Error.decryptionError("Expected 8 bytes for Double, got \(data.count)")
+        }
+        let bits = data.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+        return Double(bitPattern: bits)
+    }
+
+    /// Decrypt column and return as `UUID`.
+    public func decryptedUUID(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Foundation.UUID? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        guard data.count == 16 else {
+            throw CassandraClient.Error.decryptionError("Expected 16 bytes for UUID, got \(data.count)")
+        }
+        let u: uuid_t = (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                          data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15])
+        return Foundation.UUID(uuid: u)
+    }
+}
+
+@available(macOS 11.0, *)
+extension CassandraClient.Row {
+    /// Decrypt column by name and return as `String`.
+    public func decryptedString(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> String? {
+        try self.column(name)?.decryptedString(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `String`.
+    public func decryptedString(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> String? {
+        try self.column(index)?.decryptedString(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by name and return as `[UInt8]`.
+    public func decryptedBytes(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> [UInt8]? {
+        try self.column(name)?.decryptedBytes(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `[UInt8]`.
+    public func decryptedBytes(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> [UInt8]? {
+        try self.column(index)?.decryptedBytes(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by name and return as `Int32`.
+    public func decryptedInt32(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Int32? {
+        try self.column(name)?.decryptedInt32(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `Int32`.
+    public func decryptedInt32(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Int32? {
+        try self.column(index)?.decryptedInt32(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by name and return as `Int64`.
+    public func decryptedInt64(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Int64? {
+        try self.column(name)?.decryptedInt64(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `Int64`.
+    public func decryptedInt64(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Int64? {
+        try self.column(index)?.decryptedInt64(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by name and return as `Double`.
+    public func decryptedDouble(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Double? {
+        try self.column(name)?.decryptedDouble(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `Double`.
+    public func decryptedDouble(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Double? {
+        try self.column(index)?.decryptedDouble(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by name and return as `UUID`.
+    public func decryptedUUID(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Foundation.UUID? {
+        try self.column(name)?.decryptedUUID(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `UUID`.
+    public func decryptedUUID(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Foundation.UUID? {
+        try self.column(index)?.decryptedUUID(encryptor: encryptor, context: context)
     }
 }

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -830,7 +830,7 @@ extension CassandraClient.Column {
         guard data.count == 4 else {
             throw CassandraClient.Error.decryptionError("Expected 4 bytes for Int32, got \(data.count)")
         }
-        return data.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+        return data.withUnsafeBytes { $0.loadUnaligned(as: Int32.self).bigEndian }
     }
 
     /// Decrypt column and return as `Int64`.
@@ -842,7 +842,7 @@ extension CassandraClient.Column {
         guard data.count == 8 else {
             throw CassandraClient.Error.decryptionError("Expected 8 bytes for Int64, got \(data.count)")
         }
-        return data.withUnsafeBytes { $0.load(as: Int64.self).bigEndian }
+        return data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
     }
 
     /// Decrypt column and return as `Double`.
@@ -854,7 +854,7 @@ extension CassandraClient.Column {
         guard data.count == 8 else {
             throw CassandraClient.Error.decryptionError("Expected 8 bytes for Double, got \(data.count)")
         }
-        let bits = data.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+        let bits = data.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self).bigEndian }
         return Double(bitPattern: bits)
     }
 

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -591,7 +591,7 @@ extension CassandraClient.Column {
         return error == CASS_OK ? Array(UnsafeBufferPointer(start: value, count: size)) : nil
     }
 
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func decryptedData(
         encryptor: CassandraClient.Encryptor,
         context: CassandraClient.EncryptionContext
@@ -798,7 +798,7 @@ extension CassandraClient.Row {
 
 // MARK: - Encrypted
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Column {
     /// Decrypt column and return as `String`.
     public func decryptedString(
@@ -867,13 +867,15 @@ extension CassandraClient.Column {
         guard data.count == 16 else {
             throw CassandraClient.Error.decryptionError("Expected 16 bytes for UUID, got \(data.count)")
         }
-        let u: uuid_t = (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
-                          data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15])
+        let u: uuid_t = (
+            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+            data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]
+        )
         return Foundation.UUID(uuid: u)
     }
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Row {
     /// Decrypt column by name and return as `String`.
     public func decryptedString(

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -27,7 +27,7 @@ extension CassandraClient {
         }
 
         /// Create a decoder with encryption support for decoding `Encrypted<T>` fields.
-        @available(macOS 11.0, *)
+        @available(macOS 15.0, iOS 18.0, *)
         init(row: Row, encryptor: Encryptor, rowContext: RowEncryptionContext) {
             self.row = row
             self.userInfo[.cassandraEncryptor] = encryptor
@@ -325,8 +325,8 @@ extension CassandraClient {
 
         /// Decrypt column data using encryptor and context from userInfo.
         private func decryptColumnData(key: Key) throws -> Data {
-            guard #available(macOS 11.0, *) else {
-                throw DecodingError.notSupported("Encryption requires macOS 11.0+")
+            guard #available(macOS 15.0, iOS 18.0, *) else {
+                throw DecodingError.notSupported("Encryption requires macOS 15.0+")
             }
             guard let encryptor = userInfo[.cassandraEncryptor] as? CassandraClient.Encryptor else {
                 throw DecodingError.notSupported(

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -26,8 +26,16 @@ extension CassandraClient {
             self.row = row
         }
 
+        /// Create a decoder with encryption support for decoding `Encrypted<T>` fields.
+        @available(macOS 11.0, *)
+        init(row: Row, encryptor: Encryptor, rowContext: RowEncryptionContext) {
+            self.row = row
+            self.userInfo[.cassandraEncryptor] = encryptor
+            self.userInfo[.cassandraRowContext] = rowContext
+        }
+
         public func container<Key>(keyedBy _: Key.Type) throws -> KeyedDecodingContainer<Key> {
-            KeyedDecodingContainer(RowDecodingContainer<Key>(row: self.row))
+            KeyedDecodingContainer(RowDecodingContainer<Key>(row: self.row, userInfo: self.userInfo))
         }
 
         public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
@@ -41,11 +49,13 @@ extension CassandraClient {
 
     private struct RowDecodingContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
         private let row: Row
+        private let userInfo: [CodingUserInfoKey: Any]
 
         public var codingPath = [CodingKey]()
 
-        init(row: Row) {
+        init(row: Row, userInfo: [CodingUserInfoKey: Any] = [:]) {
             self.row = row
+            self.userInfo = userInfo
         }
 
         public var allKeys: [Key] {
@@ -167,7 +177,46 @@ extension CassandraClient {
 
         // FIXME: is there a nicer way?
         public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-            if type == [UInt8].self {
+            // Encrypted types — decrypt column and deserialize
+            if type == Encrypted<String>.self {
+                let data = try decryptColumnData(key: key)
+                guard let string = String(data: data, encoding: .utf8) else {
+                    throw DecodingError.typeMismatch("Decrypted data for \(key.stringValue) is not valid UTF-8")
+                }
+                return Encrypted<String>(string) as! T
+            } else if type == Encrypted<Int32>.self {
+                let data = try decryptColumnData(key: key)
+                guard data.count == 4 else {
+                    throw DecodingError.typeMismatch("Expected 4 bytes for Int32, got \(data.count)")
+                }
+                let value = data.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+                return Encrypted<Int32>(value) as! T
+            } else if type == Encrypted<Int64>.self {
+                let data = try decryptColumnData(key: key)
+                guard data.count == 8 else {
+                    throw DecodingError.typeMismatch("Expected 8 bytes for Int64, got \(data.count)")
+                }
+                let value = data.withUnsafeBytes { $0.load(as: Int64.self).bigEndian }
+                return Encrypted<Int64>(value) as! T
+            } else if type == Encrypted<Double>.self {
+                let data = try decryptColumnData(key: key)
+                guard data.count == 8 else {
+                    throw DecodingError.typeMismatch("Expected 8 bytes for Double, got \(data.count)")
+                }
+                let bits = data.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+                return Encrypted<Double>(Double(bitPattern: bits)) as! T
+            } else if type == Encrypted<Foundation.UUID>.self {
+                let data = try decryptColumnData(key: key)
+                guard data.count == 16 else {
+                    throw DecodingError.typeMismatch("Expected 16 bytes for UUID, got \(data.count)")
+                }
+                let u: uuid_t = (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                                  data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15])
+                return Encrypted<Foundation.UUID>(Foundation.UUID(uuid: u)) as! T
+            } else if type == Encrypted<[UInt8]>.self {
+                let data = try decryptColumnData(key: key)
+                return Encrypted<[UInt8]>(Array(data)) as! T
+            } else if type == [UInt8].self {
                 guard let value: [UInt8] = row.column(key.stringValue) else {
                     throw DecodingError.typeMismatch(
                         "value for \(key.stringValue) not found or of incorrect data type."
@@ -272,6 +321,29 @@ extension CassandraClient {
 
         public func superDecoder(forKey _: Key) throws -> Decoder {
             throw DecodingError.notSupported()
+        }
+
+        /// Decrypt column data using encryptor and context from userInfo.
+        private func decryptColumnData(key: Key) throws -> Data {
+            guard #available(macOS 11.0, *) else {
+                throw DecodingError.notSupported("Encryption requires macOS 11.0+")
+            }
+            guard let encryptor = userInfo[.cassandraEncryptor] as? CassandraClient.Encryptor else {
+                throw DecodingError.notSupported(
+                    "Encryptor not provided in decoder userInfo. Use RowDecoder(row:encryptor:rowContext:)"
+                )
+            }
+            guard let rowContext = userInfo[.cassandraRowContext] as? CassandraClient.RowEncryptionContext else {
+                throw DecodingError.notSupported("RowEncryptionContext missing from decoder userInfo")
+            }
+            let context = rowContext.forColumn(key.stringValue)
+            guard let column: Column = row.column(key.stringValue) else {
+                throw DecodingError.typeMismatch("value for \(key.stringValue) not found.")
+            }
+            guard let data = try column.decryptedData(encryptor: encryptor, context: context) else {
+                throw DecodingError.typeMismatch("value for \(key.stringValue) is null.")
+            }
+            return data
         }
     }
 }

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -189,21 +189,21 @@ extension CassandraClient {
                 guard data.count == 4 else {
                     throw DecodingError.typeMismatch("Expected 4 bytes for Int32, got \(data.count)")
                 }
-                let value = data.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+                let value = data.withUnsafeBytes { $0.loadUnaligned(as: Int32.self).bigEndian }
                 return Encrypted<Int32>(value) as! T
             } else if type == Encrypted<Int64>.self {
                 let data = try decryptColumnData(key: key)
                 guard data.count == 8 else {
                     throw DecodingError.typeMismatch("Expected 8 bytes for Int64, got \(data.count)")
                 }
-                let value = data.withUnsafeBytes { $0.load(as: Int64.self).bigEndian }
+                let value = data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
                 return Encrypted<Int64>(value) as! T
             } else if type == Encrypted<Double>.self {
                 let data = try decryptColumnData(key: key)
                 guard data.count == 8 else {
                     throw DecodingError.typeMismatch("Expected 8 bytes for Double, got \(data.count)")
                 }
-                let bits = data.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+                let bits = data.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self).bigEndian }
                 return Encrypted<Double>(Double(bitPattern: bits)) as! T
             } else if type == Encrypted<Foundation.UUID>.self {
                 let data = try decryptColumnData(key: key)

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -27,8 +27,8 @@ extension CassandraClient {
         }
 
         /// Create a decoder with encryption support for decoding `Encrypted<T>` fields.
-        @available(macOS 15.0, iOS 18.0, *)
-        init(row: Row, encryptor: Encryptor, rowContext: RowEncryptionContext) {
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        init(row: Row, encryptor: Encryptor, rowContext: EncryptionContext.Base) {
             self.row = row
             self.userInfo[.cassandraEncryptor] = encryptor
             self.userInfo[.cassandraRowContext] = rowContext
@@ -210,8 +210,10 @@ extension CassandraClient {
                 guard data.count == 16 else {
                     throw DecodingError.typeMismatch("Expected 16 bytes for UUID, got \(data.count)")
                 }
-                let u: uuid_t = (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
-                                  data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15])
+                let u: uuid_t = (
+                    data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                    data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]
+                )
                 return Encrypted<Foundation.UUID>(Foundation.UUID(uuid: u)) as! T
             } else if type == Encrypted<[UInt8]>.self {
                 let data = try decryptColumnData(key: key)
@@ -325,7 +327,7 @@ extension CassandraClient {
 
         /// Decrypt column data using encryptor and context from userInfo.
         private func decryptColumnData(key: Key) throws -> Data {
-            guard #available(macOS 15.0, iOS 18.0, *) else {
+            guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
                 throw DecodingError.notSupported("Encryption requires macOS 15.0+")
             }
             guard let encryptor = userInfo[.cassandraEncryptor] as? CassandraClient.Encryptor else {
@@ -333,8 +335,8 @@ extension CassandraClient {
                     "Encryptor not provided in decoder userInfo. Use RowDecoder(row:encryptor:rowContext:)"
                 )
             }
-            guard let rowContext = userInfo[.cassandraRowContext] as? CassandraClient.RowEncryptionContext else {
-                throw DecodingError.notSupported("RowEncryptionContext missing from decoder userInfo")
+            guard let rowContext = userInfo[.cassandraRowContext] as? CassandraClient.EncryptionContext.Base else {
+                throw DecodingError.notSupported("EncryptionContext.Base missing from decoder userInfo")
             }
             let context = rowContext.forColumn(key.stringValue)
             guard let column: Column = row.column(key.stringValue) else {

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -108,7 +108,7 @@ extension CassandraClient {
     ///
     /// This type cannot be constructed directly — use `encodeKeyComponents` to
     /// ensure key bytes are always length-prefixed and unambiguous.
-    public struct PrimaryKey: Sendable {
+    public struct PrimaryKey: Sendable, Equatable {
         internal let data: Data
     }
 }

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -1,0 +1,412 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+
+// MARK: - EncryptionContext
+
+extension CassandraClient {
+    /// Context identifying the encrypted column and row for key derivation.
+    ///
+    /// Renaming keyspace, table, or column after data has been encrypted
+    /// will make that data permanently unreadable.
+    public struct EncryptionContext {
+        public let keyspace: String
+        public let table: String
+        public let column: String
+        /// Full primary key bytes (partition key + clustering columns).
+        public let primaryKey: Data
+
+        public init(keyspace: String, table: String, column: String, primaryKey: Data) {
+            self.keyspace = keyspace
+            self.table = table
+            self.column = column
+            self.primaryKey = primaryKey
+        }
+
+        internal var contextString: String { "\(self.keyspace).\(self.table).\(self.column)" }
+
+        public func withColumn(_ column: String) -> EncryptionContext {
+            EncryptionContext(keyspace: self.keyspace, table: self.table, column: column, primaryKey: self.primaryKey)
+        }
+
+        public func withPrimaryKey(_ primaryKey: Data) -> EncryptionContext {
+            EncryptionContext(keyspace: self.keyspace, table: self.table, column: self.column, primaryKey: primaryKey)
+        }
+    }
+
+    /// Partial encryption context supplied per-row during Codable decoding.
+    /// The `column` field is derived automatically from the struct's property name.
+    public struct RowEncryptionContext {
+        public let keyspace: String
+        public let table: String
+        public let primaryKey: Data
+
+        public init(keyspace: String, table: String, primaryKey: Data) {
+            self.keyspace = keyspace
+            self.table = table
+            self.primaryKey = primaryKey
+        }
+
+        internal func forColumn(_ column: String) -> EncryptionContext {
+            EncryptionContext(keyspace: self.keyspace, table: self.table, column: column, primaryKey: self.primaryKey)
+        }
+    }
+}
+
+extension CassandraClient.EncryptionContext: Sendable {}
+
+// MARK: - Encrypted wrapper
+
+extension CassandraClient {
+    /// Wrapper that marks a value for transparent encryption on the write path
+    /// and decryption on the read path via Codable.
+    public struct Encrypted<T>: Codable where T: Codable {
+        public let value: T
+        public init(_ value: T) { self.value = value }
+
+        /// Always throws — decoding is intercepted by `RowDecodingContainer` before this is called.
+        /// This conformance exists so `Encrypted<T>` satisfies the `Codable` requirement on struct fields.
+        /// Using `Encrypted<T>` with a standard `Decoder` (e.g. `JSONDecoder`) is not supported.
+        public init(from decoder: Decoder) throws {
+            throw CassandraClient.Error.decryptionError(
+                "Encrypted<T> should be decoded via RowDecoder, not directly"
+            )
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            throw CassandraClient.Error.encryptionError(
+                "Encrypted<T> cannot be encoded directly. Use Statement.Value.encryptedXxx() on the write path."
+            )
+        }
+    }
+}
+
+// Only Sendable when T is Sendable
+extension CassandraClient.Encrypted: Sendable where T: Sendable {}
+
+// MARK: - KeysHolder
+
+extension CassandraClient {
+    /// Internal cache for derived column keys and storage for master key material.
+    /// Not thread-safe on its own — the `Encryptor` that owns it must hold a lock.
+    @available(macOS 11.0, *)
+    struct KeysHolder {
+        private var masterKeys: [String: Data]
+        private var kekCache: [String: SymmetricKey] = [:]
+        private let salt = Data("swift-cassandra-client-v1".utf8)
+
+        init(masterKeys: [String: Data]) {
+            self.masterKeys = masterKeys
+        }
+
+        func hasKey(_ name: String) -> Bool {
+            self.masterKeys[name] != nil
+        }
+
+        var allKeys: [String: Data] {
+            self.masterKeys
+        }
+
+        mutating func addKey(name: String, secret: Data) {
+            self.masterKeys[name] = secret
+        }
+
+        /// Returns cached column key (KEK) or derives and caches a new one.
+        /// Cache key is "keyName:contextString" (e.g. "key-2025:prod.users.ssn").
+        mutating func deriveKEK(keyName: String, context: String) throws -> SymmetricKey {
+            let cacheKey = "\(keyName):\(context)"
+            if let cached = self.kekCache[cacheKey] {
+                return cached
+            }
+            guard let masterKeyData = self.masterKeys[keyName] else {
+                throw CassandraClient.Error.keyNotFound("Key '\(keyName)' not found in keyMap")
+            }
+            let masterKey = SymmetricKey(data: masterKeyData)
+            let kek = HKDF<SHA256>.deriveKey(
+                inputKeyMaterial: masterKey,
+                salt: self.salt,
+                info: Data(context.utf8),
+                outputByteCount: 32
+            )
+            self.kekCache[cacheKey] = kek
+            return kek
+        }
+
+        /// Derive a per-row data encryption key (DEK) from the column key and primary key bytes.
+        /// Not cached — each row has a unique primary key, so caching would grow unbounded.
+        mutating func deriveDEK(keyName: String, context: String, primaryKey: Data) throws -> SymmetricKey {
+            let kek = try self.deriveKEK(keyName: keyName, context: context)
+            return HKDF<SHA256>.deriveKey(
+                inputKeyMaterial: kek,
+                salt: Data(),
+                info: primaryKey,
+                outputByteCount: 32
+            )
+        }
+    }
+}
+
+// MARK: - Encryptor
+
+extension CassandraClient {
+    /// Handles column-level encryption and decryption using AES-GCM with HKDF-derived keys.
+    @available(macOS 11.0, *)
+    public final class Encryptor {
+        static let envelopeVersion: UInt8 = 0x02
+        /// AES-GCM with a per-row DEK derived deterministically via HKDF from the column KEK and primary key.
+        /// Encryption is non-deterministic (random nonce per call); only the DEK derivation is deterministic.
+        static let algorithmHKDFDerivedAESGCM: UInt8 = 0x02
+        static let nonceSize = 12
+        static let keySize = 32
+        static let maxKeyNameLength = 255
+
+        private let lock = NSLock()
+        private var currentKeyName: String
+        private var keysHolder: KeysHolder
+
+        /// Create an encryptor with the given key map and current key name.
+        ///
+        /// - Parameters:
+        ///   - keyMap: Dictionary mapping key names (e.g. "key-2025") to 32-byte raw key material.
+        ///     Multiple keys can be provided to support key rotation — old keys decrypt existing data,
+        ///     while `currentKeyName` selects which key is used for new encryptions.
+        ///   - currentKeyName: The key name to use for new encryptions. Must exist in `keyMap`.
+        /// - Throws: `CassandraClient.Error.encryptionConfigError` if the key map is empty,
+        ///   a key name is invalid, a key is not 32 bytes, or `currentKeyName` is not in the map.
+        public init(keyMap: [String: Data], currentKeyName: String) throws {
+            guard !keyMap.isEmpty else {
+                throw CassandraClient.Error.encryptionConfigError("keyMap must not be empty")
+            }
+            for (name, key) in keyMap {
+                try Self.validateKey(name: name, secret: key)
+            }
+            guard keyMap[currentKeyName] != nil else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "currentKeyName '\(currentKeyName)' not found in keyMap"
+                )
+            }
+            self.currentKeyName = currentKeyName
+            self.keysHolder = KeysHolder(masterKeys: keyMap)
+        }
+
+        public func addKey(name: String, secret: Data) throws {
+            try Self.validateKey(name: name, secret: secret)
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            self.keysHolder.addKey(name: name, secret: secret)
+        }
+
+        /// Set the key name used for new encryptions. The key must already exist in the key map.
+        public func setCurrentKeyName(_ name: String) throws {
+            try Self.validateKeyName(name)
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            guard self.keysHolder.hasKey(name) else {
+                throw CassandraClient.Error.keyNotFound("Key '\(name)' not found in keyMap")
+            }
+            self.currentKeyName = name
+        }
+
+        /// Replace the entire key map. Existing keys cannot be removed or changed.
+        /// The current key name must exist in the new map.
+        public func loadKeys(from newKeyMap: [String: Data]) throws {
+            for (name, key) in newKeyMap {
+                try Self.validateKey(name: name, secret: key)
+            }
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            for (existingName, existingKey) in self.keysHolder.allKeys {
+                guard let newKey = newKeyMap[existingName] else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Cannot remove existing key '\(existingName)'"
+                    )
+                }
+                guard newKey == existingKey else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Cannot change existing key '\(existingName)'"
+                    )
+                }
+            }
+            guard newKeyMap[self.currentKeyName] != nil else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "currentKeyName '\(self.currentKeyName)' not found in new keyMap"
+                )
+            }
+            self.keysHolder = KeysHolder(masterKeys: newKeyMap)
+        }
+
+        /// Encrypt plaintext data for the given context.
+        ///
+        /// Produces an envelope: `[version:1][algorithm:1][key-name-len:1][key-name:N][nonce:12][ciphertext+tag]`
+        ///
+        /// The envelope is self-describing — it contains the key name and algorithm used,
+        /// so `decrypt` can process data encrypted with any key in the key map.
+        internal func encrypt(_ data: Data, context: EncryptionContext) throws -> Data {
+            let (keyName, dek) = try {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                let name = self.currentKeyName
+                let key = try self.keysHolder.deriveDEK(
+                    keyName: name,
+                    context: context.contextString,
+                    primaryKey: context.primaryKey
+                )
+                return (name, key)
+            }()
+
+            let keyNameBytes = Data(keyName.utf8)
+            let nonce = AES.GCM.Nonce()
+            let aad = Data(context.contextString.utf8)
+
+            let sealed: AES.GCM.SealedBox
+            do {
+                sealed = try AES.GCM.seal(data, using: dek, nonce: nonce, authenticating: aad)
+            } catch {
+                throw CassandraClient.Error.encryptionError("AES-GCM seal failed: \(error)")
+            }
+
+            var envelope = Data()
+            envelope.reserveCapacity(3 + keyNameBytes.count + Self.nonceSize + sealed.ciphertext.count + 16)
+            envelope.append(Self.envelopeVersion)
+            envelope.append(Self.algorithmHKDFDerivedAESGCM)
+            envelope.append(UInt8(keyNameBytes.count))
+            envelope.append(keyNameBytes)
+            envelope.append(contentsOf: sealed.nonce)
+            envelope.append(sealed.ciphertext)
+            envelope.append(sealed.tag)
+            return envelope
+        }
+
+        /// Decrypt an envelope for the given context.
+        ///
+        /// Parses the envelope to extract the key name and algorithm, derives the DEK
+        /// using the key from the envelope (not `currentKeyName`), and decrypts.
+        /// This allows data encrypted with any key in the key map to be decrypted.
+        internal func decrypt(_ envelope: Data, context: EncryptionContext) throws -> Data {
+            // Minimum envelope: version(1) + algorithm(1) + keyNameLen(1) + keyName(1+) + nonce(12) + tag(16)
+            let minSize = 1 + 1 + 1 + 1 + Self.nonceSize + 16
+            guard envelope.count >= minSize else {
+                throw CassandraClient.Error.decryptionError(
+                    "Envelope too small: \(envelope.count) bytes, minimum \(minSize)"
+                )
+            }
+
+            var offset = 0
+
+            let version = envelope[offset]
+            offset += 1
+            guard version == Self.envelopeVersion else {
+                throw CassandraClient.Error.decryptionError("Unsupported envelope version: \(version)")
+            }
+
+            let algorithm = envelope[offset]
+            offset += 1
+            guard algorithm == Self.algorithmHKDFDerivedAESGCM else {
+                throw CassandraClient.Error.decryptionError("Unsupported algorithm: \(algorithm)")
+            }
+
+            let keyNameLen = Int(envelope[offset])
+            offset += 1
+            guard keyNameLen > 0, offset + keyNameLen <= envelope.count else {
+                throw CassandraClient.Error.decryptionError("Invalid key name length: \(keyNameLen)")
+            }
+
+            let keyNameBytes = envelope[offset ..< offset + keyNameLen]
+            offset += keyNameLen
+            guard let keyName = String(data: Data(keyNameBytes), encoding: .utf8) else {
+                throw CassandraClient.Error.decryptionError("Invalid key name encoding")
+            }
+
+            guard envelope.count - offset >= Self.nonceSize + 16 else {
+                throw CassandraClient.Error.decryptionError("Envelope too small for nonce + ciphertext + tag")
+            }
+
+            let nonceData = envelope[offset ..< offset + Self.nonceSize]
+            offset += Self.nonceSize
+
+            let ciphertextAndTag = envelope[offset...]
+
+            let dek = try {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return try self.keysHolder.deriveDEK(
+                    keyName: keyName,
+                    context: context.contextString,
+                    primaryKey: context.primaryKey
+                )
+            }()
+
+            let nonce: AES.GCM.Nonce
+            do {
+                nonce = try AES.GCM.Nonce(data: nonceData)
+            } catch {
+                throw CassandraClient.Error.decryptionError("Invalid nonce: \(error)")
+            }
+
+            let sealedBox: AES.GCM.SealedBox
+            do {
+                sealedBox = try AES.GCM.SealedBox(
+                    nonce: nonce,
+                    ciphertext: ciphertextAndTag.dropLast(16),
+                    tag: ciphertextAndTag.suffix(16)
+                )
+            } catch {
+                throw CassandraClient.Error.decryptionError("Invalid sealed box: \(error)")
+            }
+
+            let aad = Data(context.contextString.utf8)
+            do {
+                return try AES.GCM.open(sealedBox, using: dek, authenticating: aad)
+            } catch {
+                throw CassandraClient.Error.decryptionError("AES-GCM authentication failed: \(error)")
+            }
+        }
+
+        private static func validateKey(name: String, secret: Data) throws {
+            try validateKeyName(name)
+            guard secret.count == keySize else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Key '\(name)' must be \(keySize) bytes, got \(secret.count)"
+                )
+            }
+        }
+
+        /// Validate a key name: must be 1-255 characters, alphanumeric plus '-' and '_'.
+        private static func validateKeyName(_ name: String) throws {
+            guard !name.isEmpty, name.count <= maxKeyNameLength else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Key name must be 1-\(maxKeyNameLength) characters, got \(name.count)"
+                )
+            }
+            let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+            guard name.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Key name '\(name)' contains invalid characters (allowed: alphanumeric, '-', '_')"
+                )
+            }
+        }
+    }
+}
+
+@available(macOS 11.0, *)
+extension CassandraClient.Encryptor: @unchecked Sendable {}
+
+// MARK: - CodingUserInfoKey extensions for encryption
+
+extension CodingUserInfoKey {
+    static let cassandraEncryptor = CodingUserInfoKey(rawValue: "cassandraEncryptor")!
+    static let cassandraRowContext = CodingUserInfoKey(rawValue: "cassandraRowContext")!
+}

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -27,10 +27,10 @@ extension CassandraClient {
         public let keyspace: String
         public let table: String
         public let column: String
-        /// Full primary key bytes (partition key + clustering columns).
-        public let primaryKey: Data
+        /// Full primary key (partition key + clustering columns), built via ``encodeKeyComponents(_:)``.
+        public let primaryKey: PrimaryKey
 
-        internal init(keyspace: String, table: String, column: String, primaryKey: Data) {
+        internal init(keyspace: String, table: String, column: String, primaryKey: PrimaryKey) {
             self.keyspace = keyspace
             self.table = table
             self.column = column
@@ -39,13 +39,13 @@ extension CassandraClient {
 
         internal var contextString: String { "\(self.keyspace).\(self.table).\(self.column)" }
 
-        /// Encode typed key components into a single `Data` value.
+        /// Encode typed key components into a ``PrimaryKey``.
         ///
         /// Each component is serialized as `[4-byte big-endian length][value bytes]`.
         /// This length-prefixing ensures composite keys are unambiguous — for example,
         /// `encodeKeyComponents(.string("ab"), .string("c"))` produces different bytes
         /// from `encodeKeyComponents(.string("a"), .string("bc"))`.
-        public static func encodeKeyComponents(_ components: CassandraClient.KeyComponent...) -> Data {
+        public static func encodeKeyComponents(_ components: CassandraClient.KeyComponent...) -> PrimaryKey {
             var result = Data()
             for component in components {
                 let bytes: Data
@@ -71,16 +71,16 @@ extension CassandraClient {
                 result.append(Data(bytes: &length, count: 4))
                 result.append(bytes)
             }
-            return result
+            return PrimaryKey(data: result)
         }
 
         /// Base context without a column name. Use ``forColumn(_:)`` to produce a full ``EncryptionContext``.
         public struct Base {
             public let keyspace: String
             public let table: String
-            public let primaryKey: Data
+            public let primaryKey: PrimaryKey
 
-            public init(keyspace: String, table: String, primaryKey: Data) {
+            public init(keyspace: String, table: String, primaryKey: PrimaryKey) {
                 self.keyspace = keyspace
                 self.table = table
                 self.primaryKey = primaryKey
@@ -100,6 +100,18 @@ extension CassandraClient {
 }
 
 extension CassandraClient.EncryptionContext: Sendable {}
+
+// MARK: - PrimaryKey
+
+extension CassandraClient {
+    /// Opaque primary key built via ``EncryptionContext/encodeKeyComponents(_:)``.
+    ///
+    /// This type cannot be constructed directly — use `encodeKeyComponents` to
+    /// ensure key bytes are always length-prefixed and unambiguous.
+    public struct PrimaryKey: Sendable {
+        internal let data: Data
+    }
+}
 
 // MARK: - KeyComponent
 
@@ -192,12 +204,16 @@ extension CassandraClient {
 
         /// Derive a per-row data encryption key (DEK) from the column key and primary key bytes.
         /// Not cached — each row has a unique primary key, so caching would grow unbounded.
-        mutating func deriveDEK(keyName: String, context: String, primaryKey: Data) throws -> SymmetricKey {
+        mutating func deriveDEK(
+            keyName: String,
+            context: String,
+            primaryKey: CassandraClient.PrimaryKey
+        ) throws -> SymmetricKey {
             let kek = try self.deriveKEK(keyName: keyName, context: context)
             return HKDF<SHA256>.deriveKey(
                 inputKeyMaterial: kek,
                 salt: Data(),
-                info: primaryKey,
+                info: primaryKey.data,
                 outputByteCount: 32
             )
         }

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -163,10 +163,12 @@ extension CassandraClient {
     @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     struct KeysHolder {
         private var rootKeys: [String: Data]
+        private let salt: Data
         private var kekCache: [String: SymmetricKey] = [:]
 
-        init(rootKeys: [String: Data]) {
+        init(rootKeys: [String: Data], salt: Data = Data()) {
             self.rootKeys = rootKeys
+            self.salt = salt
         }
 
         func hasKey(_ name: String) -> Bool {
@@ -192,9 +194,9 @@ extension CassandraClient {
                 throw CassandraClient.Error.keyNotFound("Key '\(keyName)' not found in keyMap")
             }
             let rootKey = SymmetricKey(data: rootKeyData)
-            let kek = HKDF<SHA256>.deriveKey(
+            let kek = HKDF<SHA512>.deriveKey(
                 inputKeyMaterial: rootKey,
-                salt: Data(),
+                salt: self.salt,
                 info: Data(context.utf8),
                 outputByteCount: 32
             )
@@ -210,7 +212,7 @@ extension CassandraClient {
             primaryKey: CassandraClient.PrimaryKey
         ) throws -> SymmetricKey {
             let kek = try self.deriveKEK(keyName: keyName, context: context)
-            return HKDF<SHA256>.deriveKey(
+            return HKDF<SHA512>.deriveKey(
                 inputKeyMaterial: kek,
                 salt: Data(),
                 info: primaryKey.data,
@@ -250,7 +252,7 @@ extension CassandraClient {
         ///   - currentKeyName: The key name to use for new encryptions. Must exist in `keyMap`.
         /// - Throws: `CassandraClient.Error.encryptionConfigError` if the key map is empty,
         ///   a key name is invalid, a key is not 32 bytes, or `currentKeyName` is not in the map.
-        public init(keyMap: [String: Data], currentKeyName: String) throws {
+        public init(keyMap: [String: Data], currentKeyName: String, salt: Data = Data()) throws {
             guard !keyMap.isEmpty else {
                 throw CassandraClient.Error.encryptionConfigError("keyMap must not be empty")
             }
@@ -265,7 +267,7 @@ extension CassandraClient {
             self.state = Mutex(
                 State(
                     currentKeyName: currentKeyName,
-                    keysHolder: KeysHolder(rootKeys: keyMap)
+                    keysHolder: KeysHolder(rootKeys: keyMap, salt: salt)
                 )
             )
         }

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -27,7 +27,7 @@ extension CassandraClient {
         public let keyspace: String
         public let table: String
         public let column: String
-        /// Full primary key (partition key + clustering columns), built via ``encodeKeyComponents(_:)``.
+        /// Full primary key (partition key + clustering columns), built via ``PrimaryKey/init(from:)``.
         public let primaryKey: PrimaryKey
 
         internal init(keyspace: String, table: String, column: String, primaryKey: PrimaryKey) {
@@ -38,41 +38,6 @@ extension CassandraClient {
         }
 
         internal var contextString: String { "\(self.keyspace).\(self.table).\(self.column)" }
-
-        /// Encode typed key components into a ``PrimaryKey``.
-        ///
-        /// Each component is serialized as `[4-byte big-endian length][value bytes]`.
-        /// This length-prefixing ensures composite keys are unambiguous — for example,
-        /// `encodeKeyComponents(.string("ab"), .string("c"))` produces different bytes
-        /// from `encodeKeyComponents(.string("a"), .string("bc"))`.
-        public static func encodeKeyComponents(_ components: CassandraClient.KeyComponent...) -> PrimaryKey {
-            var result = Data()
-            for component in components {
-                let bytes: Data
-                switch component {
-                case .string(let s):
-                    bytes = Data(s.utf8)
-                case .uuid(let u):
-                    let t = u.uuid
-                    bytes = Data([
-                        t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
-                        t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15,
-                    ])
-                case .int32(let v):
-                    var be = v.bigEndian
-                    bytes = Data(bytes: &be, count: 4)
-                case .int64(let v):
-                    var be = v.bigEndian
-                    bytes = Data(bytes: &be, count: 8)
-                case .data(let d):
-                    bytes = d
-                }
-                var length = UInt32(bytes.count).bigEndian
-                result.append(Data(bytes: &length, count: 4))
-                result.append(bytes)
-            }
-            return PrimaryKey(data: result)
-        }
 
         /// Base context without a column name. Use ``forColumn(_:)`` to produce a full ``EncryptionContext``.
         public struct Base {
@@ -104,19 +69,50 @@ extension CassandraClient.EncryptionContext: Sendable {}
 // MARK: - PrimaryKey
 
 extension CassandraClient {
-    /// Opaque primary key built via ``EncryptionContext/encodeKeyComponents(_:)``.
+    /// Opaque primary key with length-prefixed key components.
     ///
-    /// This type cannot be constructed directly — use `encodeKeyComponents` to
-    /// ensure key bytes are always length-prefixed and unambiguous.
+    /// Each component is serialized as `[4-byte big-endian length][value bytes]`.
+    /// This ensures composite keys are unambiguous — for example,
+    /// `PrimaryKey(from: .string("ab"), .string("c"))` produces different bytes
+    /// from `PrimaryKey(from: .string("a"), .string("bc"))`.
     public struct PrimaryKey: Sendable, Equatable {
         internal let data: Data
+
+        public init(from components: CassandraClient.KeyComponent...) {
+            var result = Data()
+            for component in components {
+                let bytes: Data
+                switch component {
+                case .string(let s):
+                    bytes = Data(s.utf8)
+                case .uuid(let u):
+                    let t = u.uuid
+                    bytes = Data([
+                        t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
+                        t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15,
+                    ])
+                case .int32(let v):
+                    var be = v.bigEndian
+                    bytes = Data(bytes: &be, count: 4)
+                case .int64(let v):
+                    var be = v.bigEndian
+                    bytes = Data(bytes: &be, count: 8)
+                case .data(let d):
+                    bytes = d
+                }
+                var length = UInt32(bytes.count).bigEndian
+                result.append(Data(bytes: &length, count: 4))
+                result.append(bytes)
+            }
+            self.data = result
+        }
     }
 }
 
 // MARK: - KeyComponent
 
 extension CassandraClient {
-    /// A typed key component for use with ``EncryptionContext/encodeKeyComponents(_:)``.
+    /// A typed key component for use with ``PrimaryKey/init(from:)``.
     public enum KeyComponent {
         case string(String)
         case uuid(Foundation.UUID)
@@ -250,6 +246,7 @@ extension CassandraClient {
         ///     Multiple keys can be provided to support key rotation — old keys decrypt existing data,
         ///     while `currentKeyName` selects which key is used for new encryptions.
         ///   - currentKeyName: The key name to use for new encryptions. Must exist in `keyMap`.
+        ///   - salt: Optional salt for HKDF key derivation. Defaults to empty.
         /// - Throws: `CassandraClient.Error.encryptionConfigError` if the key map is empty,
         ///   a key name is invalid, a key is not 32 bytes, or `currentKeyName` is not in the map.
         public init(keyMap: [String: Data], currentKeyName: String, salt: Data = Data()) throws {

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -30,7 +30,7 @@ extension CassandraClient {
         /// Full primary key bytes (partition key + clustering columns).
         public let primaryKey: Data
 
-        public init(keyspace: String, table: String, column: String, primaryKey: Data) {
+        internal init(keyspace: String, table: String, column: String, primaryKey: Data) {
             self.keyspace = keyspace
             self.table = table
             self.column = column
@@ -39,35 +39,80 @@ extension CassandraClient {
 
         internal var contextString: String { "\(self.keyspace).\(self.table).\(self.column)" }
 
-        public func withColumn(_ column: String) -> EncryptionContext {
-            EncryptionContext(keyspace: self.keyspace, table: self.table, column: column, primaryKey: self.primaryKey)
+        /// Encode typed key components into a single `Data` value.
+        ///
+        /// Each component is serialized as `[4-byte big-endian length][value bytes]`.
+        /// This length-prefixing ensures composite keys are unambiguous — for example,
+        /// `encodeKeyComponents(.string("ab"), .string("c"))` produces different bytes
+        /// from `encodeKeyComponents(.string("a"), .string("bc"))`.
+        public static func encodeKeyComponents(_ components: CassandraClient.KeyComponent...) -> Data {
+            var result = Data()
+            for component in components {
+                let bytes: Data
+                switch component {
+                case .string(let s):
+                    bytes = Data(s.utf8)
+                case .uuid(let u):
+                    let t = u.uuid
+                    bytes = Data([
+                        t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
+                        t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15,
+                    ])
+                case .int32(let v):
+                    var be = v.bigEndian
+                    bytes = Data(bytes: &be, count: 4)
+                case .int64(let v):
+                    var be = v.bigEndian
+                    bytes = Data(bytes: &be, count: 8)
+                case .data(let d):
+                    bytes = d
+                }
+                var length = UInt32(bytes.count).bigEndian
+                result.append(Data(bytes: &length, count: 4))
+                result.append(bytes)
+            }
+            return result
         }
 
-        public func withPrimaryKey(_ primaryKey: Data) -> EncryptionContext {
-            EncryptionContext(keyspace: self.keyspace, table: self.table, column: self.column, primaryKey: primaryKey)
+        /// Base context without a column name. Use ``forColumn(_:)`` to produce a full ``EncryptionContext``.
+        public struct Base {
+            public let keyspace: String
+            public let table: String
+            public let primaryKey: Data
+
+            public init(keyspace: String, table: String, primaryKey: Data) {
+                self.keyspace = keyspace
+                self.table = table
+                self.primaryKey = primaryKey
+            }
+
+            public func forColumn(_ column: String) -> EncryptionContext {
+                EncryptionContext(
+                    keyspace: self.keyspace,
+                    table: self.table,
+                    column: column,
+                    primaryKey: self.primaryKey
+                )
+            }
         }
     }
 
-    /// Partial encryption context supplied per-row during Codable decoding.
-    /// The `column` field is derived automatically from the struct's property name.
-    public struct RowEncryptionContext {
-        public let keyspace: String
-        public let table: String
-        public let primaryKey: Data
-
-        public init(keyspace: String, table: String, primaryKey: Data) {
-            self.keyspace = keyspace
-            self.table = table
-            self.primaryKey = primaryKey
-        }
-
-        internal func forColumn(_ column: String) -> EncryptionContext {
-            EncryptionContext(keyspace: self.keyspace, table: self.table, column: column, primaryKey: self.primaryKey)
-        }
-    }
 }
 
 extension CassandraClient.EncryptionContext: Sendable {}
+
+// MARK: - KeyComponent
+
+extension CassandraClient {
+    /// A typed key component for use with ``EncryptionContext/encodeKeyComponents(_:)``.
+    public enum KeyComponent {
+        case string(String)
+        case uuid(Foundation.UUID)
+        case int32(Int32)
+        case int64(Int64)
+        case data(Data)
+    }
+}
 
 // MARK: - Encrypted wrapper
 
@@ -103,11 +148,10 @@ extension CassandraClient.Encrypted: Sendable where T: Sendable {}
 extension CassandraClient {
     /// Internal cache for derived column keys and storage for root key material.
     /// Not thread-safe on its own — the `Encryptor` that owns it must hold a lock.
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     struct KeysHolder {
         private var rootKeys: [String: Data]
         private var kekCache: [String: SymmetricKey] = [:]
-        private let salt = Data("swift-cassandra-client-v1".utf8)
 
         init(rootKeys: [String: Data]) {
             self.rootKeys = rootKeys
@@ -138,7 +182,7 @@ extension CassandraClient {
             let rootKey = SymmetricKey(data: rootKeyData)
             let kek = HKDF<SHA256>.deriveKey(
                 inputKeyMaterial: rootKey,
-                salt: self.salt,
+                salt: Data(),
                 info: Data(context.utf8),
                 outputByteCount: 32
             )
@@ -164,7 +208,7 @@ extension CassandraClient {
 
 extension CassandraClient {
     /// Handles column-level encryption and decryption using AES-GCM with HKDF-derived keys.
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public final class Encryptor {
         static let envelopeVersion: UInt8 = 0x02
         /// AES-GCM with a per-row DEK derived deterministically via HKDF from the column KEK and primary key.
@@ -202,10 +246,12 @@ extension CassandraClient {
                     "currentKeyName '\(currentKeyName)' not found in keyMap"
                 )
             }
-            self.state = Mutex(State(
-                currentKeyName: currentKeyName,
-                keysHolder: KeysHolder(rootKeys: keyMap)
-            ))
+            self.state = Mutex(
+                State(
+                    currentKeyName: currentKeyName,
+                    keysHolder: KeysHolder(rootKeys: keyMap)
+                )
+            )
         }
 
         public func addKey(name: String, secret: Data) throws {
@@ -326,7 +372,7 @@ extension CassandraClient {
                 throw CassandraClient.Error.decryptionError("Invalid key name length: \(keyNameLen)")
             }
 
-            let keyNameBytes = envelope[offset ..< offset + keyNameLen]
+            let keyNameBytes = envelope[offset..<offset + keyNameLen]
             offset += keyNameLen
             guard let keyName = String(data: Data(keyNameBytes), encoding: .utf8) else {
                 throw CassandraClient.Error.decryptionError("Invalid key name encoding")
@@ -336,13 +382,13 @@ extension CassandraClient {
                 throw CassandraClient.Error.decryptionError("Envelope too small for nonce + ciphertext + tag")
             }
 
-            let nonceData = envelope[offset ..< offset + Self.nonceSize]
+            let nonceData = envelope[offset..<offset + Self.nonceSize]
             offset += Self.nonceSize
 
             let ciphertextAndTag = envelope[offset...]
 
             let dek = try self.state.withLock {
-                return try $0.keysHolder.deriveDEK(
+                try $0.keysHolder.deriveDEK(
                     keyName: keyName,
                     context: context.contextString,
                     primaryKey: context.primaryKey
@@ -401,7 +447,7 @@ extension CassandraClient {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Encryptor: Sendable {}
 
 // MARK: - CodingUserInfoKey extensions for encryption

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import Foundation
+import Synchronization
 
 // MARK: - EncryptionContext
 
@@ -100,28 +101,28 @@ extension CassandraClient.Encrypted: Sendable where T: Sendable {}
 // MARK: - KeysHolder
 
 extension CassandraClient {
-    /// Internal cache for derived column keys and storage for master key material.
+    /// Internal cache for derived column keys and storage for root key material.
     /// Not thread-safe on its own — the `Encryptor` that owns it must hold a lock.
-    @available(macOS 11.0, *)
+    @available(macOS 15.0, iOS 18.0, *)
     struct KeysHolder {
-        private var masterKeys: [String: Data]
+        private var rootKeys: [String: Data]
         private var kekCache: [String: SymmetricKey] = [:]
         private let salt = Data("swift-cassandra-client-v1".utf8)
 
-        init(masterKeys: [String: Data]) {
-            self.masterKeys = masterKeys
+        init(rootKeys: [String: Data]) {
+            self.rootKeys = rootKeys
         }
 
         func hasKey(_ name: String) -> Bool {
-            self.masterKeys[name] != nil
+            self.rootKeys[name] != nil
         }
 
         var allKeys: [String: Data] {
-            self.masterKeys
+            self.rootKeys
         }
 
         mutating func addKey(name: String, secret: Data) {
-            self.masterKeys[name] = secret
+            self.rootKeys[name] = secret
         }
 
         /// Returns cached column key (KEK) or derives and caches a new one.
@@ -131,12 +132,12 @@ extension CassandraClient {
             if let cached = self.kekCache[cacheKey] {
                 return cached
             }
-            guard let masterKeyData = self.masterKeys[keyName] else {
+            guard let rootKeyData = self.rootKeys[keyName] else {
                 throw CassandraClient.Error.keyNotFound("Key '\(keyName)' not found in keyMap")
             }
-            let masterKey = SymmetricKey(data: masterKeyData)
+            let rootKey = SymmetricKey(data: rootKeyData)
             let kek = HKDF<SHA256>.deriveKey(
-                inputKeyMaterial: masterKey,
+                inputKeyMaterial: rootKey,
                 salt: self.salt,
                 info: Data(context.utf8),
                 outputByteCount: 32
@@ -163,7 +164,7 @@ extension CassandraClient {
 
 extension CassandraClient {
     /// Handles column-level encryption and decryption using AES-GCM with HKDF-derived keys.
-    @available(macOS 11.0, *)
+    @available(macOS 15.0, iOS 18.0, *)
     public final class Encryptor {
         static let envelopeVersion: UInt8 = 0x02
         /// AES-GCM with a per-row DEK derived deterministically via HKDF from the column KEK and primary key.
@@ -173,9 +174,12 @@ extension CassandraClient {
         static let keySize = 32
         static let maxKeyNameLength = 255
 
-        private let lock = NSLock()
-        private var currentKeyName: String
-        private var keysHolder: KeysHolder
+        private struct State {
+            var currentKeyName: String
+            var keysHolder: KeysHolder
+        }
+
+        private let state: Mutex<State>
 
         /// Create an encryptor with the given key map and current key name.
         ///
@@ -198,26 +202,26 @@ extension CassandraClient {
                     "currentKeyName '\(currentKeyName)' not found in keyMap"
                 )
             }
-            self.currentKeyName = currentKeyName
-            self.keysHolder = KeysHolder(masterKeys: keyMap)
+            self.state = Mutex(State(
+                currentKeyName: currentKeyName,
+                keysHolder: KeysHolder(rootKeys: keyMap)
+            ))
         }
 
         public func addKey(name: String, secret: Data) throws {
             try Self.validateKey(name: name, secret: secret)
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            self.keysHolder.addKey(name: name, secret: secret)
+            self.state.withLock { $0.keysHolder.addKey(name: name, secret: secret) }
         }
 
         /// Set the key name used for new encryptions. The key must already exist in the key map.
         public func setCurrentKeyName(_ name: String) throws {
             try Self.validateKeyName(name)
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            guard self.keysHolder.hasKey(name) else {
-                throw CassandraClient.Error.keyNotFound("Key '\(name)' not found in keyMap")
+            try self.state.withLock {
+                guard $0.keysHolder.hasKey(name) else {
+                    throw CassandraClient.Error.keyNotFound("Key '\(name)' not found in keyMap")
+                }
+                $0.currentKeyName = name
             }
-            self.currentKeyName = name
         }
 
         /// Replace the entire key map. Existing keys cannot be removed or changed.
@@ -226,26 +230,26 @@ extension CassandraClient {
             for (name, key) in newKeyMap {
                 try Self.validateKey(name: name, secret: key)
             }
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            for (existingName, existingKey) in self.keysHolder.allKeys {
-                guard let newKey = newKeyMap[existingName] else {
+            try self.state.withLock {
+                for (existingName, existingKey) in $0.keysHolder.allKeys {
+                    guard let newKey = newKeyMap[existingName] else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Cannot remove existing key '\(existingName)'"
+                        )
+                    }
+                    guard newKey == existingKey else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Cannot change existing key '\(existingName)'"
+                        )
+                    }
+                }
+                guard newKeyMap[$0.currentKeyName] != nil else {
                     throw CassandraClient.Error.encryptionConfigError(
-                        "Cannot remove existing key '\(existingName)'"
+                        "currentKeyName '\($0.currentKeyName)' not found in new keyMap"
                     )
                 }
-                guard newKey == existingKey else {
-                    throw CassandraClient.Error.encryptionConfigError(
-                        "Cannot change existing key '\(existingName)'"
-                    )
-                }
+                $0.keysHolder = KeysHolder(rootKeys: newKeyMap)
             }
-            guard newKeyMap[self.currentKeyName] != nil else {
-                throw CassandraClient.Error.encryptionConfigError(
-                    "currentKeyName '\(self.currentKeyName)' not found in new keyMap"
-                )
-            }
-            self.keysHolder = KeysHolder(masterKeys: newKeyMap)
         }
 
         /// Encrypt plaintext data for the given context.
@@ -255,17 +259,15 @@ extension CassandraClient {
         /// The envelope is self-describing — it contains the key name and algorithm used,
         /// so `decrypt` can process data encrypted with any key in the key map.
         internal func encrypt(_ data: Data, context: EncryptionContext) throws -> Data {
-            let (keyName, dek) = try {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                let name = self.currentKeyName
-                let key = try self.keysHolder.deriveDEK(
+            let (keyName, dek) = try self.state.withLock {
+                let name = $0.currentKeyName
+                let key = try $0.keysHolder.deriveDEK(
                     keyName: name,
                     context: context.contextString,
                     primaryKey: context.primaryKey
                 )
                 return (name, key)
-            }()
+            }
 
             let keyNameBytes = Data(keyName.utf8)
             let nonce = AES.GCM.Nonce()
@@ -339,15 +341,13 @@ extension CassandraClient {
 
             let ciphertextAndTag = envelope[offset...]
 
-            let dek = try {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                return try self.keysHolder.deriveDEK(
+            let dek = try self.state.withLock {
+                return try $0.keysHolder.deriveDEK(
                     keyName: keyName,
                     context: context.contextString,
                     primaryKey: context.primaryKey
                 )
-            }()
+            }
 
             let nonce: AES.GCM.Nonce
             do {
@@ -401,8 +401,8 @@ extension CassandraClient {
     }
 }
 
-@available(macOS 11.0, *)
-extension CassandraClient.Encryptor: @unchecked Sendable {}
+@available(macOS 15.0, iOS 18.0, *)
+extension CassandraClient.Encryptor: Sendable {}
 
 // MARK: - CodingUserInfoKey extensions for encryption
 

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -81,28 +81,9 @@ extension CassandraClient {
         public init(from components: CassandraClient.KeyComponent...) {
             var result = Data()
             for component in components {
-                let bytes: Data
-                switch component {
-                case .string(let s):
-                    bytes = Data(s.utf8)
-                case .uuid(let u):
-                    let t = u.uuid
-                    bytes = Data([
-                        t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
-                        t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15,
-                    ])
-                case .int32(let v):
-                    var be = v.bigEndian
-                    bytes = Data(bytes: &be, count: 4)
-                case .int64(let v):
-                    var be = v.bigEndian
-                    bytes = Data(bytes: &be, count: 8)
-                case .data(let d):
-                    bytes = d
-                }
-                var length = UInt32(bytes.count).bigEndian
+                var length = UInt32(component.bytes.count).bigEndian
                 result.append(Data(bytes: &length, count: 4))
-                result.append(bytes)
+                result.append(component.bytes)
             }
             self.data = result
         }
@@ -113,12 +94,44 @@ extension CassandraClient {
 
 extension CassandraClient {
     /// A typed key component for use with ``PrimaryKey/init(from:)``.
-    public enum KeyComponent {
-        case string(String)
-        case uuid(Foundation.UUID)
-        case int32(Int32)
-        case int64(Int64)
-        case data(Data)
+    ///
+    /// New component types can be added without breaking existing consumers.
+    public struct KeyComponent: Sendable {
+        /// The serialized bytes for this component.
+        internal let bytes: Data
+
+        public static func string(_ value: String) -> KeyComponent {
+            KeyComponent(bytes: Data(value.utf8))
+        }
+
+        public static func uuid(_ value: Foundation.UUID) -> KeyComponent {
+            let t = value.uuid
+            return KeyComponent(
+                bytes: Data([
+                    t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7,
+                    t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15,
+                ])
+            )
+        }
+
+        public static func int32(_ value: Int32) -> KeyComponent {
+            var be = value.bigEndian
+            return KeyComponent(bytes: Data(bytes: &be, count: 4))
+        }
+
+        public static func int64(_ value: Int64) -> KeyComponent {
+            var be = value.bigEndian
+            return KeyComponent(bytes: Data(bytes: &be, count: 8))
+        }
+
+        public static func data(_ value: Data) -> KeyComponent {
+            KeyComponent(bytes: value)
+        }
+
+        public static func date(_ value: Date) -> KeyComponent {
+            var be = Int64(value.timeIntervalSince1970 * 1000).bigEndian
+            return KeyComponent(bytes: Data(bytes: &be, count: 8))
+        }
     }
 }
 

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -82,6 +82,11 @@ extension CassandraClient {
             case sslIdentityMismatch(String)
             case sslProtocolError(String)
             case sslClosed(String)
+            // encryption errors
+            case encryptionError(String)
+            case decryptionError(String)
+            case encryptionConfigError(String)
+            case keyNotFound(String)
             // catch all
             case other(code: UInt32, description: String?)
         }
@@ -347,6 +352,14 @@ extension CassandraClient {
                 return "Protocol error: \(description)"
             case .sslClosed(let description):
                 return "Connection closed: \(description)"
+            case .encryptionError(let description):
+                return "Encryption error: \(description)"
+            case .decryptionError(let description):
+                return "Decryption error: \(description)"
+            case .encryptionConfigError(let description):
+                return "Encryption configuration error: \(description)"
+            case .keyNotFound(let description):
+                return "Encryption key not found: \(description)"
             case .other(let code, let description):
                 return "Other (\(code)): \(description ?? "unknown")"
             }
@@ -474,6 +487,14 @@ extension CassandraClient {
                 return "Protocol error"
             case .sslClosed:
                 return "Connection closed"
+            case .encryptionError:
+                return "Encryption error"
+            case .decryptionError:
+                return "Decryption error"
+            case .encryptionConfigError:
+                return "Encryption configuration error"
+            case .keyNotFound:
+                return "Encryption key not found"
             case .other(let code, _):
                 return "Other (\(code))"
             }
@@ -718,6 +739,23 @@ extension CassandraClient {
 
         public static func sslClosed(_ description: String) -> Error {
             .init(code: .sslClosed(description))
+        }
+
+        // encryption errors
+        public static func encryptionError(_ description: String) -> Error {
+            .init(code: .encryptionError(description))
+        }
+
+        public static func decryptionError(_ description: String) -> Error {
+            .init(code: .decryptionError(description))
+        }
+
+        public static func encryptionConfigError(_ description: String) -> Error {
+            .init(code: .encryptionConfigError(description))
+        }
+
+        public static func keyNotFound(_ description: String) -> Error {
+            .init(code: .keyNotFound(description))
         }
 
         public static func other(code: UInt32, description: String?) -> Error {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -24,7 +24,7 @@ public protocol CassandraSession {
     var eventLoopGroup: EventLoopGroup { get }
 
     /// Encryptor for transparent column encryption.
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     var encryptor: CassandraClient.Encryptor? { get }
 
     /// Execute a prepared statement.
@@ -129,19 +129,21 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options
     ) throws -> CassandraClient.RowDecoder {
         if let builder = options.encryptionContextBuilder,
-           #available(macOS 15.0, iOS 18.0, *),
-           let encryptor = self.encryptor
+            #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
+            let encryptor = self.encryptor
         {
             let ctx = try builder(row)
             return CassandraClient.RowDecoder(
-                row: row, encryptor: encryptor, rowContext: ctx
+                row: row,
+                encryptor: encryptor,
+                rowContext: ctx
             )
         }
         return CassandraClient.RowDecoder(row: row)
     }
 
     /// Creates a Statement with the session's encryptor injected from Configuration.
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     private func makeStatement(
         query: String,
         parameters: [CassandraClient.Statement.Value],
@@ -219,7 +221,7 @@ extension CassandraSession {
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
             let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, *) {
+            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
                 statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             } else {
                 statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
@@ -244,7 +246,7 @@ extension CassandraSession {
     ) -> EventLoopFuture<CassandraClient.PaginatedRows> {
         do {
             let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, *) {
+            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
                 statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             } else {
                 statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
@@ -264,7 +266,7 @@ extension CassandraClient {
             self.eventLoopGroupContainer.value
         }
 
-        @available(macOS 15.0, iOS 18.0, *)
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: CassandraClient.Encryptor? {
             self.configuration.encryptor
         }
@@ -518,7 +520,7 @@ extension CassandraSession {
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
         let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, *) {
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
             statement = try self.makeStatement(query: query, parameters: parameters, options: options)
         } else {
             statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
@@ -536,7 +538,7 @@ extension CassandraSession {
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
         let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, *) {
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
             statement = try self.makeStatement(query: query, parameters: parameters, options: options)
         } else {
             statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -23,6 +23,10 @@ import NIOCore  // for async-await bridge
 public protocol CassandraSession {
     var eventLoopGroup: EventLoopGroup { get }
 
+    /// Encryptor for transparent column encryption.
+    @available(macOS 11.0, *)
+    var encryptor: CassandraClient.Encryptor? { get }
+
     /// Execute a prepared statement.
     ///
     /// **All** rows are returned.
@@ -120,6 +124,37 @@ extension CassandraSession {
 }
 
 extension CassandraSession {
+    private func makeDecoder(
+        row: CassandraClient.Row,
+        options: CassandraClient.Statement.Options
+    ) throws -> CassandraClient.RowDecoder {
+        if let builder = options.encryptionContextBuilder,
+           #available(macOS 11.0, *),
+           let encryptor = self.encryptor
+        {
+            let ctx = try builder(row)
+            return CassandraClient.RowDecoder(
+                row: row, encryptor: encryptor, rowContext: ctx
+            )
+        }
+        return CassandraClient.RowDecoder(row: row)
+    }
+
+    /// Creates a Statement with the session's encryptor injected from Configuration.
+    @available(macOS 11.0, *)
+    private func makeStatement(
+        query: String,
+        parameters: [CassandraClient.Statement.Value],
+        options: CassandraClient.Statement.Options
+    ) throws -> CassandraClient.Statement {
+        try CassandraClient.Statement(
+            query: query,
+            parameters: parameters,
+            options: options,
+            _encryptor: self.encryptor
+        )
+    }
+
     /// Run insert / update / delete or DDL command where no result is expected.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
@@ -163,7 +198,7 @@ extension CassandraSession {
         self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger)
             .flatMapThrowing { rows in
                 try rows.map { row in
-                    try T(from: CassandraClient.RowDecoder(row: row))
+                    try T(from: self.makeDecoder(row: row, options: options))
                 }
             }
     }
@@ -183,11 +218,12 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
-            let statement = try CassandraClient.Statement(
-                query: query,
-                parameters: parameters,
-                options: options
-            )
+            let statement: CassandraClient.Statement
+            if #available(macOS 11.0, *) {
+                statement = try self.makeStatement(query: query, parameters: parameters, options: options)
+            } else {
+                statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
+            }
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -207,11 +243,12 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.PaginatedRows> {
         do {
-            let statement = try CassandraClient.Statement(
-                query: query,
-                parameters: parameters,
-                options: options
-            )
+            let statement: CassandraClient.Statement
+            if #available(macOS 11.0, *) {
+                statement = try self.makeStatement(query: query, parameters: parameters, options: options)
+            } else {
+                statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
+            }
             return self.execute(statement: statement, pageSize: pageSize, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -225,6 +262,11 @@ extension CassandraClient {
         private let eventLoopGroupContainer: EventLoopGroupContainer
         public var eventLoopGroup: EventLoopGroup {
             self.eventLoopGroupContainer.value
+        }
+
+        @available(macOS 11.0, *)
+        public var encryptor: CassandraClient.Encryptor? {
+            self.configuration.encryptor
         }
 
         private let configuration: Configuration
@@ -459,7 +501,7 @@ extension CassandraSession {
             logger: logger
         )
         return try rows.map { row in
-            try T(from: CassandraClient.RowDecoder(row: row))
+            try T(from: self.makeDecoder(row: row, options: options))
         }
     }
 
@@ -475,7 +517,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
-        let statement = try CassandraClient.Statement(
+        let statement = try self.makeStatement(
             query: query,
             parameters: parameters,
             options: options
@@ -492,7 +534,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
-        let statement = try CassandraClient.Statement(
+        let statement = try self.makeStatement(
             query: query,
             parameters: parameters,
             options: options

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -24,7 +24,7 @@ public protocol CassandraSession {
     var eventLoopGroup: EventLoopGroup { get }
 
     /// Encryptor for transparent column encryption.
-    @available(macOS 11.0, *)
+    @available(macOS 15.0, iOS 18.0, *)
     var encryptor: CassandraClient.Encryptor? { get }
 
     /// Execute a prepared statement.
@@ -129,7 +129,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options
     ) throws -> CassandraClient.RowDecoder {
         if let builder = options.encryptionContextBuilder,
-           #available(macOS 11.0, *),
+           #available(macOS 15.0, iOS 18.0, *),
            let encryptor = self.encryptor
         {
             let ctx = try builder(row)
@@ -141,7 +141,7 @@ extension CassandraSession {
     }
 
     /// Creates a Statement with the session's encryptor injected from Configuration.
-    @available(macOS 11.0, *)
+    @available(macOS 15.0, iOS 18.0, *)
     private func makeStatement(
         query: String,
         parameters: [CassandraClient.Statement.Value],
@@ -219,7 +219,7 @@ extension CassandraSession {
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
             let statement: CassandraClient.Statement
-            if #available(macOS 11.0, *) {
+            if #available(macOS 15.0, iOS 18.0, *) {
                 statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             } else {
                 statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
@@ -244,7 +244,7 @@ extension CassandraSession {
     ) -> EventLoopFuture<CassandraClient.PaginatedRows> {
         do {
             let statement: CassandraClient.Statement
-            if #available(macOS 11.0, *) {
+            if #available(macOS 15.0, iOS 18.0, *) {
                 statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             } else {
                 statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
@@ -264,7 +264,7 @@ extension CassandraClient {
             self.eventLoopGroupContainer.value
         }
 
-        @available(macOS 11.0, *)
+        @available(macOS 15.0, iOS 18.0, *)
         public var encryptor: CassandraClient.Encryptor? {
             self.configuration.encryptor
         }
@@ -517,11 +517,12 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
-        let statement = try self.makeStatement(
-            query: query,
-            parameters: parameters,
-            options: options
-        )
+        let statement: CassandraClient.Statement
+        if #available(macOS 15.0, iOS 18.0, *) {
+            statement = try self.makeStatement(query: query, parameters: parameters, options: options)
+        } else {
+            statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
+        }
         return try await self.execute(statement: statement, logger: logger)
     }
 
@@ -534,11 +535,12 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
-        let statement = try self.makeStatement(
-            query: query,
-            parameters: parameters,
-            options: options
-        )
+        let statement: CassandraClient.Statement
+        if #available(macOS 15.0, iOS 18.0, *) {
+            statement = try self.makeStatement(query: query, parameters: parameters, options: options)
+        } else {
+            statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
+        }
         return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
     }
 }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -24,7 +24,7 @@ extension CassandraClient {
         internal let rawPointer: OpaquePointer
         private let _encryptor: AnyObject?
 
-        @available(macOS 15.0, iOS 18.0, *)
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         private var encryptor: Encryptor? { self._encryptor as? Encryptor }
 
         /// Create a new `Statement`.
@@ -92,33 +92,47 @@ extension CassandraClient {
                     )
                 case .encryptedString(let wrapped, let context):
                     result = try self.bindEncrypted(
-                        Data(wrapped.value.utf8), context: context, at: index
+                        Data(wrapped.value.utf8),
+                        context: context,
+                        at: index
                     )
                 case .encryptedBytes(let wrapped, let context):
                     result = try self.bindEncrypted(
-                        Data(wrapped.value), context: context, at: index
+                        Data(wrapped.value),
+                        context: context,
+                        at: index
                     )
                 case .encryptedInt32(let wrapped, let context):
                     var bigEndian = wrapped.value.bigEndian
                     result = try self.bindEncrypted(
-                        Data(bytes: &bigEndian, count: 4), context: context, at: index
+                        Data(bytes: &bigEndian, count: 4),
+                        context: context,
+                        at: index
                     )
                 case .encryptedInt64(let wrapped, let context):
                     var bigEndian = wrapped.value.bigEndian
                     result = try self.bindEncrypted(
-                        Data(bytes: &bigEndian, count: 8), context: context, at: index
+                        Data(bytes: &bigEndian, count: 8),
+                        context: context,
+                        at: index
                     )
                 case .encryptedDouble(let wrapped, let context):
                     var bits = wrapped.value.bitPattern.bigEndian
                     result = try self.bindEncrypted(
-                        Data(bytes: &bits, count: 8), context: context, at: index
+                        Data(bytes: &bits, count: 8),
+                        context: context,
+                        at: index
                     )
                 case .encryptedUUID(let wrapped, let context):
                     let u = wrapped.value.uuid
-                    let plaintext = Data([u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
-                                          u.8, u.9, u.10, u.11, u.12, u.13, u.14, u.15])
+                    let plaintext = Data([
+                        u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
+                        u.8, u.9, u.10, u.11, u.12, u.13, u.14, u.15,
+                    ])
                     result = try self.bindEncrypted(
-                        plaintext, context: context, at: index
+                        plaintext,
+                        context: context,
+                        at: index
                     )
                 case .int8Array(let array):
                     result = try self.bindArray(array, at: index)
@@ -160,7 +174,7 @@ extension CassandraClient {
             context: EncryptionContext,
             at index: Int
         ) throws -> CassError {
-            guard #available(macOS 15.0, iOS 18.0, *) else {
+            guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
                 throw CassandraClient.Error.encryptionError("Encryption requires macOS 15.0+")
             }
             guard let encryptor = self.encryptor else {
@@ -355,7 +369,10 @@ extension CassandraClient {
             public var requestTimeout: UInt64?
 
             /// Closure that extracts encryption context from each row during Codable decoding.
-            public var encryptionContextBuilder: ((CassandraClient.Row) throws -> CassandraClient.RowEncryptionContext)?
+            public var encryptionContextBuilder:
+                (
+                    (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
+                )?
 
             public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {
                 self.consistency = consistency

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -22,12 +22,22 @@ extension CassandraClient {
         internal let parameters: [Value]
         internal let options: Options
         internal let rawPointer: OpaquePointer
+        private let _encryptor: AnyObject?
+
+        @available(macOS 11.0, *)
+        private var encryptor: Encryptor? { self._encryptor as? Encryptor }
 
         /// Create a new `Statement`.
-        public init(query: String, parameters: [Value] = [], options: Options = .init()) throws {
+        public convenience init(query: String, parameters: [Value] = [], options: Options = .init()) throws {
+            try self.init(query: query, parameters: parameters, options: options, _encryptor: nil)
+        }
+
+        /// Internal init that accepts an encryptor injected by Session from Configuration.
+        internal init(query: String, parameters: [Value], options: Options, _encryptor: AnyObject?) throws {
             self.query = query
             self.parameters = parameters
             self.options = options
+            self._encryptor = _encryptor
             self.rawPointer = cass_statement_new(query, parameters.count)
 
             for (index, parameter) in parameters.enumerated() {
@@ -80,6 +90,36 @@ extension CassandraClient {
                         buffer.baseAddress,
                         buffer.count
                     )
+                case .encryptedString(let wrapped, let context):
+                    result = try self.bindEncrypted(
+                        Data(wrapped.value.utf8), context: context, at: index
+                    )
+                case .encryptedBytes(let wrapped, let context):
+                    result = try self.bindEncrypted(
+                        Data(wrapped.value), context: context, at: index
+                    )
+                case .encryptedInt32(let wrapped, let context):
+                    var bigEndian = wrapped.value.bigEndian
+                    result = try self.bindEncrypted(
+                        Data(bytes: &bigEndian, count: 4), context: context, at: index
+                    )
+                case .encryptedInt64(let wrapped, let context):
+                    var bigEndian = wrapped.value.bigEndian
+                    result = try self.bindEncrypted(
+                        Data(bytes: &bigEndian, count: 8), context: context, at: index
+                    )
+                case .encryptedDouble(let wrapped, let context):
+                    var bits = wrapped.value.bitPattern.bigEndian
+                    result = try self.bindEncrypted(
+                        Data(bytes: &bits, count: 8), context: context, at: index
+                    )
+                case .encryptedUUID(let wrapped, let context):
+                    let u = wrapped.value.uuid
+                    let plaintext = Data([u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
+                                          u.8, u.9, u.10, u.11, u.12, u.13, u.14, u.15])
+                    result = try self.bindEncrypted(
+                        plaintext, context: context, at: index
+                    )
                 case .int8Array(let array):
                     result = try self.bindArray(array, at: index)
                 case .int16Array(let array):
@@ -111,6 +151,28 @@ extension CassandraClient {
 
             if let requestTimeout = options.requestTimeout {
                 try checkResult { cass_statement_set_request_timeout(self.rawPointer, requestTimeout) }
+            }
+        }
+
+        /// Encrypt plaintext and bind the result as bytes at the given parameter index.
+        private func bindEncrypted(
+            _ plaintext: Data,
+            context: EncryptionContext,
+            at index: Int
+        ) throws -> CassError {
+            guard #available(macOS 11.0, *) else {
+                throw CassandraClient.Error.encryptionError("Encryption requires macOS 11.0+")
+            }
+            guard let encryptor = self.encryptor else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Encryptor required but not set in Configuration"
+                )
+            }
+            let encrypted = try encryptor.encrypt(plaintext, context: context)
+            let this = self
+            return encrypted.withUnsafeBytes { buffer in
+                let typed = buffer.bindMemory(to: UInt8.self)
+                return cass_statement_bind_bytes(this.rawPointer, index, typed.baseAddress, typed.count)
             }
         }
 
@@ -200,6 +262,13 @@ extension CassandraClient {
             case bytes([UInt8])
             case bytesUnsafe(UnsafeBufferPointer<UInt8>)
 
+            case encryptedString(Encrypted<String>, context: EncryptionContext)
+            case encryptedBytes(Encrypted<[UInt8]>, context: EncryptionContext)
+            case encryptedInt32(Encrypted<Int32>, context: EncryptionContext)
+            case encryptedInt64(Encrypted<Int64>, context: EncryptionContext)
+            case encryptedDouble(Encrypted<Double>, context: EncryptionContext)
+            case encryptedUUID(Encrypted<Foundation.UUID>, context: EncryptionContext)
+
             case int8Array([Int8])
             case int16Array([Int16])
             case int32Array([Int32])
@@ -284,6 +353,9 @@ extension CassandraClient {
             public var consistency: CassandraClient.Consistency?
             /// Sets the statement's request timeout in milliseconds. Default is `CASS_UINT64_MAX`
             public var requestTimeout: UInt64?
+
+            /// Closure that extracts encryption context from each row during Codable decoding.
+            public var encryptionContextBuilder: ((CassandraClient.Row) throws -> CassandraClient.RowEncryptionContext)?
 
             public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {
                 self.consistency = consistency

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -24,7 +24,7 @@ extension CassandraClient {
         internal let rawPointer: OpaquePointer
         private let _encryptor: AnyObject?
 
-        @available(macOS 11.0, *)
+        @available(macOS 15.0, iOS 18.0, *)
         private var encryptor: Encryptor? { self._encryptor as? Encryptor }
 
         /// Create a new `Statement`.
@@ -160,8 +160,8 @@ extension CassandraClient {
             context: EncryptionContext,
             at index: Int
         ) throws -> CassError {
-            guard #available(macOS 11.0, *) else {
-                throw CassandraClient.Error.encryptionError("Encryption requires macOS 11.0+")
+            guard #available(macOS 15.0, iOS 18.0, *) else {
+                throw CassandraClient.Error.encryptionError("Encryption requires macOS 15.0+")
             }
             guard let encryptor = self.encryptor else {
                 throw CassandraClient.Error.encryptionConfigError(

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -94,7 +94,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: self.configuration.keyspace!,
             table: tableName,
             column: "secret",
-            primaryKey: Data(userId.utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
         )
 
         let options = CassandraClient.Statement.Options()
@@ -152,7 +152,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         let baseContext = CassandraClient.EncryptionContext.Base(
             keyspace: keyspace,
             table: tableName,
-            primaryKey: Data(userId.utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
         )
 
         let options = CassandraClient.Statement.Options()
@@ -241,7 +241,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: keyspace,
             table: tableName,
             column: "secret",
-            primaryKey: Data(userId.utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
         )
 
         // Step 1: Write with key-1 (the encryptor from setUp uses "test-key")
@@ -330,7 +330,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: keyspace,
             table: tableName,
             column: "secret",
-            primaryKey: Data("user-null".utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("user-null"))
         )
 
         let decrypted = try row.column("secret")?.decryptedString(
@@ -358,7 +358,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: self.configuration.keyspace!,
             table: tableName,
             column: "secret",
-            primaryKey: Data(userId.utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
         )
 
         let writeOptions = CassandraClient.Statement.Options()
@@ -381,7 +381,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: self.configuration.keyspace!,
                 table: tableName,
-                primaryKey: Data(uid.utf8)
+                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(uid))
             )
         }
 
@@ -423,7 +423,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: keyspace,
                 table: tableName,
-                primaryKey: Data(uid.utf8)
+                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(uid))
             )
         }
 
@@ -432,7 +432,7 @@ final class EncryptionIntegrationTests: XCTestCase {
                 keyspace: keyspace,
                 table: tableName,
                 column: "secret",
-                primaryKey: Data(userId.utf8)
+                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
             )
             try session.run(
                 "insert into \(tableName) (user_id, secret) values (?, ?)",
@@ -477,7 +477,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         let userId = "user-multi-col"
         let name = "Alice"
         let age: Int32 = 30
-        let primaryKeyData = Data(userId.utf8)
+        let primaryKeyData = CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
 
         let baseContext = CassandraClient.EncryptionContext.Base(
             keyspace: keyspace,
@@ -494,7 +494,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: keyspace,
                 table: tableName,
-                primaryKey: Data(uid.utf8)
+                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(uid))
             )
         }
 

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -49,7 +49,8 @@ final class EncryptionIntegrationTests: XCTestCase {
         XCTAssertNoThrow(
             self.encryptor = try CassandraClient.Encryptor(
                 keyMap: [keyName: keyData],
-                currentKeyName: keyName
+                currentKeyName: keyName,
+                salt: Data("integration-test-salt".utf8)
             )
         )
 

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -1,0 +1,475 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+@available(macOS 11.0, *)
+final class EncryptionIntegrationTests: XCTestCase {
+    var cassandraClient: CassandraClient!
+    var configuration: CassandraClient.Configuration!
+    var encryptor: CassandraClient.Encryptor!
+
+    private let keyName = "test-key"
+    private lazy var keyData: Data = randomKey()
+
+    override func setUp() {
+        super.setUp()
+
+        let env = ProcessInfo.processInfo.environment
+        let keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        self.configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        self.configuration.username = env["CASSANDRA_USER"]
+        self.configuration.password = env["CASSANDRA_PASSWORD"]
+        self.configuration.keyspace = keyspace
+        self.configuration.requestTimeoutMillis = UInt32(24_000)
+        self.configuration.connectTimeoutMillis = UInt32(10_000)
+
+        XCTAssertNoThrow(
+            self.encryptor = try CassandraClient.Encryptor(
+                keyMap: [keyName: keyData],
+                currentKeyName: keyName
+            )
+        )
+
+        self.configuration.encryptor = self.encryptor
+
+        var logger = Logger(label: "test")
+        logger.logLevel = .debug
+
+        self.cassandraClient = CassandraClient(configuration: self.configuration, logger: logger)
+        XCTAssertNoThrow(
+            try self.cassandraClient.withSession(keyspace: .none) { session in
+                try session
+                    .run(
+                        "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+                    )
+                    .wait()
+            }
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        XCTAssertNoThrow(try self.cassandraClient.shutdown())
+        self.cassandraClient = nil
+    }
+
+    // MARK: - Write path + manual read path
+
+    /// Insert an encrypted string via Statement, read it back using Column.decryptedString.
+    func testWriteAndManualRead() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_\(DispatchTime.now().uptimeNanoseconds)"
+
+        try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+
+        let userId = "user-1"
+        let secretValue = "my-ssn-number"
+
+        let context = CassandraClient.EncryptionContext(
+            keyspace: self.configuration.keyspace!,
+            table: tableName,
+            column: "secret",
+            primaryKey: Data(userId.utf8)
+        )
+
+        let options = CassandraClient.Statement.Options()
+
+        try session.run(
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: context),
+            ],
+            options: options
+        ).wait()
+
+        // Read back using manual decryption
+        let rows = try session.query("select * from \(tableName) where user_id = ?", parameters: [.string(userId)]).wait()
+        let rowArray = Array(rows)
+        XCTAssertEqual(rowArray.count, 1)
+
+        let row = rowArray[0]
+
+        let rawBytes: [UInt8]? = row.column("secret")
+        XCTAssertNotNil(rawBytes)
+        XCTAssertNotEqual(rawBytes.map { Data($0) }, Data(secretValue.utf8))
+
+        let decrypted = try row.column("secret")?.decryptedString(
+            encryptor: self.encryptor,
+            context: context
+        )
+        XCTAssertEqual(decrypted, secretValue)
+    }
+
+    // MARK: - All types
+
+    /// Write and read back all encrypted types: String, Int32, Int64, Double, UUID, [UInt8].
+    func testAllEncryptedTypes() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_all_\(DispatchTime.now().uptimeNanoseconds)"
+
+        try session.run(
+            "create table \(tableName) (user_id text primary key, enc_name blob, enc_age blob, enc_count blob, enc_score blob, enc_id blob, enc_data blob)"
+        ).wait()
+
+        let userId = "user-all"
+        let name = "Alice"
+        let age: Int32 = 30
+        let count: Int64 = 9_876_543_210
+        let score: Double = 99.5
+        let id = Foundation.UUID()
+        let data: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF]
+        let keyspace = self.configuration.keyspace!
+
+        let baseContext = CassandraClient.EncryptionContext(
+            keyspace: keyspace, table: tableName, column: "enc_name", primaryKey: Data(userId.utf8)
+        )
+
+        let options = CassandraClient.Statement.Options()
+
+        try session.run(
+            "insert into \(tableName) (user_id, enc_name, enc_age, enc_count, enc_score, enc_id, enc_data) values (?, ?, ?, ?, ?, ?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(name), context: baseContext),
+                .encryptedInt32(CassandraClient.Encrypted(age), context: baseContext.withColumn("enc_age")),
+                .encryptedInt64(CassandraClient.Encrypted(count), context: baseContext.withColumn("enc_count")),
+                .encryptedDouble(CassandraClient.Encrypted(score), context: baseContext.withColumn("enc_score")),
+                .encryptedUUID(CassandraClient.Encrypted(id), context: baseContext.withColumn("enc_id")),
+                .encryptedBytes(CassandraClient.Encrypted(data), context: baseContext.withColumn("enc_data")),
+            ],
+            options: options
+        ).wait()
+
+        // Read back manually
+        let rows = try session.query(
+            "select * from \(tableName) where user_id = ?",
+            parameters: [.string(userId)]
+        ).wait()
+        let row = Array(rows)[0]
+
+        XCTAssertEqual(try row.column("enc_name")?.decryptedString(encryptor: self.encryptor, context: baseContext), name)
+        XCTAssertEqual(try row.column("enc_age")?.decryptedInt32(encryptor: self.encryptor, context: baseContext.withColumn("enc_age")), age)
+        XCTAssertEqual(try row.column("enc_count")?.decryptedInt64(encryptor: self.encryptor, context: baseContext.withColumn("enc_count")), count)
+        XCTAssertEqual(try row.column("enc_score")?.decryptedDouble(encryptor: self.encryptor, context: baseContext.withColumn("enc_score")), score)
+        XCTAssertEqual(try row.column("enc_id")?.decryptedUUID(encryptor: self.encryptor, context: baseContext.withColumn("enc_id")), id)
+        XCTAssertEqual(try row.column("enc_data")?.decryptedBytes(encryptor: self.encryptor, context: baseContext.withColumn("enc_data")), data)
+    }
+
+    // MARK: - Key rotation + re-encryption
+
+    /// Full lifecycle: write with key-1, rotate to key-2, old data still reads,
+    /// re-encrypt old data with key-2, verify it now uses key-2.
+    func testKeyRotationAndReEncryption() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_rotate_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+
+        let userId = "user-rotate"
+        let secretValue = "rotate-me"
+        let context = CassandraClient.EncryptionContext(
+            keyspace: keyspace, table: tableName, column: "secret", primaryKey: Data(userId.utf8)
+        )
+
+        // Step 1: Write with key-1 (the encryptor from setUp uses "test-key")
+        let options = CassandraClient.Statement.Options()
+
+        try session.run(
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: context),
+            ],
+            options: options
+        ).wait()
+
+        // Step 2: Rotate — add key-2, switch to it
+        try self.encryptor.addKey(name: "key-2", secret: randomKey())
+        try self.encryptor.setCurrentKeyName("key-2")
+
+        // Step 3: Old data still decrypts (key-1 is still in the map)
+        let rows = try session.query(
+            "select * from \(tableName) where user_id = ?",
+            parameters: [.string(userId)]
+        ).wait()
+        let row = Array(rows)[0]
+        let decrypted = try row.column("secret")?.decryptedString(
+            encryptor: self.encryptor, context: context
+        )
+        XCTAssertEqual(decrypted, secretValue)
+
+        // Step 4: Re-encrypt with key-2 (read plaintext, write back encrypted with new key)
+        try session.run(
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: context),
+            ],
+            options: options
+        ).wait()
+
+        // Step 5: Verify re-encrypted data still decrypts
+        let rows2 = try session.query(
+            "select * from \(tableName) where user_id = ?",
+            parameters: [.string(userId)]
+        ).wait()
+        let row2 = Array(rows2)[0]
+        let decrypted2 = try row2.column("secret")?.decryptedString(
+            encryptor: self.encryptor, context: context
+        )
+        XCTAssertEqual(decrypted2, secretValue)
+
+        // Step 6: Verify the envelope now contains "key-2"
+        let rawBytes: [UInt8]? = row2.column("secret")
+        let envelope = Data(rawBytes!)
+        // Envelope format: [version:1][algorithm:1][key-name-len:1][key-name:N]...
+        let keyNameLen = Int(envelope[2])
+        let keyName = String(data: envelope[3 ..< 3 + keyNameLen], encoding: .utf8)
+        XCTAssertEqual(keyName, "key-2")
+    }
+
+    // MARK: - Null encrypted column
+
+    /// A null encrypted column should return nil, not crash.
+    func testNullEncryptedColumn() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_null_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+
+        try session.run(
+            "insert into \(tableName) (user_id) values (?)",
+            parameters: [.string("user-null")]
+        ).wait()
+
+        let rows = try session.query(
+            "select * from \(tableName) where user_id = ?",
+            parameters: [.string("user-null")]
+        ).wait()
+        let row = Array(rows)[0]
+
+        let context = CassandraClient.EncryptionContext(
+            keyspace: keyspace, table: tableName, column: "secret", primaryKey: Data("user-null".utf8)
+        )
+
+        let decrypted = try row.column("secret")?.decryptedString(
+            encryptor: self.encryptor, context: context
+        )
+        XCTAssertNil(decrypted)
+    }
+
+    // MARK: - Codable read path
+
+    /// Insert encrypted data, read it back using the Codable path with Encrypted<String>.
+    func testCodableDecrypt() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_codable_\(DispatchTime.now().uptimeNanoseconds)"
+
+        try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+
+        let userId = "user-codable"
+        let secretValue = "codable-secret-value"
+
+        let writeContext = CassandraClient.EncryptionContext(
+            keyspace: self.configuration.keyspace!,
+            table: tableName,
+            column: "secret",
+            primaryKey: Data(userId.utf8)
+        )
+
+        let writeOptions = CassandraClient.Statement.Options()
+
+        try session.run(
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: writeContext),
+            ],
+            options: writeOptions
+        ).wait()
+
+        // Read back using Codable path
+        var readOptions = CassandraClient.Statement.Options()
+        readOptions.encryptionContextBuilder = { row in
+            guard let uid: String = row.column("user_id") else {
+                throw CassandraClient.Error.badParams("user_id not found in row")
+            }
+            return CassandraClient.RowEncryptionContext(
+                keyspace: self.configuration.keyspace!,
+                table: tableName,
+                primaryKey: Data(uid.utf8)
+            )
+        }
+
+        let results: [UserWithSecret] = try session.query(
+            "select user_id, secret from \(tableName) where user_id = ?",
+            parameters: [.string(userId)],
+            options: readOptions
+        ).wait()
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].user_id, userId)
+        XCTAssertEqual(results[0].secret.value, secretValue)
+    }
+
+    // MARK: - Multiple rows with Codable
+
+    /// Insert 3 rows, read all back via Codable, verify each decrypts with its own primaryKey.
+    func testCodableMultipleRows() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_multi_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+
+        let users = [
+            ("alice", "alice-secret"),
+            ("bob", "bob-secret"),
+            ("charlie", "charlie-secret"),
+        ]
+
+        var options = CassandraClient.Statement.Options()
+
+        options.encryptionContextBuilder = { row in
+            guard let uid: String = row.column("user_id") else {
+                throw CassandraClient.Error.badParams("user_id not found in row")
+            }
+            return CassandraClient.RowEncryptionContext(keyspace: keyspace, table: tableName, primaryKey: Data(uid.utf8))
+        }
+
+        for (userId, secretValue) in users {
+            let context = CassandraClient.EncryptionContext(
+                keyspace: keyspace, table: tableName, column: "secret", primaryKey: Data(userId.utf8)
+            )
+            try session.run(
+                "insert into \(tableName) (user_id, secret) values (?, ?)",
+                parameters: [
+                    .string(userId),
+                    .encryptedString(CassandraClient.Encrypted(secretValue), context: context),
+                ],
+                options: options
+            ).wait()
+        }
+
+        // Read all back via Codable
+        let results: [UserWithSecret] = try session.query(
+            "select user_id, secret from \(tableName)",
+            options: options
+        ).wait()
+
+        XCTAssertEqual(results.count, 3)
+
+        // Sort by user_id since Cassandra doesn't guarantee order
+        let sorted = results.sorted { $0.user_id < $1.user_id }
+        for (i, (expectedId, expectedSecret)) in users.sorted(by: { $0.0 < $1.0 }).enumerated() {
+            XCTAssertEqual(sorted[i].user_id, expectedId)
+            XCTAssertEqual(sorted[i].secret.value, expectedSecret)
+        }
+    }
+
+    // MARK: - Codable with multiple encrypted columns
+
+    /// Struct with two Encrypted fields of different types, decoded via Codable.
+    func testCodableMultipleEncryptedColumns() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_multi_col_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        try session.run(
+            "create table \(tableName) (user_id text primary key, secret_name blob, secret_age blob)"
+        ).wait()
+
+        let userId = "user-multi-col"
+        let name = "Alice"
+        let age: Int32 = 30
+        let primaryKeyData = Data(userId.utf8)
+
+        let baseContext = CassandraClient.EncryptionContext(
+            keyspace: keyspace, table: tableName, column: "secret_name", primaryKey: primaryKeyData
+        )
+
+        var options = CassandraClient.Statement.Options()
+
+        options.encryptionContextBuilder = { row in
+            guard let uid: String = row.column("user_id") else {
+                throw CassandraClient.Error.badParams("user_id not found in row")
+            }
+            return CassandraClient.RowEncryptionContext(keyspace: keyspace, table: tableName, primaryKey: Data(uid.utf8))
+        }
+
+        try session.run(
+            "insert into \(tableName) (user_id, secret_name, secret_age) values (?, ?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(name), context: baseContext),
+                .encryptedInt32(CassandraClient.Encrypted(age), context: baseContext.withColumn("secret_age")),
+            ],
+            options: options
+        ).wait()
+
+        // Read back via Codable
+        let results: [UserWithMultipleSecrets] = try session.query(
+            "select user_id, secret_name, secret_age from \(tableName) where user_id = ?",
+            parameters: [.string(userId)],
+            options: options
+        ).wait()
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].user_id, userId)
+        XCTAssertEqual(results[0].secret_name.value, name)
+        XCTAssertEqual(results[0].secret_age.value, age)
+    }
+}
+
+// MARK: - Test model
+
+struct UserWithSecret: Decodable {
+    let user_id: String
+    let secret: CassandraClient.Encrypted<String>
+}
+
+struct UserWithMultipleSecrets: Decodable {
+    let user_id: String
+    let secret_name: CassandraClient.Encrypted<String>
+    let secret_age: CassandraClient.Encrypted<Int32>
+}

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -95,7 +95,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: self.configuration.keyspace!,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
+            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
         )
 
         let options = CassandraClient.Statement.Options()
@@ -153,7 +153,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         let baseContext = CassandraClient.EncryptionContext.Base(
             keyspace: keyspace,
             table: tableName,
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
+            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
         )
 
         let options = CassandraClient.Statement.Options()
@@ -242,7 +242,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: keyspace,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
+            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
         )
 
         // Step 1: Write with key-1 (the encryptor from setUp uses "test-key")
@@ -331,7 +331,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: keyspace,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("user-null"))
+            primaryKey: CassandraClient.PrimaryKey(from: .string("user-null"))
         )
 
         let decrypted = try row.column("secret")?.decryptedString(
@@ -359,7 +359,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: self.configuration.keyspace!,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
+            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
         )
 
         let writeOptions = CassandraClient.Statement.Options()
@@ -382,7 +382,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: self.configuration.keyspace!,
                 table: tableName,
-                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(uid))
+                primaryKey: CassandraClient.PrimaryKey(from: .string(uid))
             )
         }
 
@@ -424,7 +424,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: keyspace,
                 table: tableName,
-                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(uid))
+                primaryKey: CassandraClient.PrimaryKey(from: .string(uid))
             )
         }
 
@@ -433,7 +433,7 @@ final class EncryptionIntegrationTests: XCTestCase {
                 keyspace: keyspace,
                 table: tableName,
                 column: "secret",
-                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
+                primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
             )
             try session.run(
                 "insert into \(tableName) (user_id, secret) values (?, ?)",
@@ -478,7 +478,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         let userId = "user-multi-col"
         let name = "Alice"
         let age: Int32 = 30
-        let primaryKeyData = CassandraClient.EncryptionContext.encodeKeyComponents(.string(userId))
+        let primaryKeyData = CassandraClient.PrimaryKey(from: .string(userId))
 
         let baseContext = CassandraClient.EncryptionContext.Base(
             keyspace: keyspace,
@@ -495,7 +495,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: keyspace,
                 table: tableName,
-                primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string(uid))
+                primaryKey: CassandraClient.PrimaryKey(from: .string(uid))
             )
         }
 

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -95,7 +95,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: self.configuration.keyspace!,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
+            primaryKey: .init(from: .string(userId))
         )
 
         let options = CassandraClient.Statement.Options()
@@ -153,7 +153,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         let baseContext = CassandraClient.EncryptionContext.Base(
             keyspace: keyspace,
             table: tableName,
-            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
+            primaryKey: .init(from: .string(userId))
         )
 
         let options = CassandraClient.Statement.Options()
@@ -242,7 +242,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: keyspace,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
+            primaryKey: .init(from: .string(userId))
         )
 
         // Step 1: Write with key-1 (the encryptor from setUp uses "test-key")
@@ -331,7 +331,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: keyspace,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.PrimaryKey(from: .string("user-null"))
+            primaryKey: .init(from: .string("user-null"))
         )
 
         let decrypted = try row.column("secret")?.decryptedString(
@@ -359,7 +359,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             keyspace: self.configuration.keyspace!,
             table: tableName,
             column: "secret",
-            primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
+            primaryKey: .init(from: .string(userId))
         )
 
         let writeOptions = CassandraClient.Statement.Options()
@@ -382,7 +382,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: self.configuration.keyspace!,
                 table: tableName,
-                primaryKey: CassandraClient.PrimaryKey(from: .string(uid))
+                primaryKey: .init(from: .string(uid))
             )
         }
 
@@ -424,7 +424,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: keyspace,
                 table: tableName,
-                primaryKey: CassandraClient.PrimaryKey(from: .string(uid))
+                primaryKey: .init(from: .string(uid))
             )
         }
 
@@ -433,7 +433,7 @@ final class EncryptionIntegrationTests: XCTestCase {
                 keyspace: keyspace,
                 table: tableName,
                 column: "secret",
-                primaryKey: CassandraClient.PrimaryKey(from: .string(userId))
+                primaryKey: .init(from: .string(userId))
             )
             try session.run(
                 "insert into \(tableName) (user_id, secret) values (?, ?)",
@@ -495,7 +495,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             return CassandraClient.EncryptionContext.Base(
                 keyspace: keyspace,
                 table: tableName,
-                primaryKey: CassandraClient.PrimaryKey(from: .string(uid))
+                primaryKey: .init(from: .string(uid))
             )
         }
 

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import CassandraClient
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 final class EncryptionIntegrationTests: XCTestCase {
     var cassandraClient: CassandraClient!
     var configuration: CassandraClient.Configuration!
@@ -109,7 +109,8 @@ final class EncryptionIntegrationTests: XCTestCase {
         ).wait()
 
         // Read back using manual decryption
-        let rows = try session.query("select * from \(tableName) where user_id = ?", parameters: [.string(userId)]).wait()
+        let rows = try session.query("select * from \(tableName) where user_id = ?", parameters: [.string(userId)])
+            .wait()
         let rowArray = Array(rows)
         XCTAssertEqual(rowArray.count, 1)
 
@@ -148,8 +149,10 @@ final class EncryptionIntegrationTests: XCTestCase {
         let data: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF]
         let keyspace = self.configuration.keyspace!
 
-        let baseContext = CassandraClient.EncryptionContext(
-            keyspace: keyspace, table: tableName, column: "enc_name", primaryKey: Data(userId.utf8)
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: Data(userId.utf8)
         )
 
         let options = CassandraClient.Statement.Options()
@@ -158,12 +161,12 @@ final class EncryptionIntegrationTests: XCTestCase {
             "insert into \(tableName) (user_id, enc_name, enc_age, enc_count, enc_score, enc_id, enc_data) values (?, ?, ?, ?, ?, ?, ?)",
             parameters: [
                 .string(userId),
-                .encryptedString(CassandraClient.Encrypted(name), context: baseContext),
-                .encryptedInt32(CassandraClient.Encrypted(age), context: baseContext.withColumn("enc_age")),
-                .encryptedInt64(CassandraClient.Encrypted(count), context: baseContext.withColumn("enc_count")),
-                .encryptedDouble(CassandraClient.Encrypted(score), context: baseContext.withColumn("enc_score")),
-                .encryptedUUID(CassandraClient.Encrypted(id), context: baseContext.withColumn("enc_id")),
-                .encryptedBytes(CassandraClient.Encrypted(data), context: baseContext.withColumn("enc_data")),
+                .encryptedString(CassandraClient.Encrypted(name), context: baseContext.forColumn("enc_name")),
+                .encryptedInt32(CassandraClient.Encrypted(age), context: baseContext.forColumn("enc_age")),
+                .encryptedInt64(CassandraClient.Encrypted(count), context: baseContext.forColumn("enc_count")),
+                .encryptedDouble(CassandraClient.Encrypted(score), context: baseContext.forColumn("enc_score")),
+                .encryptedUUID(CassandraClient.Encrypted(id), context: baseContext.forColumn("enc_id")),
+                .encryptedBytes(CassandraClient.Encrypted(data), context: baseContext.forColumn("enc_data")),
             ],
             options: options
         ).wait()
@@ -175,12 +178,48 @@ final class EncryptionIntegrationTests: XCTestCase {
         ).wait()
         let row = Array(rows)[0]
 
-        XCTAssertEqual(try row.column("enc_name")?.decryptedString(encryptor: self.encryptor, context: baseContext), name)
-        XCTAssertEqual(try row.column("enc_age")?.decryptedInt32(encryptor: self.encryptor, context: baseContext.withColumn("enc_age")), age)
-        XCTAssertEqual(try row.column("enc_count")?.decryptedInt64(encryptor: self.encryptor, context: baseContext.withColumn("enc_count")), count)
-        XCTAssertEqual(try row.column("enc_score")?.decryptedDouble(encryptor: self.encryptor, context: baseContext.withColumn("enc_score")), score)
-        XCTAssertEqual(try row.column("enc_id")?.decryptedUUID(encryptor: self.encryptor, context: baseContext.withColumn("enc_id")), id)
-        XCTAssertEqual(try row.column("enc_data")?.decryptedBytes(encryptor: self.encryptor, context: baseContext.withColumn("enc_data")), data)
+        XCTAssertEqual(
+            try row.column("enc_name")?.decryptedString(
+                encryptor: self.encryptor,
+                context: baseContext.forColumn("enc_name")
+            ),
+            name
+        )
+        XCTAssertEqual(
+            try row.column("enc_age")?.decryptedInt32(
+                encryptor: self.encryptor,
+                context: baseContext.forColumn("enc_age")
+            ),
+            age
+        )
+        XCTAssertEqual(
+            try row.column("enc_count")?.decryptedInt64(
+                encryptor: self.encryptor,
+                context: baseContext.forColumn("enc_count")
+            ),
+            count
+        )
+        XCTAssertEqual(
+            try row.column("enc_score")?.decryptedDouble(
+                encryptor: self.encryptor,
+                context: baseContext.forColumn("enc_score")
+            ),
+            score
+        )
+        XCTAssertEqual(
+            try row.column("enc_id")?.decryptedUUID(
+                encryptor: self.encryptor,
+                context: baseContext.forColumn("enc_id")
+            ),
+            id
+        )
+        XCTAssertEqual(
+            try row.column("enc_data")?.decryptedBytes(
+                encryptor: self.encryptor,
+                context: baseContext.forColumn("enc_data")
+            ),
+            data
+        )
     }
 
     // MARK: - Key rotation + re-encryption
@@ -199,7 +238,10 @@ final class EncryptionIntegrationTests: XCTestCase {
         let userId = "user-rotate"
         let secretValue = "rotate-me"
         let context = CassandraClient.EncryptionContext(
-            keyspace: keyspace, table: tableName, column: "secret", primaryKey: Data(userId.utf8)
+            keyspace: keyspace,
+            table: tableName,
+            column: "secret",
+            primaryKey: Data(userId.utf8)
         )
 
         // Step 1: Write with key-1 (the encryptor from setUp uses "test-key")
@@ -225,7 +267,8 @@ final class EncryptionIntegrationTests: XCTestCase {
         ).wait()
         let row = Array(rows)[0]
         let decrypted = try row.column("secret")?.decryptedString(
-            encryptor: self.encryptor, context: context
+            encryptor: self.encryptor,
+            context: context
         )
         XCTAssertEqual(decrypted, secretValue)
 
@@ -246,7 +289,8 @@ final class EncryptionIntegrationTests: XCTestCase {
         ).wait()
         let row2 = Array(rows2)[0]
         let decrypted2 = try row2.column("secret")?.decryptedString(
-            encryptor: self.encryptor, context: context
+            encryptor: self.encryptor,
+            context: context
         )
         XCTAssertEqual(decrypted2, secretValue)
 
@@ -255,7 +299,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         let envelope = Data(rawBytes!)
         // Envelope format: [version:1][algorithm:1][key-name-len:1][key-name:N]...
         let keyNameLen = Int(envelope[2])
-        let keyName = String(data: envelope[3 ..< 3 + keyNameLen], encoding: .utf8)
+        let keyName = String(data: envelope[3..<3 + keyNameLen], encoding: .utf8)
         XCTAssertEqual(keyName, "key-2")
     }
 
@@ -283,11 +327,15 @@ final class EncryptionIntegrationTests: XCTestCase {
         let row = Array(rows)[0]
 
         let context = CassandraClient.EncryptionContext(
-            keyspace: keyspace, table: tableName, column: "secret", primaryKey: Data("user-null".utf8)
+            keyspace: keyspace,
+            table: tableName,
+            column: "secret",
+            primaryKey: Data("user-null".utf8)
         )
 
         let decrypted = try row.column("secret")?.decryptedString(
-            encryptor: self.encryptor, context: context
+            encryptor: self.encryptor,
+            context: context
         )
         XCTAssertNil(decrypted)
     }
@@ -330,7 +378,7 @@ final class EncryptionIntegrationTests: XCTestCase {
             guard let uid: String = row.column("user_id") else {
                 throw CassandraClient.Error.badParams("user_id not found in row")
             }
-            return CassandraClient.RowEncryptionContext(
+            return CassandraClient.EncryptionContext.Base(
                 keyspace: self.configuration.keyspace!,
                 table: tableName,
                 primaryKey: Data(uid.utf8)
@@ -372,12 +420,19 @@ final class EncryptionIntegrationTests: XCTestCase {
             guard let uid: String = row.column("user_id") else {
                 throw CassandraClient.Error.badParams("user_id not found in row")
             }
-            return CassandraClient.RowEncryptionContext(keyspace: keyspace, table: tableName, primaryKey: Data(uid.utf8))
+            return CassandraClient.EncryptionContext.Base(
+                keyspace: keyspace,
+                table: tableName,
+                primaryKey: Data(uid.utf8)
+            )
         }
 
         for (userId, secretValue) in users {
             let context = CassandraClient.EncryptionContext(
-                keyspace: keyspace, table: tableName, column: "secret", primaryKey: Data(userId.utf8)
+                keyspace: keyspace,
+                table: tableName,
+                column: "secret",
+                primaryKey: Data(userId.utf8)
             )
             try session.run(
                 "insert into \(tableName) (user_id, secret) values (?, ?)",
@@ -424,8 +479,10 @@ final class EncryptionIntegrationTests: XCTestCase {
         let age: Int32 = 30
         let primaryKeyData = Data(userId.utf8)
 
-        let baseContext = CassandraClient.EncryptionContext(
-            keyspace: keyspace, table: tableName, column: "secret_name", primaryKey: primaryKeyData
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: primaryKeyData
         )
 
         var options = CassandraClient.Statement.Options()
@@ -434,15 +491,19 @@ final class EncryptionIntegrationTests: XCTestCase {
             guard let uid: String = row.column("user_id") else {
                 throw CassandraClient.Error.badParams("user_id not found in row")
             }
-            return CassandraClient.RowEncryptionContext(keyspace: keyspace, table: tableName, primaryKey: Data(uid.utf8))
+            return CassandraClient.EncryptionContext.Base(
+                keyspace: keyspace,
+                table: tableName,
+                primaryKey: Data(uid.utf8)
+            )
         }
 
         try session.run(
             "insert into \(tableName) (user_id, secret_name, secret_age) values (?, ?, ?)",
             parameters: [
                 .string(userId),
-                .encryptedString(CassandraClient.Encrypted(name), context: baseContext),
-                .encryptedInt32(CassandraClient.Encrypted(age), context: baseContext.withColumn("secret_age")),
+                .encryptedString(CassandraClient.Encrypted(name), context: baseContext.forColumn("secret_name")),
+                .encryptedInt32(CassandraClient.Encrypted(age), context: baseContext.forColumn("secret_age")),
             ],
             options: options
         ).wait()

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import CassandraClient
 
-@available(macOS 11.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 final class EncryptionIntegrationTests: XCTestCase {
     var cassandraClient: CassandraClient!
     var configuration: CassandraClient.Configuration!

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -38,7 +38,7 @@ final class EncryptorTests: XCTestCase {
             keyspace: "test_keyspace",
             table: "users",
             column: column,
-            primaryKey: primaryKey ?? CassandraClient.PrimaryKey(from: .string("row-1"))
+            primaryKey: primaryKey ?? .init(from: .string("row-1"))
         )
     }
 
@@ -87,7 +87,7 @@ final class EncryptorTests: XCTestCase {
         let rowContext = CassandraClient.EncryptionContext.Base(
             keyspace: "test_keyspace",
             table: "users",
-            primaryKey: CassandraClient.PrimaryKey(from: .string("row-1"))
+            primaryKey: .init(from: .string("row-1"))
         )
         let ssnContext = rowContext.forColumn("ssn")
         let ccContext = rowContext.forColumn("credit_card")
@@ -103,12 +103,12 @@ final class EncryptorTests: XCTestCase {
         let (encryptor, _) = try makeEncryptor()
         let plaintext = Data("secret-value".utf8)
 
-        let context1 = testContext(primaryKey: CassandraClient.PrimaryKey(from: .string("row-1")))
+        let context1 = testContext(primaryKey: .init(from: .string("row-1")))
         let context2 = CassandraClient.EncryptionContext(
             keyspace: "test_keyspace",
             table: "users",
             column: "ssn",
-            primaryKey: CassandraClient.PrimaryKey(from: .string("row-2"))
+            primaryKey: .init(from: .string("row-2"))
         )
 
         let encrypted1 = try encryptor.encrypt(plaintext, context: context1)
@@ -120,8 +120,8 @@ final class EncryptorTests: XCTestCase {
     /// Decrypt with a different primaryKey should fail.
     func testWrongContext() throws {
         let (encryptor, _) = try makeEncryptor()
-        let contextA = testContext(primaryKey: CassandraClient.PrimaryKey(from: .string("row-1")))
-        let contextB = testContext(primaryKey: CassandraClient.PrimaryKey(from: .string("row-2")))
+        let contextA = testContext(primaryKey: .init(from: .string("row-1")))
+        let contextB = testContext(primaryKey: .init(from: .string("row-2")))
         let encrypted = try encryptor.encrypt(Data("secret".utf8), context: contextA)
         XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: contextB))
     }
@@ -392,7 +392,7 @@ final class EncryptorTests: XCTestCase {
                         keyspace: "test",
                         table: "users",
                         column: "col_\(i % 5)",
-                        primaryKey: CassandraClient.PrimaryKey(from: .string("row-\(i)"))
+                        primaryKey: .init(from: .string("row-\(i)"))
                     )
                     let encrypted = try encryptor.encrypt(plaintext, context: context)
                     let decrypted = try encryptor.decrypt(encrypted, context: context)

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -412,4 +412,53 @@ final class EncryptorTests: XCTestCase {
         group.wait()
         XCTAssertEqual(errors.count, 0, "Concurrent errors: \(errors)")
     }
+
+    // MARK: - Salt
+
+    /// Encrypt then decrypt with a custom salt should round-trip correctly.
+    func testCustomSaltRoundtrip() throws {
+        let keyData = randomKey()
+        let salt = Data("my-application-salt".utf8)
+        let encryptor = try CassandraClient.Encryptor(
+            keyMap: ["key-1": keyData],
+            currentKeyName: "key-1",
+            salt: salt
+        )
+        let context = testContext()
+        let plaintext = Data("secret-value".utf8)
+
+        let encrypted = try encryptor.encrypt(plaintext, context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+
+        XCTAssertEqual(decrypted, plaintext)
+    }
+
+    /// Different salts with the same key should produce different ciphertext envelopes
+    /// (different KEK → different DEK → different ciphertext).
+    func testDifferentSaltProducesDifferentKeys() throws {
+        let keyData = randomKey()
+        let encryptorA = try CassandraClient.Encryptor(
+            keyMap: ["key-1": keyData],
+            currentKeyName: "key-1",
+            salt: Data("salt-a".utf8)
+        )
+        let encryptorB = try CassandraClient.Encryptor(
+            keyMap: ["key-1": keyData],
+            currentKeyName: "key-1",
+            salt: Data("salt-b".utf8)
+        )
+        let context = testContext()
+        let plaintext = Data("hello".utf8)
+
+        let encryptedA = try encryptorA.encrypt(plaintext, context: context)
+        let encryptedB = try encryptorB.encrypt(plaintext, context: context)
+
+        // Both should decrypt with their own encryptor
+        XCTAssertEqual(try encryptorA.decrypt(encryptedA, context: context), plaintext)
+        XCTAssertEqual(try encryptorB.decrypt(encryptedB, context: context), plaintext)
+
+        // Cross-decryption should fail (different salt → different derived keys)
+        XCTAssertThrowsError(try encryptorA.decrypt(encryptedB, context: context))
+        XCTAssertThrowsError(try encryptorB.decrypt(encryptedA, context: context))
+    }
 }

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -26,7 +26,7 @@ func randomKey() -> Data {
     return Data(bytes)
 }
 
-@available(macOS 11.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 final class EncryptorTests: XCTestCase {
 
     // Helper: create a simple context for testing
@@ -329,13 +329,15 @@ final class EncryptorTests: XCTestCase {
         var errors = [Error]()
         let errorLock = NSLock()
 
-        for i in 0 ..< iterations {
+        for i in 0..<iterations {
             group.enter()
             DispatchQueue.global().async {
                 defer { group.leave() }
                 do {
                     let context = CassandraClient.EncryptionContext(
-                        keyspace: "test", table: "users", column: "col_\(i % 5)",
+                        keyspace: "test",
+                        table: "users",
+                        column: "col_\(i % 5)",
                         primaryKey: Data("row-\(i)".utf8)
                     )
                     let encrypted = try encryptor.encrypt(plaintext, context: context)

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -20,13 +20,13 @@ import XCTest
 /// Generate a random 32-byte key for testing.
 func randomKey() -> Data {
     var bytes = [UInt8](repeating: 0, count: 32)
-    for i in 0 ..< bytes.count {
-        bytes[i] = UInt8.random(in: 0 ... 255)
+    for i in 0..<bytes.count {
+        bytes[i] = UInt8.random(in: 0...255)
     }
     return Data(bytes)
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 final class EncryptorTests: XCTestCase {
 
     // Helper: create a simple context for testing
@@ -40,7 +40,8 @@ final class EncryptorTests: XCTestCase {
     }
 
     // Helper: create an encryptor with one key
-    private func makeEncryptor(keyName: String = "key-1", key: Data? = nil) throws -> (CassandraClient.Encryptor, Data) {
+    private func makeEncryptor(keyName: String = "key-1", key: Data? = nil) throws -> (CassandraClient.Encryptor, Data)
+    {
         let keyData = key ?? randomKey()
         let encryptor = try CassandraClient.Encryptor(
             keyMap: [keyName: keyData],
@@ -80,8 +81,13 @@ final class EncryptorTests: XCTestCase {
         let (encryptor, _) = try makeEncryptor()
         let plaintext = Data("secret-value".utf8)
 
-        let ssnContext = testContext(column: "ssn")
-        let ccContext = ssnContext.withColumn("credit_card")
+        let rowContext = CassandraClient.EncryptionContext.Base(
+            keyspace: "test_keyspace",
+            table: "users",
+            primaryKey: Data("row-1".utf8)
+        )
+        let ssnContext = rowContext.forColumn("ssn")
+        let ccContext = rowContext.forColumn("credit_card")
 
         let encryptedSSN = try encryptor.encrypt(plaintext, context: ssnContext)
         let encryptedCC = try encryptor.encrypt(plaintext, context: ccContext)
@@ -95,7 +101,12 @@ final class EncryptorTests: XCTestCase {
         let plaintext = Data("secret-value".utf8)
 
         let context1 = testContext(primaryKey: Data("row-1".utf8))
-        let context2 = context1.withPrimaryKey(Data("row-2".utf8))
+        let context2 = CassandraClient.EncryptionContext(
+            keyspace: "test_keyspace",
+            table: "users",
+            column: "ssn",
+            primaryKey: Data("row-2".utf8)
+        )
 
         let encrypted1 = try encryptor.encrypt(plaintext, context: context1)
         let encrypted2 = try encryptor.encrypt(plaintext, context: context2)
@@ -162,15 +173,19 @@ final class EncryptorTests: XCTestCase {
         let context = testContext(column: "uid")
         let value = Foundation.UUID()
         let u = value.uuid
-        let data = Data([u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
-                          u.8, u.9, u.10, u.11, u.12, u.13, u.14, u.15])
+        let data = Data([
+            u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
+            u.8, u.9, u.10, u.11, u.12, u.13, u.14, u.15,
+        ])
         let encrypted = try encryptor.encrypt(data, context: context)
         let decrypted = try encryptor.decrypt(encrypted, context: context)
         XCTAssertEqual(decrypted.count, 16)
-        let t: uuid_t = (decrypted[0], decrypted[1], decrypted[2], decrypted[3],
-                          decrypted[4], decrypted[5], decrypted[6], decrypted[7],
-                          decrypted[8], decrypted[9], decrypted[10], decrypted[11],
-                          decrypted[12], decrypted[13], decrypted[14], decrypted[15])
+        let t: uuid_t = (
+            decrypted[0], decrypted[1], decrypted[2], decrypted[3],
+            decrypted[4], decrypted[5], decrypted[6], decrypted[7],
+            decrypted[8], decrypted[9], decrypted[10], decrypted[11],
+            decrypted[12], decrypted[13], decrypted[14], decrypted[15]
+        )
         XCTAssertEqual(Foundation.UUID(uuid: t), value)
     }
 
@@ -218,26 +233,32 @@ final class EncryptorTests: XCTestCase {
 
     /// Empty key name should be rejected.
     func testEmptyKeyName() {
-        XCTAssertThrowsError(try CassandraClient.Encryptor(
-            keyMap: ["": randomKey()],
-            currentKeyName: ""
-        ))
+        XCTAssertThrowsError(
+            try CassandraClient.Encryptor(
+                keyMap: ["": randomKey()],
+                currentKeyName: ""
+            )
+        )
     }
 
     /// Key name with invalid characters should be rejected.
     func testInvalidKeyNameCharacters() {
-        XCTAssertThrowsError(try CassandraClient.Encryptor(
-            keyMap: ["key with spaces": randomKey()],
-            currentKeyName: "key with spaces"
-        ))
+        XCTAssertThrowsError(
+            try CassandraClient.Encryptor(
+                keyMap: ["key with spaces": randomKey()],
+                currentKeyName: "key with spaces"
+            )
+        )
     }
 
     /// Key that is not 32 bytes should be rejected.
     func testWrongKeySize() {
-        XCTAssertThrowsError(try CassandraClient.Encryptor(
-            keyMap: ["key-1": Data([0x01, 0x02, 0x03])],
-            currentKeyName: "key-1"
-        ))
+        XCTAssertThrowsError(
+            try CassandraClient.Encryptor(
+                keyMap: ["key-1": Data([0x01, 0x02, 0x03])],
+                currentKeyName: "key-1"
+            )
+        )
     }
 
     /// Cannot remove an existing key from the map.
@@ -249,7 +270,7 @@ final class EncryptorTests: XCTestCase {
             currentKeyName: "key-1"
         )
         // New map missing "key-2" — should throw
-        XCTAssertThrowsError(try encryptor.loadKeys(from:["key-1": key1]))
+        XCTAssertThrowsError(try encryptor.loadKeys(from: ["key-1": key1]))
     }
 
     /// Cannot change an existing key's bytes.
@@ -260,7 +281,7 @@ final class EncryptorTests: XCTestCase {
             currentKeyName: "key-1"
         )
         // Same name, different bytes — should throw
-        XCTAssertThrowsError(try encryptor.loadKeys(from:["key-1": randomKey()]))
+        XCTAssertThrowsError(try encryptor.loadKeys(from: ["key-1": randomKey()]))
     }
 
     /// Can add a new key via loadKeys while keeping existing ones.
@@ -271,7 +292,7 @@ final class EncryptorTests: XCTestCase {
             currentKeyName: "key-1"
         )
         let key2 = randomKey()
-        XCTAssertNoThrow(try encryptor.loadKeys(from:["key-1": key1, "key-2": key2]))
+        XCTAssertNoThrow(try encryptor.loadKeys(from: ["key-1": key1, "key-2": key2]))
     }
 
     // MARK: - Envelope validation
@@ -315,6 +336,36 @@ final class EncryptorTests: XCTestCase {
         encrypted[tamperIndex] ^= 0xFF
 
         XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: context))
+    }
+
+    // MARK: - encodeKeyComponents
+
+    /// Single string component produces 4-byte length prefix followed by UTF-8 bytes.
+    func testEncodeKeyComponentsSingleString() {
+        let encoded = CassandraClient.EncryptionContext.encodeKeyComponents(.string("hello"))
+        let utf8 = Data("hello".utf8)
+        var expectedLength = UInt32(utf8.count).bigEndian
+        var expected = Data(bytes: &expectedLength, count: 4)
+        expected.append(utf8)
+        XCTAssertEqual(encoded, expected)
+    }
+
+    /// Composite key (string + UUID) is deterministic and produces correct bytes.
+    func testEncodeKeyComponentsComposite() {
+        let uuid = Foundation.UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+        let encoded1 = CassandraClient.EncryptionContext.encodeKeyComponents(.string("user"), .uuid(uuid))
+        let encoded2 = CassandraClient.EncryptionContext.encodeKeyComponents(.string("user"), .uuid(uuid))
+        XCTAssertEqual(encoded1, encoded2, "Same inputs should produce identical output")
+        // String "user" = 4 bytes → length(4) + value(4) = 8
+        // UUID = 16 bytes → length(4) + value(16) = 20
+        XCTAssertEqual(encoded1.count, 8 + 20)
+    }
+
+    /// Length-prefixing prevents ambiguity: ("ab", "c") != ("a", "bc").
+    func testEncodeKeyComponentsAmbiguity() {
+        let abC = CassandraClient.EncryptionContext.encodeKeyComponents(.string("ab"), .string("c"))
+        let aBc = CassandraClient.EncryptionContext.encodeKeyComponents(.string("a"), .string("bc"))
+        XCTAssertNotEqual(abC, aBc, "Length-prefixing should prevent ambiguity from naive concatenation")
     }
 
     // MARK: - Concurrent access

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -350,7 +350,7 @@ final class EncryptorTests: XCTestCase {
         var expectedLength = UInt32(utf8.count).bigEndian
         var expected = Data(bytes: &expectedLength, count: 4)
         expected.append(utf8)
-        XCTAssertEqual(encoded, expected)
+        XCTAssertEqual(encoded.data, expected)
     }
 
     /// Composite key (string + UUID) is deterministic and produces correct bytes.
@@ -361,7 +361,7 @@ final class EncryptorTests: XCTestCase {
         XCTAssertEqual(encoded1, encoded2, "Same inputs should produce identical output")
         // String "user" = 4 bytes → length(4) + value(4) = 8
         // UUID = 16 bytes → length(4) + value(16) = 20
-        XCTAssertEqual(encoded1.count, 8 + 20)
+        XCTAssertEqual(encoded1.data.count, 8 + 20)
     }
 
     /// Length-prefixing prevents ambiguity: ("ab", "c") != ("a", "bc").

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -30,12 +30,15 @@ func randomKey() -> Data {
 final class EncryptorTests: XCTestCase {
 
     // Helper: create a simple context for testing
-    private func testContext(column: String = "ssn", primaryKey: Data? = nil) -> CassandraClient.EncryptionContext {
+    private func testContext(
+        column: String = "ssn",
+        primaryKey: CassandraClient.PrimaryKey? = nil
+    ) -> CassandraClient.EncryptionContext {
         CassandraClient.EncryptionContext(
             keyspace: "test_keyspace",
             table: "users",
             column: column,
-            primaryKey: primaryKey ?? Data("row-1".utf8)
+            primaryKey: primaryKey ?? CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1"))
         )
     }
 
@@ -84,7 +87,7 @@ final class EncryptorTests: XCTestCase {
         let rowContext = CassandraClient.EncryptionContext.Base(
             keyspace: "test_keyspace",
             table: "users",
-            primaryKey: Data("row-1".utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1"))
         )
         let ssnContext = rowContext.forColumn("ssn")
         let ccContext = rowContext.forColumn("credit_card")
@@ -100,12 +103,12 @@ final class EncryptorTests: XCTestCase {
         let (encryptor, _) = try makeEncryptor()
         let plaintext = Data("secret-value".utf8)
 
-        let context1 = testContext(primaryKey: Data("row-1".utf8))
+        let context1 = testContext(primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1")))
         let context2 = CassandraClient.EncryptionContext(
             keyspace: "test_keyspace",
             table: "users",
             column: "ssn",
-            primaryKey: Data("row-2".utf8)
+            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-2"))
         )
 
         let encrypted1 = try encryptor.encrypt(plaintext, context: context1)
@@ -117,8 +120,8 @@ final class EncryptorTests: XCTestCase {
     /// Decrypt with a different primaryKey should fail.
     func testWrongContext() throws {
         let (encryptor, _) = try makeEncryptor()
-        let contextA = testContext(primaryKey: Data("row-1".utf8))
-        let contextB = testContext(primaryKey: Data("row-2".utf8))
+        let contextA = testContext(primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1")))
+        let contextB = testContext(primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-2")))
         let encrypted = try encryptor.encrypt(Data("secret".utf8), context: contextA)
         XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: contextB))
     }
@@ -135,7 +138,7 @@ final class EncryptorTests: XCTestCase {
         let encrypted = try encryptor.encrypt(data, context: context)
         let decrypted = try encryptor.decrypt(encrypted, context: context)
         XCTAssertEqual(decrypted.count, 4)
-        let result = decrypted.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+        let result = decrypted.withUnsafeBytes { $0.loadUnaligned(as: Int32.self).bigEndian }
         XCTAssertEqual(result, value)
     }
 
@@ -149,7 +152,7 @@ final class EncryptorTests: XCTestCase {
         let encrypted = try encryptor.encrypt(data, context: context)
         let decrypted = try encryptor.decrypt(encrypted, context: context)
         XCTAssertEqual(decrypted.count, 8)
-        let result = decrypted.withUnsafeBytes { $0.load(as: Int64.self).bigEndian }
+        let result = decrypted.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
         XCTAssertEqual(result, value)
     }
 
@@ -163,7 +166,7 @@ final class EncryptorTests: XCTestCase {
         let encrypted = try encryptor.encrypt(data, context: context)
         let decrypted = try encryptor.decrypt(encrypted, context: context)
         XCTAssertEqual(decrypted.count, 8)
-        let result = Double(bitPattern: decrypted.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian })
+        let result = Double(bitPattern: decrypted.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self).bigEndian })
         XCTAssertEqual(result, value)
     }
 
@@ -389,7 +392,7 @@ final class EncryptorTests: XCTestCase {
                         keyspace: "test",
                         table: "users",
                         column: "col_\(i % 5)",
-                        primaryKey: Data("row-\(i)".utf8)
+                        primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-\(i)"))
                     )
                     let encrypted = try encryptor.encrypt(plaintext, context: context)
                     let decrypted = try encryptor.decrypt(encrypted, context: context)

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -1,0 +1,359 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+@testable import CassandraClient
+
+/// Generate a random 32-byte key for testing.
+func randomKey() -> Data {
+    var bytes = [UInt8](repeating: 0, count: 32)
+    for i in 0 ..< bytes.count {
+        bytes[i] = UInt8.random(in: 0 ... 255)
+    }
+    return Data(bytes)
+}
+
+@available(macOS 11.0, *)
+final class EncryptorTests: XCTestCase {
+
+    // Helper: create a simple context for testing
+    private func testContext(column: String = "ssn", primaryKey: Data? = nil) -> CassandraClient.EncryptionContext {
+        CassandraClient.EncryptionContext(
+            keyspace: "test_keyspace",
+            table: "users",
+            column: column,
+            primaryKey: primaryKey ?? Data("row-1".utf8)
+        )
+    }
+
+    // Helper: create an encryptor with one key
+    private func makeEncryptor(keyName: String = "key-1", key: Data? = nil) throws -> (CassandraClient.Encryptor, Data) {
+        let keyData = key ?? randomKey()
+        let encryptor = try CassandraClient.Encryptor(
+            keyMap: [keyName: keyData],
+            currentKeyName: keyName
+        )
+        return (encryptor, keyData)
+    }
+
+    // MARK: - Basic encrypt / decrypt
+
+    /// Encrypt then decrypt should return the original plaintext.
+    func testEncryptDecrypt() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext()
+        let plaintext = Data("hello-world!".utf8)
+
+        let encrypted = try encryptor.encrypt(plaintext, context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+
+        XCTAssertEqual(decrypted, plaintext)
+        XCTAssertNotEqual(encrypted, plaintext, "Encrypted data should differ from plaintext")
+    }
+
+    /// Encrypt and decrypt empty data.
+    func testEmptyPlaintext() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext()
+        let encrypted = try encryptor.encrypt(Data(), context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+        XCTAssertEqual(decrypted, Data())
+    }
+
+    // MARK: - Context binding
+
+    /// Same plaintext encrypted for different columns should produce different ciphertext.
+    func testContextBinding() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let plaintext = Data("secret-value".utf8)
+
+        let ssnContext = testContext(column: "ssn")
+        let ccContext = ssnContext.withColumn("credit_card")
+
+        let encryptedSSN = try encryptor.encrypt(plaintext, context: ssnContext)
+        let encryptedCC = try encryptor.encrypt(plaintext, context: ccContext)
+
+        XCTAssertNotEqual(encryptedSSN, encryptedCC, "Different columns should produce different ciphertext")
+    }
+
+    /// Same plaintext encrypted for different rows should produce different ciphertext.
+    func testRowBinding() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let plaintext = Data("secret-value".utf8)
+
+        let context1 = testContext(primaryKey: Data("row-1".utf8))
+        let context2 = context1.withPrimaryKey(Data("row-2".utf8))
+
+        let encrypted1 = try encryptor.encrypt(plaintext, context: context1)
+        let encrypted2 = try encryptor.encrypt(plaintext, context: context2)
+
+        XCTAssertNotEqual(encrypted1, encrypted2, "Different primary keys should produce different ciphertext")
+    }
+
+    /// Decrypt with a different primaryKey should fail.
+    func testWrongContext() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let contextA = testContext(primaryKey: Data("row-1".utf8))
+        let contextB = testContext(primaryKey: Data("row-2".utf8))
+        let encrypted = try encryptor.encrypt(Data("secret".utf8), context: contextA)
+        XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: contextB))
+    }
+
+    // MARK: - Type-specific roundtrips
+
+    /// Encrypt and decrypt Int32.
+    func testInt32Roundtrip() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext(column: "age")
+        let value: Int32 = -42
+        var bigEndian = value.bigEndian
+        let data = Data(bytes: &bigEndian, count: 4)
+        let encrypted = try encryptor.encrypt(data, context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+        XCTAssertEqual(decrypted.count, 4)
+        let result = decrypted.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+        XCTAssertEqual(result, value)
+    }
+
+    /// Encrypt and decrypt Int64.
+    func testInt64Roundtrip() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext(column: "age64")
+        let value: Int64 = 9_876_543_210
+        var bigEndian = value.bigEndian
+        let data = Data(bytes: &bigEndian, count: 8)
+        let encrypted = try encryptor.encrypt(data, context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+        XCTAssertEqual(decrypted.count, 8)
+        let result = decrypted.withUnsafeBytes { $0.load(as: Int64.self).bigEndian }
+        XCTAssertEqual(result, value)
+    }
+
+    /// Encrypt and decrypt Double.
+    func testDoubleRoundtrip() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext(column: "score")
+        let value: Double = 3.14159
+        var bits = value.bitPattern.bigEndian
+        let data = Data(bytes: &bits, count: 8)
+        let encrypted = try encryptor.encrypt(data, context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+        XCTAssertEqual(decrypted.count, 8)
+        let result = Double(bitPattern: decrypted.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian })
+        XCTAssertEqual(result, value)
+    }
+
+    /// Encrypt and decrypt UUID.
+    func testUUIDRoundtrip() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext(column: "uid")
+        let value = Foundation.UUID()
+        let u = value.uuid
+        let data = Data([u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
+                          u.8, u.9, u.10, u.11, u.12, u.13, u.14, u.15])
+        let encrypted = try encryptor.encrypt(data, context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+        XCTAssertEqual(decrypted.count, 16)
+        let t: uuid_t = (decrypted[0], decrypted[1], decrypted[2], decrypted[3],
+                          decrypted[4], decrypted[5], decrypted[6], decrypted[7],
+                          decrypted[8], decrypted[9], decrypted[10], decrypted[11],
+                          decrypted[12], decrypted[13], decrypted[14], decrypted[15])
+        XCTAssertEqual(Foundation.UUID(uuid: t), value)
+    }
+
+    /// Encrypt and decrypt raw bytes.
+    func testBytesRoundtrip() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext(column: "blob")
+        let value: [UInt8] = [0x00, 0xFF, 0x42, 0xAB, 0x01]
+        let encrypted = try encryptor.encrypt(Data(value), context: context)
+        let decrypted = try encryptor.decrypt(encrypted, context: context)
+        XCTAssertEqual(Array(decrypted), value)
+    }
+
+    // MARK: - Key management
+
+    /// Encrypt with key-1, add key-2, switch to key-2, old data still decrypts.
+    func testKeyRotation() throws {
+        let (encryptor, _) = try makeEncryptor(keyName: "key-1")
+        let context = testContext()
+        let plaintext = Data("secret-data".utf8)
+
+        let encryptedWithKey1 = try encryptor.encrypt(plaintext, context: context)
+
+        try encryptor.addKey(name: "key-2", secret: randomKey())
+        try encryptor.setCurrentKeyName("key-2")
+
+        let encryptedWithKey2 = try encryptor.encrypt(plaintext, context: context)
+
+        let decrypted1 = try encryptor.decrypt(encryptedWithKey1, context: context)
+        let decrypted2 = try encryptor.decrypt(encryptedWithKey2, context: context)
+
+        XCTAssertEqual(decrypted1, plaintext)
+        XCTAssertEqual(decrypted2, plaintext)
+    }
+
+    /// Decrypt with an encryptor that doesn't have the key used to encrypt.
+    func testMissingKey() throws {
+        let (encryptor1, _) = try makeEncryptor(keyName: "key-1")
+        let context = testContext()
+        let encrypted = try encryptor1.encrypt(Data("secret".utf8), context: context)
+
+        let (encryptor2, _) = try makeEncryptor(keyName: "key-2")
+        XCTAssertThrowsError(try encryptor2.decrypt(encrypted, context: context))
+    }
+
+    /// Empty key name should be rejected.
+    func testEmptyKeyName() {
+        XCTAssertThrowsError(try CassandraClient.Encryptor(
+            keyMap: ["": randomKey()],
+            currentKeyName: ""
+        ))
+    }
+
+    /// Key name with invalid characters should be rejected.
+    func testInvalidKeyNameCharacters() {
+        XCTAssertThrowsError(try CassandraClient.Encryptor(
+            keyMap: ["key with spaces": randomKey()],
+            currentKeyName: "key with spaces"
+        ))
+    }
+
+    /// Key that is not 32 bytes should be rejected.
+    func testWrongKeySize() {
+        XCTAssertThrowsError(try CassandraClient.Encryptor(
+            keyMap: ["key-1": Data([0x01, 0x02, 0x03])],
+            currentKeyName: "key-1"
+        ))
+    }
+
+    /// Cannot remove an existing key from the map.
+    func testLoadKeysCannotRemoveKey() throws {
+        let key1 = randomKey()
+        let key2 = randomKey()
+        let encryptor = try CassandraClient.Encryptor(
+            keyMap: ["key-1": key1, "key-2": key2],
+            currentKeyName: "key-1"
+        )
+        // New map missing "key-2" — should throw
+        XCTAssertThrowsError(try encryptor.loadKeys(from:["key-1": key1]))
+    }
+
+    /// Cannot change an existing key's bytes.
+    func testLoadKeysCannotChangeKey() throws {
+        let key1 = randomKey()
+        let encryptor = try CassandraClient.Encryptor(
+            keyMap: ["key-1": key1],
+            currentKeyName: "key-1"
+        )
+        // Same name, different bytes — should throw
+        XCTAssertThrowsError(try encryptor.loadKeys(from:["key-1": randomKey()]))
+    }
+
+    /// Can add a new key via loadKeys while keeping existing ones.
+    func testLoadKeysCanAddKey() throws {
+        let key1 = randomKey()
+        let encryptor = try CassandraClient.Encryptor(
+            keyMap: ["key-1": key1],
+            currentKeyName: "key-1"
+        )
+        let key2 = randomKey()
+        XCTAssertNoThrow(try encryptor.loadKeys(from:["key-1": key1, "key-2": key2]))
+    }
+
+    // MARK: - Envelope validation
+
+    /// Envelope too short to contain even the header fields.
+    func testEnvelopeTooShort() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext()
+        let tooShort = Data([0x01, 0x02, 0x03])
+        XCTAssertThrowsError(try encryptor.decrypt(tooShort, context: context))
+    }
+
+    /// Envelope with wrong version byte.
+    func testEnvelopeWrongVersion() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext()
+        var envelope = try encryptor.encrypt(Data("hello".utf8), context: context)
+        envelope[0] = 0xFF  // corrupt version byte
+        XCTAssertThrowsError(try encryptor.decrypt(envelope, context: context))
+    }
+
+    /// Envelope with wrong algorithm byte.
+    func testEnvelopeWrongAlgorithm() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext()
+        var envelope = try encryptor.encrypt(Data("hello".utf8), context: context)
+        envelope[1] = 0xFF  // corrupt algorithm byte
+        XCTAssertThrowsError(try encryptor.decrypt(envelope, context: context))
+    }
+
+    /// Flipping a byte in the ciphertext should cause decryption to fail.
+    func testTamperDetection() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let context = testContext()
+        let plaintext = Data("hello-world!".utf8)
+
+        var encrypted = try encryptor.encrypt(plaintext, context: context)
+
+        // Flip a byte near the end (in the ciphertext region)
+        let tamperIndex = encrypted.count - 20
+        encrypted[tamperIndex] ^= 0xFF
+
+        XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: context))
+    }
+
+    // MARK: - Concurrent access
+
+    /// Multiple threads encrypting and decrypting simultaneously should not crash or corrupt data.
+    func testConcurrentEncryptDecrypt() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let plaintext = Data("concurrent-test".utf8)
+        let iterations = 100
+
+        let group = DispatchGroup()
+        var errors = [Error]()
+        let errorLock = NSLock()
+
+        for i in 0 ..< iterations {
+            group.enter()
+            DispatchQueue.global().async {
+                defer { group.leave() }
+                do {
+                    let context = CassandraClient.EncryptionContext(
+                        keyspace: "test", table: "users", column: "col_\(i % 5)",
+                        primaryKey: Data("row-\(i)".utf8)
+                    )
+                    let encrypted = try encryptor.encrypt(plaintext, context: context)
+                    let decrypted = try encryptor.decrypt(encrypted, context: context)
+                    if decrypted != plaintext {
+                        errorLock.lock()
+                        errors.append(CassandraClient.Error.decryptionError("Data mismatch on iteration \(i)"))
+                        errorLock.unlock()
+                    }
+                } catch {
+                    errorLock.lock()
+                    errors.append(error)
+                    errorLock.unlock()
+                }
+            }
+        }
+
+        group.wait()
+        XCTAssertEqual(errors.count, 0, "Concurrent errors: \(errors)")
+    }
+}

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -38,7 +38,7 @@ final class EncryptorTests: XCTestCase {
             keyspace: "test_keyspace",
             table: "users",
             column: column,
-            primaryKey: primaryKey ?? CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1"))
+            primaryKey: primaryKey ?? CassandraClient.PrimaryKey(from: .string("row-1"))
         )
     }
 
@@ -87,7 +87,7 @@ final class EncryptorTests: XCTestCase {
         let rowContext = CassandraClient.EncryptionContext.Base(
             keyspace: "test_keyspace",
             table: "users",
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1"))
+            primaryKey: CassandraClient.PrimaryKey(from: .string("row-1"))
         )
         let ssnContext = rowContext.forColumn("ssn")
         let ccContext = rowContext.forColumn("credit_card")
@@ -103,12 +103,12 @@ final class EncryptorTests: XCTestCase {
         let (encryptor, _) = try makeEncryptor()
         let plaintext = Data("secret-value".utf8)
 
-        let context1 = testContext(primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1")))
+        let context1 = testContext(primaryKey: CassandraClient.PrimaryKey(from: .string("row-1")))
         let context2 = CassandraClient.EncryptionContext(
             keyspace: "test_keyspace",
             table: "users",
             column: "ssn",
-            primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-2"))
+            primaryKey: CassandraClient.PrimaryKey(from: .string("row-2"))
         )
 
         let encrypted1 = try encryptor.encrypt(plaintext, context: context1)
@@ -120,8 +120,8 @@ final class EncryptorTests: XCTestCase {
     /// Decrypt with a different primaryKey should fail.
     func testWrongContext() throws {
         let (encryptor, _) = try makeEncryptor()
-        let contextA = testContext(primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-1")))
-        let contextB = testContext(primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-2")))
+        let contextA = testContext(primaryKey: CassandraClient.PrimaryKey(from: .string("row-1")))
+        let contextB = testContext(primaryKey: CassandraClient.PrimaryKey(from: .string("row-2")))
         let encrypted = try encryptor.encrypt(Data("secret".utf8), context: contextA)
         XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: contextB))
     }
@@ -341,11 +341,11 @@ final class EncryptorTests: XCTestCase {
         XCTAssertThrowsError(try encryptor.decrypt(encrypted, context: context))
     }
 
-    // MARK: - encodeKeyComponents
+    // MARK: - PrimaryKey
 
     /// Single string component produces 4-byte length prefix followed by UTF-8 bytes.
     func testEncodeKeyComponentsSingleString() {
-        let encoded = CassandraClient.EncryptionContext.encodeKeyComponents(.string("hello"))
+        let encoded = CassandraClient.PrimaryKey(from: .string("hello"))
         let utf8 = Data("hello".utf8)
         var expectedLength = UInt32(utf8.count).bigEndian
         var expected = Data(bytes: &expectedLength, count: 4)
@@ -356,8 +356,8 @@ final class EncryptorTests: XCTestCase {
     /// Composite key (string + UUID) is deterministic and produces correct bytes.
     func testEncodeKeyComponentsComposite() {
         let uuid = Foundation.UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
-        let encoded1 = CassandraClient.EncryptionContext.encodeKeyComponents(.string("user"), .uuid(uuid))
-        let encoded2 = CassandraClient.EncryptionContext.encodeKeyComponents(.string("user"), .uuid(uuid))
+        let encoded1 = CassandraClient.PrimaryKey(from: .string("user"), .uuid(uuid))
+        let encoded2 = CassandraClient.PrimaryKey(from: .string("user"), .uuid(uuid))
         XCTAssertEqual(encoded1, encoded2, "Same inputs should produce identical output")
         // String "user" = 4 bytes → length(4) + value(4) = 8
         // UUID = 16 bytes → length(4) + value(16) = 20
@@ -366,8 +366,8 @@ final class EncryptorTests: XCTestCase {
 
     /// Length-prefixing prevents ambiguity: ("ab", "c") != ("a", "bc").
     func testEncodeKeyComponentsAmbiguity() {
-        let abC = CassandraClient.EncryptionContext.encodeKeyComponents(.string("ab"), .string("c"))
-        let aBc = CassandraClient.EncryptionContext.encodeKeyComponents(.string("a"), .string("bc"))
+        let abC = CassandraClient.PrimaryKey(from: .string("ab"), .string("c"))
+        let aBc = CassandraClient.PrimaryKey(from: .string("a"), .string("bc"))
         XCTAssertNotEqual(abC, aBc, "Length-prefixing should prevent ambiguity from naive concatenation")
     }
 
@@ -392,7 +392,7 @@ final class EncryptorTests: XCTestCase {
                         keyspace: "test",
                         table: "users",
                         column: "col_\(i % 5)",
-                        primaryKey: CassandraClient.EncryptionContext.encodeKeyComponents(.string("row-\(i)"))
+                        primaryKey: CassandraClient.PrimaryKey(from: .string("row-\(i)"))
                     )
                     let encrypted = try encryptor.encrypt(plaintext, context: context)
                     let decrypted = try encryptor.decrypt(encrypted, context: context)


### PR DESCRIPTION
Add column-level encryption for Swift Cassandra client

Motivation:
Sensitive data stored in Cassandra (e.g. SSNs, credit card numbers) needs to be encrypted at the column level so that plaintext is never exposed in the database. The solution needs to support key rotation without requiring all data to be re-encrypted at once.

Modifications:
Core encryption engine: Encryptor using AES-256-GCM with per-column and per-row key derivation. Self-describing envelope format.
Write path + manual read: Encrypted parameter types for writes, decryption convenience methods for reads, encryptor wiring through Configuration → Session → Statement.
Automatic decryption of Encrypted<T> struct fields via the existing Codable query path.

Result:
Users can encrypt columns on write, decrypt on read (manually or automatically via Codable), and rotate keys without downtime.