### PR TITLE
Add column registration, encryption metrics, and write-path enforcement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,6 +105,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "2.0.0")),
     ],
     targets: [
         .target(
@@ -164,6 +165,7 @@ let package = Package(
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "Metrics", package: "swift-metrics"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -31,6 +31,15 @@ public class CassandraClient: CassandraSession {
         self.configuration.encryptor
     }
 
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    public var encryptionSchemas: [String: CassandraClient.EncryptionSchema] {
+        self.configuration.encryptionSchemas
+    }
+
+    public var keyspace: String? {
+        self.configuration.keyspace
+    }
+
     private let configuration: Configuration
     private let logger: Logger
     private let defaultSession: Session

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -49,8 +49,6 @@ extension CassandraClient {
         public var compact: Bool?
 
         /// Encryptor for transparent column encryption.
-        // TODO: Add encrypted column registration (EncryptedColumnSchema, registerEncryptedColumns, isEncrypted)
-        // once prepared statement metadata integration is available for enforcement.
         @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: Encryptor? {
             get { self._encryptor as? Encryptor }
@@ -58,6 +56,23 @@ extension CassandraClient {
         }
 
         private var _encryptor: AnyObject?
+
+        /// Registered encryption schemas.
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        public var encryptionSchemas: [String: EncryptionSchema] {
+            get { self._encryptionSchemas as! [String: EncryptionSchema] }
+            set { self._encryptionSchemas = newValue }
+        }
+
+        private var _encryptionSchemas: Any = [String: EncryptionSchema]()
+
+        /// Register an encryption schema for automatic context building during decoding.
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        public mutating func registerEncryptionSchema(_ schema: EncryptionSchema) {
+            var schemas = self.encryptionSchemas
+            schemas[schema.registryKey] = schema
+            self.encryptionSchemas = schemas
+        }
 
         /// Sets the cluster's consistency level. Default is `.localOne`.
         public var consistency: CassandraClient.Consistency?

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -873,6 +873,19 @@ extension CassandraClient.Column {
         )
         return Foundation.UUID(uuid: u)
     }
+
+    /// Decrypt column and return as `Date`.
+    public func decryptedDate(
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Foundation.Date? {
+        guard let data = try self.decryptedData(encryptor: encryptor, context: context) else { return nil }
+        guard data.count == 8 else {
+            throw CassandraClient.Error.decryptionError("Expected 8 bytes for Date, got \(data.count)")
+        }
+        let millis = data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
+        return Foundation.Date(timeIntervalSince1970: Double(millis) / 1000.0)
+    }
 }
 
 @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
@@ -983,5 +996,23 @@ extension CassandraClient.Row {
         context: CassandraClient.EncryptionContext
     ) throws -> Foundation.UUID? {
         try self.column(index)?.decryptedUUID(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by name and return as `Date`.
+    public func decryptedDate(
+        _ name: String,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Foundation.Date? {
+        try self.column(name)?.decryptedDate(encryptor: encryptor, context: context)
+    }
+
+    /// Decrypt column by index and return as `Date`.
+    public func decryptedDate(
+        _ index: Int,
+        encryptor: CassandraClient.Encryptor,
+        context: CassandraClient.EncryptionContext
+    ) throws -> Foundation.Date? {
+        try self.column(index)?.decryptedDate(encryptor: encryptor, context: context)
     }
 }

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -17,6 +17,37 @@ import Foundation
 import Logging
 import NIO
 
+// MARK: - Safe big-endian parsing helpers
+
+extension Data {
+    internal func parseInt32BigEndian() -> Int32? {
+        guard self.count >= 4 else { return nil }
+        var value = UInt32(0)
+        for byte in self.prefix(4) {
+            value = (value << 8) | UInt32(byte)
+        }
+        return Int32(bitPattern: value)
+    }
+
+    internal func parseInt64BigEndian() -> Int64? {
+        guard self.count >= 8 else { return nil }
+        var value = UInt64(0)
+        for byte in self.prefix(8) {
+            value = (value << 8) | UInt64(byte)
+        }
+        return Int64(bitPattern: value)
+    }
+
+    internal func parseUInt64BigEndian() -> UInt64? {
+        guard self.count >= 8 else { return nil }
+        var value = UInt64(0)
+        for byte in self.prefix(8) {
+            value = (value << 8) | UInt64(byte)
+        }
+        return value
+    }
+}
+
 public protocol PagingStateToken: ContiguousBytes {}
 
 extension CassandraClient {
@@ -830,7 +861,10 @@ extension CassandraClient.Column {
         guard data.count == 4 else {
             throw CassandraClient.Error.decryptionError("Expected 4 bytes for Int32, got \(data.count)")
         }
-        return data.withUnsafeBytes { $0.loadUnaligned(as: Int32.self).bigEndian }
+        guard let value = data.parseInt32BigEndian() else {
+            throw CassandraClient.Error.decryptionError("Expected 4 bytes for Int32, got \(data.count)")
+        }
+        return value
     }
 
     /// Decrypt column and return as `Int64`.
@@ -842,7 +876,10 @@ extension CassandraClient.Column {
         guard data.count == 8 else {
             throw CassandraClient.Error.decryptionError("Expected 8 bytes for Int64, got \(data.count)")
         }
-        return data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
+        guard let value = data.parseInt64BigEndian() else {
+            throw CassandraClient.Error.decryptionError("Expected 8 bytes for Int64, got \(data.count)")
+        }
+        return value
     }
 
     /// Decrypt column and return as `Double`.
@@ -854,7 +891,9 @@ extension CassandraClient.Column {
         guard data.count == 8 else {
             throw CassandraClient.Error.decryptionError("Expected 8 bytes for Double, got \(data.count)")
         }
-        let bits = data.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self).bigEndian }
+        guard let bits = data.parseUInt64BigEndian() else {
+            throw CassandraClient.Error.decryptionError("Expected 8 bytes for Double, got \(data.count)")
+        }
         return Double(bitPattern: bits)
     }
 
@@ -883,7 +922,9 @@ extension CassandraClient.Column {
         guard data.count == 8 else {
             throw CassandraClient.Error.decryptionError("Expected 8 bytes for Date, got \(data.count)")
         }
-        let millis = data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
+        guard let millis = data.parseInt64BigEndian() else {
+            throw CassandraClient.Error.decryptionError("Expected 8 bytes for Date, got \(data.count)")
+        }
         return Foundation.Date(timeIntervalSince1970: Double(millis) / 1000.0)
     }
 }

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -218,6 +218,13 @@ extension CassandraClient {
             } else if type == Encrypted<[UInt8]>.self {
                 let data = try decryptColumnData(key: key)
                 return Encrypted<[UInt8]>(Array(data)) as! T
+            } else if type == Encrypted<Foundation.Date>.self {
+                let data = try decryptColumnData(key: key)
+                guard data.count == 8 else {
+                    throw DecodingError.typeMismatch("Expected 8 bytes for Date, got \(data.count)")
+                }
+                let millis = data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
+                return Encrypted<Foundation.Date>(Foundation.Date(timeIntervalSince1970: Double(millis) / 1000.0)) as! T
             } else if type == [UInt8].self {
                 guard let value: [UInt8] = row.column(key.stringValue) else {
                     throw DecodingError.typeMismatch(

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -189,21 +189,27 @@ extension CassandraClient {
                 guard data.count == 4 else {
                     throw DecodingError.typeMismatch("Expected 4 bytes for Int32, got \(data.count)")
                 }
-                let value = data.withUnsafeBytes { $0.loadUnaligned(as: Int32.self).bigEndian }
+                guard let value = data.parseInt32BigEndian() else {
+                    throw DecodingError.typeMismatch("Expected 4 bytes for Int32, got \(data.count)")
+                }
                 return Encrypted<Int32>(value) as! T
             } else if type == Encrypted<Int64>.self {
                 let data = try decryptColumnData(key: key)
                 guard data.count == 8 else {
                     throw DecodingError.typeMismatch("Expected 8 bytes for Int64, got \(data.count)")
                 }
-                let value = data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
+                guard let value = data.parseInt64BigEndian() else {
+                    throw DecodingError.typeMismatch("Expected 8 bytes for Int64, got \(data.count)")
+                }
                 return Encrypted<Int64>(value) as! T
             } else if type == Encrypted<Double>.self {
                 let data = try decryptColumnData(key: key)
                 guard data.count == 8 else {
                     throw DecodingError.typeMismatch("Expected 8 bytes for Double, got \(data.count)")
                 }
-                let bits = data.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self).bigEndian }
+                guard let bits = data.parseUInt64BigEndian() else {
+                    throw DecodingError.typeMismatch("Expected 8 bytes for Double, got \(data.count)")
+                }
                 return Encrypted<Double>(Double(bitPattern: bits)) as! T
             } else if type == Encrypted<Foundation.UUID>.self {
                 let data = try decryptColumnData(key: key)
@@ -223,7 +229,9 @@ extension CassandraClient {
                 guard data.count == 8 else {
                     throw DecodingError.typeMismatch("Expected 8 bytes for Date, got \(data.count)")
                 }
-                let millis = data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).bigEndian }
+                guard let millis = data.parseInt64BigEndian() else {
+                    throw DecodingError.typeMismatch("Expected 8 bytes for Date, got \(data.count)")
+                }
                 return Encrypted<Foundation.Date>(Foundation.Date(timeIntervalSince1970: Double(millis) / 1000.0)) as! T
             } else if type == [UInt8].self {
                 guard let value: [UInt8] = row.column(key.stringValue) else {

--- a/Sources/CassandraClient/EncryptionConstants.swift
+++ b/Sources/CassandraClient/EncryptionConstants.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Centralised encryption string constants
+
+extension CassandraClient {
+    internal enum EncryptionLogKey {
+        static let keyName = "encryption.keyName"
+        static let column = "encryption.column"
+        static let keyRotationFrom = "encryption.keyRotation.from"
+        static let keyRotationTo = "encryption.keyRotation.to"
+        static let keysLoaded = "encryption.keysLoaded"
+        static let rowsDecrypted = "encryption.rowsDecrypted"
+    }
+
+    internal enum EncryptionMetric {
+        static let encryptTotal = "cassandra.encryption.encrypt.total"
+        static let encryptDuration = "cassandra.encryption.encrypt.duration"
+        static let decryptTotal = "cassandra.encryption.decrypt.total"
+        static let decryptDuration = "cassandra.encryption.decrypt.duration"
+        static let decryptFailures = "cassandra.encryption.decrypt.failures"
+        static let keyRotationTotal = "cassandra.encryption.key_rotation.total"
+        static let dimensionKeyName = "keyName"
+    }
+}

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -211,9 +211,10 @@ extension CassandraClient {
                 throw CassandraClient.Error.keyNotFound("Key '\(keyName)' not found in keyMap")
             }
             let rootKey = SymmetricKey(data: rootKeyData)
+            let kekSalt = self.salt.isEmpty ? Data() : self.salt + Data("-kek".utf8)
             let kek = HKDF<SHA512>.deriveKey(
                 inputKeyMaterial: rootKey,
-                salt: self.salt,
+                salt: kekSalt,
                 info: Data(context.utf8),
                 outputByteCount: 32
             )
@@ -229,9 +230,10 @@ extension CassandraClient {
             primaryKey: CassandraClient.PrimaryKey
         ) throws -> SymmetricKey {
             let kek = try self.deriveKEK(keyName: keyName, context: context)
+            let dekSalt = self.salt.isEmpty ? Data() : self.salt + Data("-dek".utf8)
             return HKDF<SHA512>.deriveKey(
                 inputKeyMaterial: kek,
-                salt: Data(),
+                salt: dekSalt,
                 info: primaryKey.data,
                 outputByteCount: 32
             )

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -180,12 +180,16 @@ extension CassandraClient {
     @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     struct KeysHolder {
         private var rootKeys: [String: Data]
-        private let salt: Data
+        let salt: Data
+        private let kekSalt: Data
+        private let dekSalt: Data
         private var kekCache: [String: SymmetricKey] = [:]
 
-        init(rootKeys: [String: Data], salt: Data = Data()) {
+        init(rootKeys: [String: Data], salt: Data) {
             self.rootKeys = rootKeys
             self.salt = salt
+            self.kekSalt = salt + Data("-KEK".utf8)
+            self.dekSalt = salt + Data("-DEK".utf8)
         }
 
         func hasKey(_ name: String) -> Bool {
@@ -211,10 +215,9 @@ extension CassandraClient {
                 throw CassandraClient.Error.keyNotFound("Key '\(keyName)' not found in keyMap")
             }
             let rootKey = SymmetricKey(data: rootKeyData)
-            let kekSalt = self.salt.isEmpty ? Data() : self.salt + Data("-kek".utf8)
             let kek = HKDF<SHA512>.deriveKey(
                 inputKeyMaterial: rootKey,
-                salt: kekSalt,
+                salt: self.kekSalt,
                 info: Data(context.utf8),
                 outputByteCount: 32
             )
@@ -230,10 +233,9 @@ extension CassandraClient {
             primaryKey: CassandraClient.PrimaryKey
         ) throws -> SymmetricKey {
             let kek = try self.deriveKEK(keyName: keyName, context: context)
-            let dekSalt = self.salt.isEmpty ? Data() : self.salt + Data("-dek".utf8)
             return HKDF<SHA512>.deriveKey(
                 inputKeyMaterial: kek,
-                salt: dekSalt,
+                salt: self.dekSalt,
                 info: primaryKey.data,
                 outputByteCount: 32
             )
@@ -298,16 +300,19 @@ extension CassandraClient {
         ///     Multiple keys can be provided to support key rotation — old keys decrypt existing data,
         ///     while `currentKeyName` selects which key is used for new encryptions.
         ///   - currentKeyName: The key name to use for new encryptions. Must exist in `keyMap`.
-        ///   - salt: Optional salt for HKDF key derivation. Defaults to empty.
+        ///   - salt: Salt for HKDF key derivation. Suffixed with `-KEK` and `-DEK` internally for domain separation.
         ///   - logger: Logger for encryption audit trail.
         /// - Throws: `CassandraClient.Error.encryptionConfigError` if the key map is empty,
-        ///   a key name is invalid, a key is not 32 bytes, or `currentKeyName` is not in the map.
+        ///   a key name is invalid, a key is not 32 bytes, the salt is empty, or `currentKeyName` is not in the map.
         public init(
             keyMap: [String: Data],
             currentKeyName: String,
-            salt: Data = Data(),
+            salt: Data,
             logger: Logger
         ) throws {
+            guard !salt.isEmpty else {
+                throw CassandraClient.Error.encryptionConfigError("salt must not be empty")
+            }
             guard !keyMap.isEmpty else {
                 throw CassandraClient.Error.encryptionConfigError("keyMap must not be empty")
             }
@@ -381,7 +386,7 @@ extension CassandraClient {
                     )
                 }
                 let added = newKeyMap.count - existingKeys.count
-                $0.keysHolder = KeysHolder(rootKeys: newKeyMap)
+                $0.keysHolder = KeysHolder(rootKeys: newKeyMap, salt: $0.keysHolder.salt)
                 return added
             }
             self.logger.info(
@@ -526,14 +531,25 @@ extension CassandraClient {
 
             let ciphertextAndTag = envelope[offset...]
 
-            let (dek, metrics) = try self.state.withLock {
-                let key = try $0.keysHolder.deriveDEK(
+            let dek: SymmetricKey
+            let metrics: EncryptorMetrics
+            do {
+                (dek, metrics) = try self.state.withLock {
+                    let key = try $0.keysHolder.deriveDEK(
+                        keyName: keyName,
+                        context: context.contextString,
+                        primaryKey: context.primaryKey
+                    )
+                    let m = $0.metrics(forKey: keyName)
+                    return (key, m)
+                }
+            } catch {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — key derivation error",
                     keyName: keyName,
-                    context: context.contextString,
-                    primaryKey: context.primaryKey
+                    column: context.column
                 )
-                let m = $0.metrics(forKey: keyName)
-                return (key, m)
+                throw error
             }
 
             let nonce: AES.GCM.Nonce

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -277,12 +277,12 @@ extension CassandraClient {
             let decryptFailures: Counter
 
             init(keyName: String) {
-                let dims = [("keyName", keyName)]
-                self.encryptTotal = Counter(label: "cassandra.encryption.encrypt.total", dimensions: dims)
-                self.encryptDuration = Timer(label: "cassandra.encryption.encrypt.duration", dimensions: dims)
-                self.decryptTotal = Counter(label: "cassandra.encryption.decrypt.total", dimensions: dims)
-                self.decryptDuration = Timer(label: "cassandra.encryption.decrypt.duration", dimensions: dims)
-                self.decryptFailures = Counter(label: "cassandra.encryption.decrypt.failures", dimensions: dims)
+                let dims = [(EncryptionMetric.dimensionKeyName, keyName)]
+                self.encryptTotal = Counter(label: EncryptionMetric.encryptTotal, dimensions: dims)
+                self.encryptDuration = Timer(label: EncryptionMetric.encryptDuration, dimensions: dims)
+                self.decryptTotal = Counter(label: EncryptionMetric.decryptTotal, dimensions: dims)
+                self.decryptDuration = Timer(label: EncryptionMetric.decryptDuration, dimensions: dims)
+                self.decryptFailures = Counter(label: EncryptionMetric.decryptFailures, dimensions: dims)
             }
         }
 
@@ -297,14 +297,14 @@ extension CassandraClient {
         ///     while `currentKeyName` selects which key is used for new encryptions.
         ///   - currentKeyName: The key name to use for new encryptions. Must exist in `keyMap`.
         ///   - salt: Optional salt for HKDF key derivation. Defaults to empty.
-        ///   - logger: Logger for encryption audit trail. Defaults to a logger labeled "cassandra.encryption".
+        ///   - logger: Logger for encryption audit trail.
         /// - Throws: `CassandraClient.Error.encryptionConfigError` if the key map is empty,
         ///   a key name is invalid, a key is not 32 bytes, or `currentKeyName` is not in the map.
         public init(
             keyMap: [String: Data],
             currentKeyName: String,
             salt: Data = Data(),
-            logger: Logger = Logger(label: "cassandra.encryption")
+            logger: Logger
         ) throws {
             guard !keyMap.isEmpty else {
                 throw CassandraClient.Error.encryptionConfigError("keyMap must not be empty")
@@ -343,13 +343,14 @@ extension CassandraClient {
                 return old
             }
             self.logger.info(
-                "Key rotation",
+                "Cassandra client key rotated",
                 metadata: [
-                    "encryption.keyRotation.from": "\(oldName)",
-                    "encryption.keyRotation.to": "\(name)",
+                    EncryptionLogKey.keyRotationFrom: "\(oldName)",
+                    EncryptionLogKey.keyRotationTo: "\(name)",
                 ]
             )
-            Counter(label: "cassandra.encryption.key_rotation.total", dimensions: [("keyName", name)]).increment()
+            Counter(label: EncryptionMetric.keyRotationTotal, dimensions: [(EncryptionMetric.dimensionKeyName, name)])
+                .increment()
         }
 
         /// Replace the entire key map. Existing keys cannot be removed or changed.
@@ -384,7 +385,7 @@ extension CassandraClient {
             self.logger.info(
                 "Keys loaded",
                 metadata: [
-                    "encryption.keysLoaded": "\(newKeyCount)"
+                    EncryptionLogKey.keysLoaded: "\(newKeyCount)"
                 ]
             )
         }
@@ -433,8 +434,8 @@ extension CassandraClient {
             self.logger.debug(
                 "Encrypted column",
                 metadata: [
-                    "encryption.keyName": "\(keyName)",
-                    "encryption.column": "\(context.column)",
+                    EncryptionLogKey.keyName: "\(keyName)",
+                    EncryptionLogKey.column: "\(context.column)",
                 ]
             )
             metrics.encryptTotal.increment()
@@ -570,8 +571,8 @@ extension CassandraClient {
                 self.logger.debug(
                     "Decrypted column",
                     metadata: [
-                        "encryption.keyName": "\(keyName)",
-                        "encryption.column": "\(context.column)",
+                        EncryptionLogKey.keyName: "\(keyName)",
+                        EncryptionLogKey.column: "\(context.column)",
                     ]
                 )
                 metrics.decryptTotal.increment()
@@ -597,14 +598,17 @@ extension CassandraClient {
             self.logger.warning(
                 "\(message)",
                 metadata: [
-                    "encryption.keyName": "\(keyName)",
-                    "encryption.column": "\(column)",
+                    EncryptionLogKey.keyName: "\(keyName)",
+                    EncryptionLogKey.column: "\(column)",
                 ]
             )
             if let metrics = metrics {
                 metrics.decryptFailures.increment()
             } else {
-                Counter(label: "cassandra.encryption.decrypt.failures", dimensions: [("keyName", keyName)]).increment()
+                Counter(
+                    label: EncryptionMetric.decryptFailures,
+                    dimensions: [(EncryptionMetric.dimensionKeyName, keyName)]
+                ).increment()
             }
         }
 

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -13,7 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+import Dispatch
 import Foundation
+import Logging
+import Metrics
 import Synchronization
 
 // MARK: - EncryptionContext
@@ -79,6 +82,11 @@ extension CassandraClient {
         internal let data: Data
 
         public init(from components: CassandraClient.KeyComponent...) {
+            self.init(from: components)
+        }
+
+        /// Internal init from an array of key components (variadic can't be forwarded).
+        internal init(from components: [CassandraClient.KeyComponent]) {
             var result = Data()
             for component in components {
                 var length = UInt32(component.bytes.count).bigEndian
@@ -248,9 +256,38 @@ extension CassandraClient {
         private struct State {
             var currentKeyName: String
             var keysHolder: KeysHolder
+            var metricsCache: [String: EncryptorMetrics] = [:]
+
+            mutating func metrics(forKey keyName: String) -> EncryptorMetrics {
+                if let cached = metricsCache[keyName] {
+                    return cached
+                }
+                let m = EncryptorMetrics(keyName: keyName)
+                metricsCache[keyName] = m
+                return m
+            }
+        }
+
+        /// Cached metric handles for a single key name, avoiding per-call allocation.
+        private struct EncryptorMetrics {
+            let encryptTotal: Counter
+            let encryptDuration: Timer
+            let decryptTotal: Counter
+            let decryptDuration: Timer
+            let decryptFailures: Counter
+
+            init(keyName: String) {
+                let dims = [("keyName", keyName)]
+                self.encryptTotal = Counter(label: "cassandra.encryption.encrypt.total", dimensions: dims)
+                self.encryptDuration = Timer(label: "cassandra.encryption.encrypt.duration", dimensions: dims)
+                self.decryptTotal = Counter(label: "cassandra.encryption.decrypt.total", dimensions: dims)
+                self.decryptDuration = Timer(label: "cassandra.encryption.decrypt.duration", dimensions: dims)
+                self.decryptFailures = Counter(label: "cassandra.encryption.decrypt.failures", dimensions: dims)
+            }
         }
 
         private let state: Mutex<State>
+        private let logger: Logger
 
         /// Create an encryptor with the given key map and current key name.
         ///
@@ -260,9 +297,15 @@ extension CassandraClient {
         ///     while `currentKeyName` selects which key is used for new encryptions.
         ///   - currentKeyName: The key name to use for new encryptions. Must exist in `keyMap`.
         ///   - salt: Optional salt for HKDF key derivation. Defaults to empty.
+        ///   - logger: Logger for encryption audit trail. Defaults to a logger labeled "cassandra.encryption".
         /// - Throws: `CassandraClient.Error.encryptionConfigError` if the key map is empty,
         ///   a key name is invalid, a key is not 32 bytes, or `currentKeyName` is not in the map.
-        public init(keyMap: [String: Data], currentKeyName: String, salt: Data = Data()) throws {
+        public init(
+            keyMap: [String: Data],
+            currentKeyName: String,
+            salt: Data = Data(),
+            logger: Logger = Logger(label: "cassandra.encryption")
+        ) throws {
             guard !keyMap.isEmpty else {
                 throw CassandraClient.Error.encryptionConfigError("keyMap must not be empty")
             }
@@ -274,6 +317,7 @@ extension CassandraClient {
                     "currentKeyName '\(currentKeyName)' not found in keyMap"
                 )
             }
+            self.logger = logger
             self.state = Mutex(
                 State(
                     currentKeyName: currentKeyName,
@@ -290,12 +334,22 @@ extension CassandraClient {
         /// Set the key name used for new encryptions. The key must already exist in the key map.
         public func setCurrentKeyName(_ name: String) throws {
             try Self.validateKeyName(name)
-            try self.state.withLock {
+            let oldName = try self.state.withLock {
                 guard $0.keysHolder.hasKey(name) else {
                     throw CassandraClient.Error.keyNotFound("Key '\(name)' not found in keyMap")
                 }
+                let old = $0.currentKeyName
                 $0.currentKeyName = name
+                return old
             }
+            self.logger.info(
+                "Key rotation",
+                metadata: [
+                    "encryption.keyRotation.from": "\(oldName)",
+                    "encryption.keyRotation.to": "\(name)",
+                ]
+            )
+            Counter(label: "cassandra.encryption.key_rotation.total", dimensions: [("keyName", name)]).increment()
         }
 
         /// Replace the entire key map. Existing keys cannot be removed or changed.
@@ -304,8 +358,9 @@ extension CassandraClient {
             for (name, key) in newKeyMap {
                 try Self.validateKey(name: name, secret: key)
             }
-            try self.state.withLock {
-                for (existingName, existingKey) in $0.keysHolder.allKeys {
+            let newKeyCount = try self.state.withLock {
+                let existingKeys = $0.keysHolder.allKeys
+                for (existingName, existingKey) in existingKeys {
                     guard let newKey = newKeyMap[existingName] else {
                         throw CassandraClient.Error.encryptionConfigError(
                             "Cannot remove existing key '\(existingName)'"
@@ -322,8 +377,16 @@ extension CassandraClient {
                         "currentKeyName '\($0.currentKeyName)' not found in new keyMap"
                     )
                 }
+                let added = newKeyMap.count - existingKeys.count
                 $0.keysHolder = KeysHolder(rootKeys: newKeyMap)
+                return added
             }
+            self.logger.info(
+                "Keys loaded",
+                metadata: [
+                    "encryption.keysLoaded": "\(newKeyCount)"
+                ]
+            )
         }
 
         /// Encrypt plaintext data for the given context.
@@ -333,14 +396,16 @@ extension CassandraClient {
         /// The envelope is self-describing — it contains the key name and algorithm used,
         /// so `decrypt` can process data encrypted with any key in the key map.
         internal func encrypt(_ data: Data, context: EncryptionContext) throws -> Data {
-            let (keyName, dek) = try self.state.withLock {
+            let start = DispatchTime.now()
+            let (keyName, dek, metrics) = try self.state.withLock {
                 let name = $0.currentKeyName
                 let key = try $0.keysHolder.deriveDEK(
                     keyName: name,
                     context: context.contextString,
                     primaryKey: context.primaryKey
                 )
-                return (name, key)
+                let m = $0.metrics(forKey: name)
+                return (name, key, m)
             }
 
             let keyNameBytes = Data(keyName.utf8)
@@ -363,6 +428,18 @@ extension CassandraClient {
             envelope.append(contentsOf: sealed.nonce)
             envelope.append(sealed.ciphertext)
             envelope.append(sealed.tag)
+
+            let duration = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
+            self.logger.debug(
+                "Encrypted column",
+                metadata: [
+                    "encryption.keyName": "\(keyName)",
+                    "encryption.column": "\(context.column)",
+                ]
+            )
+            metrics.encryptTotal.increment()
+            metrics.encryptDuration.recordNanoseconds(Int64(duration))
+
             return envelope
         }
 
@@ -372,9 +449,15 @@ extension CassandraClient {
         /// using the key from the envelope (not `currentKeyName`), and decrypts.
         /// This allows data encrypted with any key in the key map to be decrypted.
         internal func decrypt(_ envelope: Data, context: EncryptionContext) throws -> Data {
+            let start = DispatchTime.now()
             // Minimum envelope: version(1) + algorithm(1) + keyNameLen(1) + keyName(1+) + nonce(12) + tag(16)
             let minSize = 1 + 1 + 1 + 1 + Self.nonceSize + 16
             guard envelope.count >= minSize else {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — envelope too small",
+                    keyName: "unavailable",
+                    column: context.column
+                )
                 throw CassandraClient.Error.decryptionError(
                     "Envelope too small: \(envelope.count) bytes, minimum \(minSize)"
                 )
@@ -385,28 +468,53 @@ extension CassandraClient {
             let version = envelope[offset]
             offset += 1
             guard version == Self.envelopeVersion else {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — unsupported envelope version",
+                    keyName: "unavailable",
+                    column: context.column
+                )
                 throw CassandraClient.Error.decryptionError("Unsupported envelope version: \(version)")
             }
 
             let algorithm = envelope[offset]
             offset += 1
             guard algorithm == Self.algorithmHKDFDerivedAESGCM else {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — unsupported algorithm",
+                    keyName: "unavailable",
+                    column: context.column
+                )
                 throw CassandraClient.Error.decryptionError("Unsupported algorithm: \(algorithm)")
             }
 
             let keyNameLen = Int(envelope[offset])
             offset += 1
             guard keyNameLen > 0, offset + keyNameLen <= envelope.count else {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — invalid key name length",
+                    keyName: "unavailable",
+                    column: context.column
+                )
                 throw CassandraClient.Error.decryptionError("Invalid key name length: \(keyNameLen)")
             }
 
             let keyNameBytes = envelope[offset..<offset + keyNameLen]
             offset += keyNameLen
             guard let keyName = String(data: Data(keyNameBytes), encoding: .utf8) else {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — invalid key name encoding",
+                    keyName: "unavailable",
+                    column: context.column
+                )
                 throw CassandraClient.Error.decryptionError("Invalid key name encoding")
             }
 
             guard envelope.count - offset >= Self.nonceSize + 16 else {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — envelope too small for nonce + ciphertext + tag",
+                    keyName: keyName,
+                    column: context.column
+                )
                 throw CassandraClient.Error.decryptionError("Envelope too small for nonce + ciphertext + tag")
             }
 
@@ -415,18 +523,26 @@ extension CassandraClient {
 
             let ciphertextAndTag = envelope[offset...]
 
-            let dek = try self.state.withLock {
-                try $0.keysHolder.deriveDEK(
+            let (dek, metrics) = try self.state.withLock {
+                let key = try $0.keysHolder.deriveDEK(
                     keyName: keyName,
                     context: context.contextString,
                     primaryKey: context.primaryKey
                 )
+                let m = $0.metrics(forKey: keyName)
+                return (key, m)
             }
 
             let nonce: AES.GCM.Nonce
             do {
                 nonce = try AES.GCM.Nonce(data: nonceData)
             } catch {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — invalid nonce",
+                    keyName: keyName,
+                    column: context.column,
+                    metrics: metrics
+                )
                 throw CassandraClient.Error.decryptionError("Invalid nonce: \(error)")
             }
 
@@ -438,14 +554,57 @@ extension CassandraClient {
                     tag: ciphertextAndTag.suffix(16)
                 )
             } catch {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — invalid sealed box",
+                    keyName: keyName,
+                    column: context.column,
+                    metrics: metrics
+                )
                 throw CassandraClient.Error.decryptionError("Invalid sealed box: \(error)")
             }
 
             let aad = Data(context.contextString.utf8)
             do {
-                return try AES.GCM.open(sealedBox, using: dek, authenticating: aad)
+                let plaintext = try AES.GCM.open(sealedBox, using: dek, authenticating: aad)
+                let duration = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
+                self.logger.debug(
+                    "Decrypted column",
+                    metadata: [
+                        "encryption.keyName": "\(keyName)",
+                        "encryption.column": "\(context.column)",
+                    ]
+                )
+                metrics.decryptTotal.increment()
+                metrics.decryptDuration.recordNanoseconds(Int64(duration))
+                return plaintext
             } catch {
+                self.onDecryptionFailure(
+                    message: "Decryption failed — possible data corruption or tampering",
+                    keyName: keyName,
+                    column: context.column,
+                    metrics: metrics
+                )
                 throw CassandraClient.Error.decryptionError("AES-GCM authentication failed: \(error)")
+            }
+        }
+
+        private func onDecryptionFailure(
+            message: String,
+            keyName: String,
+            column: String,
+            metrics: EncryptorMetrics? = nil
+        ) {
+            self.logger.warning(
+                "\(message)",
+                metadata: [
+                    "encryption.keyName": "\(keyName)",
+                    "encryption.column": "\(column)",
+                ]
+            )
+            if let metrics = metrics {
+                metrics.decryptFailures.increment()
+            } else {
+                Counter(label: "cassandra.encryption.decrypt.failures", dimensions: [("keyName", keyName)]).increment()
             }
         }
 
@@ -477,6 +636,74 @@ extension CassandraClient {
 
 @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Encryptor: Sendable {}
+
+// MARK: - KeyColumnType
+
+extension CassandraClient {
+    /// Type tag for key columns used in column registration.
+    ///
+    /// New column types can be added without breaking existing consumers.
+    public struct KeyColumnType: Sendable, Equatable {
+        internal let rawValue: String
+
+        public static let string = KeyColumnType(rawValue: "string")
+        public static let uuid = KeyColumnType(rawValue: "uuid")
+        public static let int32 = KeyColumnType(rawValue: "int32")
+        public static let int64 = KeyColumnType(rawValue: "int64")
+        public static let data = KeyColumnType(rawValue: "data")
+        public static let date = KeyColumnType(rawValue: "date")
+    }
+}
+
+// MARK: - EncryptionSchema
+
+extension CassandraClient {
+    /// Describes one table's encrypted column layout for automatic context building.
+    ///
+    /// Register a schema via ``Configuration/registerEncryptionSchema(_:)`` so the decoder
+    /// can build ``EncryptionContext/Base`` per row without an `encryptionContextBuilder` closure.
+    public struct EncryptionSchema: Sendable {
+        /// A column in the table's primary key, used to build the PrimaryKey for DEK derivation.
+        public struct KeyColumn: Sendable {
+            public let name: String
+            public let type: KeyColumnType
+
+            public init(name: String, type: KeyColumnType) {
+                self.name = name
+                self.type = type
+            }
+        }
+
+        public let keyspace: String
+        public let table: String
+        public let keyColumns: [KeyColumn]
+        /// Names of all encrypted regular columns in the table.
+        public let encryptedColumns: Set<String>
+
+        public init(
+            keyspace: String,
+            table: String,
+            keyColumns: [KeyColumn],
+            encryptedColumns: Set<String> = []
+        ) throws {
+            let keyColumnNames = Set(keyColumns.map(\.name))
+            let overlap = keyColumnNames.intersection(encryptedColumns)
+            guard overlap.isEmpty else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Key columns cannot also be encrypted columns: \(overlap.sorted())"
+                )
+            }
+            self.keyspace = keyspace
+            self.table = table
+            self.keyColumns = keyColumns
+            self.encryptedColumns = encryptedColumns
+        }
+
+        /// Registry lookup key: "keyspace.table".
+        internal var registryKey: String { "\(self.keyspace).\(self.table)" }
+
+    }
+}
 
 // MARK: - CodingUserInfoKey extensions for encryption
 

--- a/Sources/CassandraClient/Session+Encryption.swift
+++ b/Sources/CassandraClient/Session+Encryption.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// MARK: - Encryption helpers for CassandraSession
+
+extension CassandraSession {
+    /// Resolve "table" or "keyspace.table" into the registry lookup key and schema.
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    internal func resolveSchema(
+        tableName: String
+    ) throws -> CassandraClient.EncryptionSchema {
+        let keyspace: String
+        let table: String
+        if let dotIndex = tableName.firstIndex(of: ".") {
+            keyspace = String(tableName[tableName.startIndex..<dotIndex])
+            table = String(tableName[tableName.index(after: dotIndex)...])
+        } else {
+            guard let sessionKeyspace = self.keyspace else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "encryptionTable '\(tableName)' has no keyspace qualifier and session has no default keyspace"
+                )
+            }
+            keyspace = sessionKeyspace
+            table = tableName
+        }
+        let registryKey = "\(keyspace).\(table)"
+        guard let schema = self.encryptionSchemas[registryKey] else {
+            throw CassandraClient.Error.encryptionConfigError(
+                "No EncryptionSchema registered for '\(registryKey)'"
+            )
+        }
+        return schema
+    }
+
+    /// Validate that encrypted parameter values are bound to columns registered as encrypted.
+    ///
+    /// For each `.encryptedXxx` value, extracts the column name from its `EncryptionContext`
+    /// and checks that column is in the schema's `encryptedColumns` set.
+    ///
+    /// This catches: encrypted values bound to wrong/unregistered columns (typos, copy-paste errors).
+    /// It does NOT catch: plaintext values bound to encrypted columns — that requires prepared statement
+    /// metadata to map positional parameters to column names.
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    func validateEncryptionBindings(
+        parameters: [CassandraClient.Statement.Value],
+        options: CassandraClient.Statement.Options
+    ) throws {
+        guard let tableName = options.encryptionTable else { return }
+        let schema = try self.resolveSchema(tableName: tableName)
+
+        for value in parameters {
+            guard value.isEncrypted, let columnName = value.encryptedColumnName else { continue }
+            guard schema.encryptedColumns.contains(columnName) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(columnName)' is not registered as encrypted but received an encrypted value"
+                )
+            }
+        }
+    }
+
+    /// Build an EncryptionContext.Base from a row using the registered schema.
+    /// Reads PK and CK columns as-is from the row, then constructs the full primaryKey.
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    internal func buildEncryptionContext(
+        row: CassandraClient.Row,
+        tableName: String,
+        encryptor: CassandraClient.Encryptor
+    ) throws -> CassandraClient.EncryptionContext.Base {
+        let schema = try self.resolveSchema(tableName: tableName)
+
+        var components: [CassandraClient.KeyComponent] = []
+        for col in schema.keyColumns {
+            let component = try Self.readKeyComponent(from: row, name: col.name, type: col.type)
+            components.append(component)
+        }
+
+        let primaryKey = CassandraClient.PrimaryKey(from: components)
+
+        return CassandraClient.EncryptionContext.Base(
+            keyspace: schema.keyspace,
+            table: schema.table,
+            primaryKey: primaryKey
+        )
+    }
+
+    /// Read a cleartext column value from a row and return it as a KeyComponent.
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    private static func readKeyComponent(
+        from row: CassandraClient.Row,
+        name: String,
+        type: CassandraClient.KeyColumnType
+    ) throws -> CassandraClient.KeyComponent {
+        if type == .string {
+            guard let value: String = row.column(name) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(name)' not found or not a string in row"
+                )
+            }
+            return .string(value)
+        } else if type == .uuid {
+            guard let value: Foundation.UUID = row.column(name) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(name)' not found or not a UUID in row"
+                )
+            }
+            return .uuid(value)
+        } else if type == .int32 {
+            guard let value: Int32 = row.column(name) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(name)' not found or not an Int32 in row"
+                )
+            }
+            return .int32(value)
+        } else if type == .int64 {
+            guard let value: Int64 = row.column(name) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(name)' not found or not an Int64 in row"
+                )
+            }
+            return .int64(value)
+        } else if type == .data {
+            guard let value: [UInt8] = row.column(name) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(name)' not found or not bytes in row"
+                )
+            }
+            return .data(Data(value))
+        } else if type == .date {
+            guard let value: Int64 = row.column(name) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(name)' not found or not a timestamp in row"
+                )
+            }
+            return .date(Date(timeIntervalSince1970: Double(value) / 1000.0))
+        } else {
+            throw CassandraClient.Error.encryptionConfigError(
+                "Unsupported key column type '\(type.rawValue)' for column '\(name)'"
+            )
+        }
+    }
+}

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -14,6 +14,7 @@
 
 @_implementationOnly import CDataStaxDriver
 import Dispatch
+import Foundation
 import Logging
 import NIO
 import NIOConcurrencyHelpers
@@ -26,6 +27,13 @@ public protocol CassandraSession {
     /// Encryptor for transparent column encryption.
     @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     var encryptor: CassandraClient.Encryptor? { get }
+
+    /// Registered encrypted column schemas for automatic context building.
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    var encryptionSchemas: [String: CassandraClient.EncryptionSchema] { get }
+
+    /// The default keyspace for this session, used to resolve unqualified table names.
+    var keyspace: String? { get }
 
     /// Execute a prepared statement.
     ///
@@ -103,7 +111,20 @@ public protocol CassandraSession {
     func getMetrics() -> CassandraMetrics
 }
 
+private let encryptionLogger = Logger(label: "cassandra.encryption")
+
 extension CassandraSession {
+    private func logDecryptedRows(count: Int, options: CassandraClient.Statement.Options, logger: Logger?) {
+        if count > 0, options.hasEncryptionOptions {
+            (logger ?? encryptionLogger).debug(
+                "Decrypted rows",
+                metadata: [
+                    "encryption.rowsDecrypted": "\(count)"
+                ]
+            )
+        }
+    }
+
     /// Execute a prepared statement.
     ///
     /// **All** rows are returned.
@@ -128,11 +149,26 @@ extension CassandraSession {
         row: CassandraClient.Row,
         options: CassandraClient.Statement.Options
     ) throws -> CassandraClient.RowDecoder {
-        if let builder = options.encryptionContextBuilder,
-            #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
+            let builder = options.encryptionContextBuilder,
             let encryptor = self.encryptor
         {
             let ctx = try builder(row)
+            return CassandraClient.RowDecoder(
+                row: row,
+                encryptor: encryptor,
+                rowContext: ctx
+            )
+        }
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
+            let tableName = options.encryptionTable,
+            let encryptor = self.encryptor
+        {
+            let ctx = try self.buildEncryptionContext(
+                row: row,
+                tableName: tableName,
+                encryptor: encryptor
+            )
             return CassandraClient.RowDecoder(
                 row: row,
                 encryptor: encryptor,
@@ -149,7 +185,8 @@ extension CassandraSession {
         parameters: [CassandraClient.Statement.Value],
         options: CassandraClient.Statement.Options
     ) throws -> CassandraClient.Statement {
-        try CassandraClient.Statement(
+        try self.validateEncryptionBindings(parameters: parameters, options: options)
+        return try CassandraClient.Statement(
             query: query,
             parameters: parameters,
             options: options,
@@ -199,9 +236,11 @@ extension CassandraSession {
     ) -> EventLoopFuture<[T]> {
         self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger)
             .flatMapThrowing { rows in
-                try rows.map { row in
+                let result = try rows.map { row in
                     try T(from: self.makeDecoder(row: row, options: options))
                 }
+                self.logDecryptedRows(count: result.count, options: options, logger: logger)
+                return result
             }
     }
 
@@ -269,6 +308,15 @@ extension CassandraClient {
         @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: CassandraClient.Encryptor? {
             self.configuration.encryptor
+        }
+
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        public var encryptionSchemas: [String: CassandraClient.EncryptionSchema] {
+            self.configuration.encryptionSchemas
+        }
+
+        public var keyspace: String? {
+            self.configuration.keyspace
         }
 
         private let configuration: Configuration
@@ -502,9 +550,11 @@ extension CassandraSession {
             options: options,
             logger: logger
         )
-        return try rows.map { row in
+        let result = try rows.map { row in
             try T(from: self.makeDecoder(row: row, options: options))
         }
+        self.logDecryptedRows(count: result.count, options: options, logger: logger)
+        return result
     }
 
     /// Query large data-sets where using an interator helps control memory usage.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -119,7 +119,7 @@ extension CassandraSession {
             (logger ?? encryptionLogger).debug(
                 "Decrypted rows",
                 metadata: [
-                    "encryption.rowsDecrypted": "\(count)"
+                    CassandraClient.EncryptionLogKey.rowsDecrypted: "\(count)"
                 ]
             )
         }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -432,6 +432,10 @@ extension CassandraClient {
             /// Use `"table"` (combined with the session keyspace) or `"keyspace.table"` for cross-keyspace queries.
             /// When set and a matching ``EncryptionSchema`` is registered, the decoder builds
             /// ``EncryptionContext/Base`` automatically. ``encryptionContextBuilder`` takes precedence if both are set.
+            ///
+            /// - Important: The query must SELECT all primary key columns registered in the schema.
+            ///   The decoder reads these columns from each result row to build the ``PrimaryKey`` for key derivation.
+            ///   Omitting a key column will cause decryption to fail at runtime.
             @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
             public var encryptionTable: String? {
                 get { self._encryptionTable }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -40,6 +40,10 @@ extension CassandraClient {
             self._encryptor = _encryptor
             self.rawPointer = cass_statement_new(query, parameters.count)
 
+            try self.bindParameters()
+        }
+
+        private func bindParameters() throws {
             for (index, parameter) in parameters.enumerated() {
                 let result: CassError
                 switch parameter {
@@ -131,6 +135,13 @@ extension CassandraClient {
                     ])
                     result = try self.bindEncrypted(
                         plaintext,
+                        context: context,
+                        at: index
+                    )
+                case .encryptedDate(let wrapped, let context):
+                    var bigEndian = Int64(wrapped.value.timeIntervalSince1970 * 1000).bigEndian
+                    result = try self.bindEncrypted(
+                        Data(bytes: &bigEndian, count: 8),
                         context: context,
                         at: index
                     )
@@ -282,6 +293,7 @@ extension CassandraClient {
             case encryptedInt64(Encrypted<Int64>, context: EncryptionContext)
             case encryptedDouble(Encrypted<Double>, context: EncryptionContext)
             case encryptedUUID(Encrypted<Foundation.UUID>, context: EncryptionContext)
+            case encryptedDate(Encrypted<Foundation.Date>, context: EncryptionContext)
 
             case int8Array([Int8])
             case int16Array([Int16])
@@ -360,6 +372,34 @@ extension CassandraClient {
             case timeuuidBoolMap([TimeBasedUUID: Bool])
             case timeuuidStringMap([TimeBasedUUID: String])
             case timeuuidUUIDMap([TimeBasedUUID: Foundation.UUID])
+
+            /// Whether this value is an encrypted regular column value (`.encryptedXxx` cases).
+            internal var isEncrypted: Bool {
+                switch self {
+                case .encryptedString, .encryptedBytes, .encryptedInt32,
+                    .encryptedInt64, .encryptedDouble, .encryptedUUID,
+                    .encryptedDate:
+                    return true
+                default:
+                    return false
+                }
+            }
+
+            /// The column name from the encryption context, if this is an encrypted value.
+            internal var encryptedColumnName: String? {
+                switch self {
+                case .encryptedString(_, let ctx),
+                    .encryptedBytes(_, let ctx),
+                    .encryptedInt32(_, let ctx),
+                    .encryptedInt64(_, let ctx),
+                    .encryptedDouble(_, let ctx),
+                    .encryptedUUID(_, let ctx),
+                    .encryptedDate(_, let ctx):
+                    return ctx.column
+                default:
+                    return nil
+                }
+            }
         }
 
         public struct Options: CustomStringConvertible {
@@ -368,11 +408,40 @@ extension CassandraClient {
             /// Sets the statement's request timeout in milliseconds. Default is `CASS_UINT64_MAX`
             public var requestTimeout: UInt64?
 
+            /// Type-erased backing store for ``encryptionContextBuilder``.
+            private var _encryptionContextBuilder: Any?
+
             /// Closure that extracts encryption context from each row during Codable decoding.
+            @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
             public var encryptionContextBuilder:
                 (
                     (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
                 )?
+            {
+                get {
+                    self._encryptionContextBuilder
+                        as? (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
+                }
+                set { self._encryptionContextBuilder = newValue }
+            }
+
+            /// Backing store for ``encryptionTable``.
+            private var _encryptionTable: String?
+
+            /// Table name for column-registration-based automatic decryption.
+            /// Use `"table"` (combined with the session keyspace) or `"keyspace.table"` for cross-keyspace queries.
+            /// When set and a matching ``EncryptionSchema`` is registered, the decoder builds
+            /// ``EncryptionContext/Base`` automatically. ``encryptionContextBuilder`` takes precedence if both are set.
+            @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+            public var encryptionTable: String? {
+                get { self._encryptionTable }
+                set { self._encryptionTable = newValue }
+            }
+
+            /// Whether any encryption options are set (context builder or table name).
+            internal var hasEncryptionOptions: Bool {
+                self._encryptionContextBuilder != nil || self._encryptionTable != nil
+            }
 
             public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {
                 self.consistency = consistency

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -50,7 +50,8 @@ final class EncryptionIntegrationTests: XCTestCase {
             self.encryptor = try CassandraClient.Encryptor(
                 keyMap: [keyName: keyData],
                 currentKeyName: keyName,
-                salt: Data("integration-test-salt".utf8)
+                salt: Data("integration-test-salt".utf8),
+                logger: Logger(label: "test.encryptor")
             )
         )
 

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -663,7 +663,6 @@ final class EncryptionIntegrationTests: XCTestCase {
     /// encryptionTable set but no matching schema registered → throws encryptionConfigError.
     func testColumnRegistrationMissingSchema() throws {
         let tableName = "test_colreg_missing_\(DispatchTime.now().uptimeNanoseconds)"
-        let keyspace = self.configuration.keyspace!
 
         // Create the table and insert a row so the decoder is invoked
         do {

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -77,6 +77,14 @@ final class EncryptionIntegrationTests: XCTestCase {
         self.cassandraClient = nil
     }
 
+    /// Shutdown and recreate the client after configuration changes (e.g. registering schemas).
+    private func recreateClient() {
+        XCTAssertNoThrow(try self.cassandraClient.shutdown())
+        var logger = Logger(label: "test")
+        logger.logLevel = .debug
+        self.cassandraClient = CassandraClient(configuration: self.configuration, logger: logger)
+    }
+
     // MARK: - Write path + manual read path
 
     /// Insert an encrypted string via Statement, read it back using Column.decryptedString.
@@ -521,6 +529,220 @@ final class EncryptionIntegrationTests: XCTestCase {
         XCTAssertEqual(results[0].secret_name.value, name)
         XCTAssertEqual(results[0].secret_age.value, age)
     }
+
+    // MARK: - Column registration
+
+    /// No clustering key, one encrypted regular column.
+    /// Verify decryption works without an encryptionContextBuilder — uses column registration instead.
+    func testColumnRegistrationSimple() throws {
+        let tableName = "test_colreg_simple_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        // Create table using a session from the current client
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        // Register the schema
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        // Recreate client with updated configuration
+        self.recreateClient()
+
+        let userId = "user-reg"
+        let secretValue = "registered-secret"
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string(userId))
+        )
+
+        // Write with explicit context using a new session
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        try session.run(
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: baseContext.forColumn("secret")),
+            ]
+        ).wait()
+
+        // Read via column registration — no encryptionContextBuilder needed
+        var readOptions = CassandraClient.Statement.Options()
+        readOptions.encryptionTable = tableName
+
+        let results: [UserWithSecret] = try self.cassandraClient.query(
+            "select user_id, secret from \(tableName) where user_id = ?",
+            parameters: [.string(userId)],
+            options: readOptions
+        ).wait()
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].user_id, userId)
+        XCTAssertEqual(results[0].secret.value, secretValue)
+    }
+
+    /// Both encryptionContextBuilder and encryptionTable are set — builder wins.
+    func testColumnRegistrationBuilderTakesPrecedence() throws {
+        let tableName = "test_colreg_prec_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        // Create table using a session from the current client
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        // Register schema and recreate client
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        self.recreateClient()
+
+        let userId = "user-prec"
+        let secretValue = "precedence-secret"
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string(userId))
+        )
+
+        // Insert using the new client's session
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        try session.run(
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: baseContext.forColumn("secret")),
+            ]
+        ).wait()
+
+        // Set both builder and encryptionTable — builder should win
+        var readOptions = CassandraClient.Statement.Options()
+        readOptions.encryptionTable = tableName
+        readOptions.encryptionContextBuilder = { row in
+            guard let uid: String = row.column("user_id") else {
+                throw CassandraClient.Error.badParams("user_id not found in row")
+            }
+            return CassandraClient.EncryptionContext.Base(
+                keyspace: keyspace,
+                table: tableName,
+                primaryKey: .init(from: .string(uid))
+            )
+        }
+
+        let results: [UserWithSecret] = try self.cassandraClient.query(
+            "select user_id, secret from \(tableName) where user_id = ?",
+            parameters: [.string(userId)],
+            options: readOptions
+        ).wait()
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].secret.value, secretValue)
+    }
+
+    /// encryptionTable set but no matching schema registered → throws encryptionConfigError.
+    func testColumnRegistrationMissingSchema() throws {
+        let tableName = "test_colreg_missing_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        // Create the table and insert a row so the decoder is invoked
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try session.run(
+                "insert into \(tableName) (user_id, secret) values (?, ?)",
+                parameters: [.string("user-1"), .bytes([0x01, 0x02])]
+            ).wait()
+        }
+
+        // Do NOT register a schema — that's what we're testing
+        var readOptions = CassandraClient.Statement.Options()
+        readOptions.encryptionTable = tableName
+
+        do {
+            let _: [UserWithSecret] = try self.cassandraClient.query(
+                "select user_id, secret from \(tableName)",
+                options: readOptions
+            ).wait()
+            XCTFail("Expected encryptionConfigError to be thrown")
+        } catch let error as CassandraClient.Error {
+            let msg = error.description
+            XCTAssertTrue(
+                msg.contains("No EncryptionSchema registered"),
+                "Unexpected message: \(msg)"
+            )
+        }
+    }
+
+    // MARK: - Write-path enforcement
+
+    /// Binding an encrypted value to a column NOT registered as encrypted should throw.
+    func testWritePathRejectsEncryptedForPlaintextColumn() throws {
+        let tableName = "test_wp_reject_enc_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, name text)").wait()
+        }
+
+        // Schema has no encrypted columns — only PK
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        self.recreateClient()
+
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string("user-1"))
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        do {
+            // Bind encrypted value to a plaintext column — should be rejected
+            try self.cassandraClient.run(
+                "insert into \(tableName) (user_id, name) values (?, ?)",
+                parameters: [
+                    .string("user-1"),
+                    .encryptedString(CassandraClient.Encrypted("oops"), context: baseContext.forColumn("name")),
+                ],
+                options: options
+            ).wait()
+            XCTFail("Expected encryptionConfigError for encrypted value on plaintext column")
+        } catch let error as CassandraClient.Error {
+            let msg = error.description
+            XCTAssertTrue(msg.contains("name"), "Error should mention column name: \(msg)")
+        }
+    }
+
 }
 
 // MARK: - Test model

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -50,6 +50,7 @@ final class EncryptorTests: XCTestCase {
         let encryptor = try CassandraClient.Encryptor(
             keyMap: [keyName: keyData],
             currentKeyName: keyName,
+            salt: Data("test-salt".utf8),
             logger: Logger(label: "test.encryptor")
         )
         return (encryptor, keyData)
@@ -236,12 +237,25 @@ final class EncryptorTests: XCTestCase {
         XCTAssertThrowsError(try encryptor2.decrypt(encrypted, context: context))
     }
 
+    /// Empty salt should be rejected.
+    func testEmptySaltRejected() {
+        XCTAssertThrowsError(
+            try CassandraClient.Encryptor(
+                keyMap: ["key-1": randomKey()],
+                currentKeyName: "key-1",
+                salt: Data(),
+                logger: Logger(label: "test.encryptor")
+            )
+        )
+    }
+
     /// Empty key name should be rejected.
     func testEmptyKeyName() {
         XCTAssertThrowsError(
             try CassandraClient.Encryptor(
                 keyMap: ["": randomKey()],
                 currentKeyName: "",
+                salt: Data("test-salt".utf8),
                 logger: Logger(label: "test.encryptor")
             )
         )
@@ -253,6 +267,7 @@ final class EncryptorTests: XCTestCase {
             try CassandraClient.Encryptor(
                 keyMap: ["key with spaces": randomKey()],
                 currentKeyName: "key with spaces",
+                salt: Data("test-salt".utf8),
                 logger: Logger(label: "test.encryptor")
             )
         )
@@ -264,6 +279,7 @@ final class EncryptorTests: XCTestCase {
             try CassandraClient.Encryptor(
                 keyMap: ["key-1": Data([0x01, 0x02, 0x03])],
                 currentKeyName: "key-1",
+                salt: Data("test-salt".utf8),
                 logger: Logger(label: "test.encryptor")
             )
         )
@@ -276,6 +292,7 @@ final class EncryptorTests: XCTestCase {
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": key1, "key-2": key2],
             currentKeyName: "key-1",
+            salt: Data("test-salt".utf8),
             logger: Logger(label: "test.encryptor")
         )
         // New map missing "key-2" — should throw
@@ -288,6 +305,7 @@ final class EncryptorTests: XCTestCase {
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": key1],
             currentKeyName: "key-1",
+            salt: Data("test-salt".utf8),
             logger: Logger(label: "test.encryptor")
         )
         // Same name, different bytes — should throw
@@ -300,6 +318,7 @@ final class EncryptorTests: XCTestCase {
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": key1],
             currentKeyName: "key-1",
+            salt: Data("test-salt".utf8),
             logger: Logger(label: "test.encryptor")
         )
         let key2 = randomKey()

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -48,7 +48,8 @@ final class EncryptorTests: XCTestCase {
         let keyData = key ?? randomKey()
         let encryptor = try CassandraClient.Encryptor(
             keyMap: [keyName: keyData],
-            currentKeyName: keyName
+            currentKeyName: keyName,
+            logger: Logger(label: "test.encryptor")
         )
         return (encryptor, keyData)
     }
@@ -239,7 +240,8 @@ final class EncryptorTests: XCTestCase {
         XCTAssertThrowsError(
             try CassandraClient.Encryptor(
                 keyMap: ["": randomKey()],
-                currentKeyName: ""
+                currentKeyName: "",
+                logger: Logger(label: "test.encryptor")
             )
         )
     }
@@ -249,7 +251,8 @@ final class EncryptorTests: XCTestCase {
         XCTAssertThrowsError(
             try CassandraClient.Encryptor(
                 keyMap: ["key with spaces": randomKey()],
-                currentKeyName: "key with spaces"
+                currentKeyName: "key with spaces",
+                logger: Logger(label: "test.encryptor")
             )
         )
     }
@@ -259,7 +262,8 @@ final class EncryptorTests: XCTestCase {
         XCTAssertThrowsError(
             try CassandraClient.Encryptor(
                 keyMap: ["key-1": Data([0x01, 0x02, 0x03])],
-                currentKeyName: "key-1"
+                currentKeyName: "key-1",
+                logger: Logger(label: "test.encryptor")
             )
         )
     }
@@ -270,7 +274,8 @@ final class EncryptorTests: XCTestCase {
         let key2 = randomKey()
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": key1, "key-2": key2],
-            currentKeyName: "key-1"
+            currentKeyName: "key-1",
+            logger: Logger(label: "test.encryptor")
         )
         // New map missing "key-2" — should throw
         XCTAssertThrowsError(try encryptor.loadKeys(from: ["key-1": key1]))
@@ -281,7 +286,8 @@ final class EncryptorTests: XCTestCase {
         let key1 = randomKey()
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": key1],
-            currentKeyName: "key-1"
+            currentKeyName: "key-1",
+            logger: Logger(label: "test.encryptor")
         )
         // Same name, different bytes — should throw
         XCTAssertThrowsError(try encryptor.loadKeys(from: ["key-1": randomKey()]))
@@ -292,7 +298,8 @@ final class EncryptorTests: XCTestCase {
         let key1 = randomKey()
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": key1],
-            currentKeyName: "key-1"
+            currentKeyName: "key-1",
+            logger: Logger(label: "test.encryptor")
         )
         let key2 = randomKey()
         XCTAssertNoThrow(try encryptor.loadKeys(from: ["key-1": key1, "key-2": key2]))
@@ -422,7 +429,8 @@ final class EncryptorTests: XCTestCase {
         let encryptor = try CassandraClient.Encryptor(
             keyMap: ["key-1": keyData],
             currentKeyName: "key-1",
-            salt: salt
+            salt: salt,
+            logger: Logger(label: "test.encryptor")
         )
         let context = testContext()
         let plaintext = Data("secret-value".utf8)
@@ -440,12 +448,14 @@ final class EncryptorTests: XCTestCase {
         let encryptorA = try CassandraClient.Encryptor(
             keyMap: ["key-1": keyData],
             currentKeyName: "key-1",
-            salt: Data("salt-a".utf8)
+            salt: Data("salt-a".utf8),
+            logger: Logger(label: "test.encryptor")
         )
         let encryptorB = try CassandraClient.Encryptor(
             keyMap: ["key-1": keyData],
             currentKeyName: "key-1",
-            salt: Data("salt-b".utf8)
+            salt: Data("salt-b".utf8),
+            logger: Logger(label: "test.encryptor")
         )
         let context = testContext()
         let plaintext = Data("hello".utf8)

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -461,4 +461,81 @@ final class EncryptorTests: XCTestCase {
         XCTAssertThrowsError(try encryptorA.decrypt(encryptedB, context: context))
         XCTAssertThrowsError(try encryptorB.decrypt(encryptedA, context: context))
     }
+
+    // MARK: - Array-based PrimaryKey.init
+
+    /// Array-based PrimaryKey.init produces identical bytes to the variadic init.
+    func testArrayBasedPrimaryKeyInit() {
+        let variadic = CassandraClient.PrimaryKey(
+            from:
+                .string("user"),
+            .int32(42),
+            .uuid(Foundation.UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!)
+        )
+        let arrayBased = CassandraClient.PrimaryKey(from: [
+            .string("user"),
+            .int32(42),
+            .uuid(Foundation.UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!),
+        ])
+        XCTAssertEqual(variadic, arrayBased)
+    }
+
+    // MARK: - EncryptionSchema
+
+    /// Basic construction and registryKey.
+    func testEncryptionSchemaConstruction() throws {
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: "prod",
+            table: "users",
+            keyColumns: [
+                .init(name: "user_id", type: .string),
+                .init(name: "created_at", type: .int64),
+            ],
+            encryptedColumns: ["phone_enc", "secret", "ssn"]
+        )
+        XCTAssertEqual(schema.registryKey, "prod.users")
+        XCTAssertEqual(schema.keyColumns.count, 2)
+        XCTAssertTrue(schema.encryptedColumns.contains("phone_enc"))
+        XCTAssertEqual(schema.encryptedColumns, ["phone_enc", "secret", "ssn"])
+    }
+
+    /// Register a schema on Configuration and verify it round-trips through the AnyObject? backing store.
+    func testRegisterAndRetrieveSchema() throws {
+        var config = CassandraClient.Configuration(
+            contactPointsProvider: { callback in callback(.success(["localhost"])) },
+            port: 9042,
+            protocolVersion: .v3
+        )
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: "prod",
+            table: "users",
+            keyColumns: [
+                .init(name: "user_id", type: .string)
+            ],
+            encryptedColumns: ["ssn"]
+        )
+        config.registerEncryptionSchema(schema)
+
+        let retrieved = config.encryptionSchemas["prod.users"]
+        XCTAssertNotNil(retrieved)
+        XCTAssertEqual(retrieved?.keyspace, "prod")
+        XCTAssertEqual(retrieved?.table, "users")
+        XCTAssertEqual(retrieved?.keyColumns.count, 1)
+        XCTAssertEqual(retrieved?.encryptedColumns, ["ssn"])
+    }
+
+    /// Key column names must not overlap with encrypted column names.
+    func testEncryptionSchemaRejectsKeyColumnOverlap() {
+        XCTAssertThrowsError(
+            try CassandraClient.EncryptionSchema(
+                keyspace: "prod",
+                table: "users",
+                keyColumns: [.init(name: "user_id", type: .string)],
+                encryptedColumns: ["user_id", "ssn"]
+            )
+        ) { error in
+            let description = String(describing: error)
+            XCTAssertTrue(description.contains("user_id"), "Error should mention the overlapping column")
+        }
+    }
 }

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Logging
 import XCTest
 
 @testable import CassandraClient


### PR DESCRIPTION
Add column registration, encryption metrics, and write-path enforcement to Swift 

### Motivation:

Callers had to manually construct EncryptionContext.Base for every query. Encryption operations had no logging or metrics for observability. Write-path enforcement couldn't validate that encrypted values were bound to registered columns.

### Modifications:

- Encryptor.swift: EncryptionSchema type for column registration, KeyColumnType as extensible struct, cached EncryptorMetrics (counters/timers per key name), structured logging via swift-log
- Configuration.swift: Schema registry with registerEncryptionSchema(_:), rejects encrypted partition keys
- Session+Encryption.swift: Auto-builds encryption context from row using registered schema, write-path validation extracts column names from EncryptionContext carried by encrypted values
- Session.swift: Column registration integration in makeDecoder, write-path validation in makeStatement() (covers both run() and query()), file-level shared Logger
- Statement.swift: encryptionTable option, encryptedDate value type, isEncrypted/encryptedColumnName helpers
- Data.swift/Decoding.swift: decryptedDate support (Int64 millis ↔ Date)
- Package.swift: swift-metrics dependency
- Tests: 4 unit + 8 integration tests

### Result:

Register an EncryptionSchema per table and set options.encryptionTable for automatic context building. Write-path validation ensures encrypted values are bound only to registered encrypted columns. All encryption operations emit structured logs and metrics.
