### PR TITLE
Add batch execution support

### DIFF
--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import CDataStaxDriver
+import Foundation
+
+extension CassandraClient {
+    /// The type of a batch operation.
+    public struct BatchType: Equatable {
+        let rawValue: CassBatchType
+
+        /// All statements are applied atomically with a write to the batch log.
+        public static let logged = BatchType(rawValue: CASS_BATCH_TYPE_LOGGED)
+        /// Statements are applied without atomicity guarantees.
+        public static let unlogged = BatchType(rawValue: CASS_BATCH_TYPE_UNLOGGED)
+        /// All statements must be counter updates.
+        public static let counter = BatchType(rawValue: CASS_BATCH_TYPE_COUNTER)
+    }
+
+    /// A batch of statements to execute in Cassandra.
+    public struct Batch: ~Copyable {
+        internal let rawPointer: OpaquePointer
+
+        internal init(configuration: Configuration) throws {
+            self.rawPointer = cass_batch_new(configuration.type.rawValue)
+
+            if let consistency = configuration.consistency {
+                try checkResult {
+                    cass_batch_set_consistency(self.rawPointer, consistency.cassConsistency)
+                }
+            }
+            if let serialConsistency = configuration.serialConsistency {
+                try checkResult {
+                    cass_batch_set_serial_consistency(self.rawPointer, serialConsistency.cassConsistency)
+                }
+            }
+            if let timestamp = configuration.timestamp {
+                let microseconds = Int64(timestamp.timeIntervalSince1970 * 1_000_000)
+                try checkResult {
+                    cass_batch_set_timestamp(self.rawPointer, cass_int64_t(microseconds))
+                }
+            }
+            if let requestTimeout = configuration.requestTimeout {
+                try checkResult {
+                    cass_batch_set_request_timeout(self.rawPointer, requestTimeout)
+                }
+            }
+            if let isIdempotent = configuration.isIdempotent {
+                try checkResult {
+                    cass_batch_set_is_idempotent(self.rawPointer, isIdempotent ? cass_true : cass_false)
+                }
+            }
+            if let tracing = configuration.tracing {
+                try checkResult {
+                    cass_batch_set_tracing(self.rawPointer, tracing ? cass_true : cass_false)
+                }
+            }
+            if let keyspace = configuration.keyspace {
+                try checkResult {
+                    cass_batch_set_keyspace_n(self.rawPointer, keyspace, keyspace.utf8.count)
+                }
+            }
+        }
+
+        deinit {
+            cass_batch_free(self.rawPointer)
+        }
+
+        /// Add a statement to this batch.
+        public mutating func add(statement: Statement) throws {
+            try checkResult {
+                cass_batch_add_statement(self.rawPointer, statement.rawPointer)
+            }
+        }
+
+        /// Batch configuration options.
+        public struct Configuration {
+            /// The batch type. Defaults to `.logged`.
+            public var type: CassandraClient.BatchType = .logged
+            /// The batch's consistency level.
+            public var consistency: CassandraClient.Consistency?
+            /// The batch's serial consistency level for conditional updates.
+            public var serialConsistency: CassandraClient.SerialConsistency?
+            /// The batch's write timestamp.
+            public var timestamp: Foundation.Date?
+            /// The batch's request timeout in milliseconds.
+            public var requestTimeout: UInt64?
+            /// Whether the batch is idempotent.
+            public var isIdempotent: Bool?
+            /// Whether tracing is enabled for this batch.
+            public var tracing: Bool?
+            /// The keyspace for the batch.
+            public var keyspace: String?
+
+            public init() {}
+        }
+    }
+}
+
+private func checkResult(body: () -> CassError) throws {
+    let result = body()
+    guard result == CASS_OK else {
+        throw CassandraClient.Error(result, message: "Failed to configure Batch")
+    }
+}

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -154,6 +154,22 @@ public class CassandraClient: CassandraSession {
         )
     }
 
+    /// Execute a batch of statements.
+    ///
+    /// - Parameters:
+    ///   - configuration: Options to apply to the batch.
+    ///   - eventLoop: The `EventLoop` to use, or create a new one.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///   - build: Closure that adds statements to the batch.
+    public func batch(
+        configuration: Batch.Configuration = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none,
+        _ build: (inout Batch) throws -> Void
+    ) -> EventLoopFuture<Void> {
+        self.defaultSession.batch(configuration: configuration, on: eventLoop, logger: logger, build)
+    }
+
     /// Create a new ``CassandraSession`` that can be used to perform queries on the given or configured keyspace.
     ///
     /// - Parameters:
@@ -269,6 +285,21 @@ extension CassandraClient {
             pageSize: pageSize,
             logger: logger
         )
+    }
+
+    /// Execute a batch of statements.
+    ///
+    /// - Parameters:
+    ///   - configuration: Options to apply to the batch.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///   - build: Closure that adds statements to the batch.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func batch(
+        configuration: Batch.Configuration = .init(),
+        logger: Logger? = .none,
+        _ build: (inout Batch) async throws -> Void
+    ) async throws {
+        try await self.defaultSession.batch(configuration: configuration, logger: logger, build)
     }
 
     /// Create a new ``CassandraSession`` for the given or configured keyspace then invoke the closure.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -104,6 +104,27 @@ public protocol CassandraSession {
     )
         async throws -> CassandraClient.PaginatedRows
 
+    /// Execute a batch of statements.
+    ///
+    /// - Parameters:
+    ///   - configuration: Options to apply to the batch.
+    ///   - eventLoop: The `EventLoop` to use, or create a new one.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///   - build: Closure that adds statements to the batch.
+    func batch(
+        configuration: CassandraClient.Batch.Configuration,
+        on eventLoop: EventLoop?,
+        logger: Logger?,
+        _ build: (inout CassandraClient.Batch) throws -> Void
+    ) -> EventLoopFuture<Void>
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func batch(
+        configuration: CassandraClient.Batch.Configuration,
+        logger: Logger?,
+        _ build: (inout CassandraClient.Batch) async throws -> Void
+    ) async throws
+
     /// Terminate the session and free resources.
     func shutdown() throws
 
@@ -368,13 +389,12 @@ extension CassandraClient {
             }
         }
 
-        func execute(
-            statement: Statement,
+        /// Ensure the session is connected, then invoke `body` on the given event loop.
+        private func withConnection<Result>(
             on eventLoop: EventLoop?,
-            logger: Logger? = .none
-        )
-            -> EventLoopFuture<Rows>
-        {
+            logger: Logger?,
+            _ body: @escaping (EventLoop, Logger) -> EventLoopFuture<Result>
+        ) -> EventLoopFuture<Result> {
             let eventLoop = eventLoop ?? self.eventLoopGroup.next()
             let logger = logger ?? self.logger
 
@@ -388,40 +408,49 @@ extension CassandraClient {
                     self.lock.withLock {
                         self.state = .connected
                     }
-                    return self.execute(statement: statement, on: eventLoop, logger: logger)
+                    return body(eventLoop, logger)
                 }
             case .connectingFuture(let future):
                 self.lock.unlock()
                 return future.flatMap { _ in
-                    self.execute(statement: statement, on: eventLoop, logger: logger)
+                    body(eventLoop, logger)
                 }
             case .connecting(let task):
                 self.lock.unlock()
-                let promise = eventLoop.makePromise(of: Rows.self)
+                let promise = eventLoop.makePromise(of: Result.self)
                 if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
                     promise.completeWithTask {
                         try await task.task.value
-                        return try await self.execute(statement: statement, logger: logger)
+                        return try await body(eventLoop, logger).get()
                     }
                 }
                 return promise.futureResult
             case .connected:
                 self.lock.unlock()
+                return body(eventLoop, logger)
+            case .disconnected:
+                self.lock.unlock()
+                if self.eventLoopGroupContainer.managed {
+                    preconditionFailure("client is disconnected")
+                }
+                return eventLoop.makeFailedFuture(Error.disconnected)
+            }
+        }
+
+        func execute(
+            statement: Statement,
+            on eventLoop: EventLoop?,
+            logger: Logger? = .none
+        ) -> EventLoopFuture<Rows> {
+            self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing: \(statement.query)")
                 logger.trace("\(statement.parameters)")
                 let promise = eventLoop.makePromise(of: Rows.self)
-                let future = cass_session_execute(rawPointer, statement.rawPointer)
+                let future = cass_session_execute(self.rawPointer, statement.rawPointer)
                 futureSetResultCallback(future!) { result in
                     promise.completeWith(result)
                 }
                 return promise.futureResult
-            case .disconnected:
-                self.lock.unlock()
-                if self.eventLoopGroupContainer.managed {
-                    // eventloop *is* shutdown now
-                    preconditionFailure("client is disconnected")
-                }
-                return eventLoop.makeFailedFuture(Error.disconnected)
             }
         }
 
@@ -442,6 +471,45 @@ extension CassandraClient {
             return eventLoop.makeSucceededFuture(
                 PaginatedRows(session: self, statement: statement, on: eventLoop, logger: logger)
             )
+        }
+
+        func execute(
+            batch: consuming Batch,
+            on eventLoop: EventLoop?,
+            logger: Logger?
+        ) -> EventLoopFuture<Void> {
+            self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
+                logger.debug("executing batch")
+                let promise = eventLoop.makePromise(of: Void.self)
+                let future = cass_session_execute_batch(self.rawPointer, batch.rawPointer)
+                futureSetCallback(future!) { result in
+                    promise.completeWith(result)
+                }
+                return promise.futureResult
+            }
+        }
+
+        /// Execute a batch of statements.
+        ///
+        /// - Parameters:
+        ///   - configuration: Options to apply to the batch.
+        ///   - eventLoop: The `EventLoop` to use, or create a new one.
+        ///   - logger: If `nil`, the client's default `Logger` is used.
+        ///   - build: Closure that adds statements to the batch.
+        public func batch(
+            configuration: Batch.Configuration = .init(),
+            on eventLoop: EventLoop? = .none,
+            logger: Logger? = .none,
+            _ build: (inout Batch) throws -> Void
+        ) -> EventLoopFuture<Void> {
+            do {
+                var batch = try Batch(configuration: configuration)
+                try build(&batch)
+                return self.execute(batch: batch, on: eventLoop, logger: logger)
+            } catch {
+                let eventLoop = eventLoop ?? eventLoopGroup.next()
+                return eventLoop.makeFailedFuture(error)
+            }
         }
 
         private func connect(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Void> {
@@ -598,13 +666,12 @@ extension CassandraSession {
 }
 
 extension CassandraClient.Session {
+    /// Ensure the session is connected, then invoke `body`.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func execute(
-        statement: CassandraClient.Statement,
-        logger: Logger? = .none
-    ) async throws
-        -> CassandraClient.Rows
-    {
+    private func withConnection<T>(
+        logger: Logger?,
+        _ body: (Logger) async throws -> T
+    ) async throws -> T {
         let logger = logger ?? self.logger
 
         lock.lock()
@@ -618,29 +685,21 @@ extension CassandraClient.Session {
             lock.withLock {
                 self.state = .connected
             }
-            return try await self.execute(statement: statement, logger: logger)
+            return try await body(logger)
         case .connectingFuture(let future):
             lock.unlock()
             try await future.get()
-            return try await self.execute(statement: statement, logger: logger)
+            return try await body(logger)
         case .connecting(let task):
             lock.unlock()
             try await task.task.value
-            return try await self.execute(statement: statement, logger: logger)
+            return try await body(logger)
         case .connected:
             lock.unlock()
-            logger.debug("executing: \(statement.query)")
-            logger.trace("\(statement.parameters)")
-            let future = cass_session_execute(rawPointer, statement.rawPointer)
-            return try await withCheckedThrowingContinuation { continuation in
-                futureSetResultCallback(future!) { result in
-                    continuation.resume(with: result)
-                }
-            }
+            return try await body(logger)
         case .disconnected:
             lock.unlock()
             if eventLoopGroupContainer.managed {
-                // eventloop *is* shutdown now
                 preconditionFailure("client is disconnected")
             }
             throw CassandraClient.Error.disconnected
@@ -650,13 +709,63 @@ extension CassandraClient.Session {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute(
         statement: CassandraClient.Statement,
+        logger: Logger? = .none
+    ) async throws
+        -> CassandraClient.Rows
+    {
+        try await self.withConnection(logger: logger) { logger in
+            logger.debug("executing: \(statement.query)")
+            logger.trace("\(statement.parameters)")
+            let future = cass_session_execute(rawPointer, statement.rawPointer)
+            return try await withCheckedThrowingContinuation { continuation in
+                futureSetResultCallback(future!) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func execute(
+        statement: CassandraClient.Statement,
         pageSize: Int32,
         logger: Logger? = .none
-    )
-        async throws -> CassandraClient.PaginatedRows
-    {
+    ) async throws -> CassandraClient.PaginatedRows {
         try statement.setPagingSize(pageSize)
         return CassandraClient.PaginatedRows(session: self, statement: statement, logger: logger)
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func execute(
+        batch: consuming CassandraClient.Batch,
+        logger: Logger?
+    ) async throws {
+        try await self.withConnection(logger: logger) { logger in
+            logger.debug("executing batch")
+            let future = cass_session_execute_batch(rawPointer, batch.rawPointer)
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
+                futureSetCallback(future!) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Execute a batch of statements.
+    ///
+    /// - Parameters:
+    ///   - configuration: Options to apply to the batch.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///   - build: Closure that adds statements to the batch.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func batch(
+        configuration: CassandraClient.Batch.Configuration = .init(),
+        logger: Logger? = .none,
+        _ build: (inout CassandraClient.Batch) async throws -> Void
+    ) async throws {
+        var batch = try CassandraClient.Batch(configuration: configuration)
+        try await build(&batch)
+        try await self.execute(batch: batch, logger: logger)
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -1370,6 +1370,53 @@ final class Tests: XCTestCase {
         XCTAssertEqual(row.column("valid_map"), validMap)
     }
 
+    // MARK: - Batch tests
+
+    func testBatchInsertion() throws {
+        let tableName = "test_batch_logged_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id int primary key, name text);"
+        ).wait()
+
+        try self.cassandraClient.batch { batch in
+            for i: Int32 in 0..<10 {
+                try batch.add(
+                    statement: CassandraClient.Statement(
+                        query: "insert into \(tableName) (id, name) values (?, ?);",
+                        parameters: [.int32(i), .string("name_\(i)")]
+                    )
+                )
+            }
+        }.wait()
+
+        let result = try self.cassandraClient.query("select * from \(tableName);").wait()
+        XCTAssertEqual(Array(result).count, 10)
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testBatchInsertionAsync() throws {
+        runAsyncAndWaitFor {
+            let tableName = "test_batch_async_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.cassandraClient.run(
+                "create table \(tableName) (id int primary key, name text);"
+            )
+
+            try await self.cassandraClient.batch { batch in
+                for i: Int32 in 0..<10 {
+                    try batch.add(
+                        statement: CassandraClient.Statement(
+                            query: "insert into \(tableName) (id, name) values (?, ?);",
+                            parameters: [.int32(i), .string("name_\(i)")]
+                        )
+                    )
+                }
+            }
+
+            let result = try await self.cassandraClient.query("select * from \(tableName);")
+            XCTAssertEqual(Array(result).count, 10)
+        }
+    }
+
     // meh, but nothing cross platform available
     func randomBytes(size: Int) -> [UInt8] {
         var buffer = [UInt8]()


### PR DESCRIPTION
Add support to batch insert or update data to Cassandra using the `cass_batch_*` api in the DataStax driver.

I would like to get some feedback on whether we should expose the batch API like this where the client needs to explicitly control the size of the batch or if we should have some mechanism to let the client add statements to the batch and swift-cassandra-driver automatically flushes a batch when some threshold is reached. The tricky part here would be defining that threshold. As far as I could tell there are limits to the maximum batch size in Cassandra but I haven’t found a good way to (a) figure out that limit for the Cassandra instance that we are connected to and (b) counting the number of bytes that are currently included in a batch to compare it against that maximum batch size limit.