### PR TITLE
Adding support for prepared statements in Swift driver

### DIFF
--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -31,11 +31,14 @@ extension CassandraClient {
     /// A batch of statements to execute in Cassandra.
     public struct Batch: ~Copyable {
         internal let rawPointer: OpaquePointer
-        internal var resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)?
+        internal let resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)?
 
-        internal init(configuration: Configuration) throws {
+        internal init(
+            configuration: Configuration,
+            resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)? = nil
+        ) throws {
             self.rawPointer = cass_batch_new(configuration.type.rawValue)
-            self.resolver = nil
+            self.resolver = resolver
 
             if let consistency = configuration.consistency {
                 try checkResult {

--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -31,9 +31,11 @@ extension CassandraClient {
     /// A batch of statements to execute in Cassandra.
     public struct Batch: ~Copyable {
         internal let rawPointer: OpaquePointer
+        internal var resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)?
 
         internal init(configuration: Configuration) throws {
             self.rawPointer = cass_batch_new(configuration.type.rawValue)
+            self.resolver = nil
 
             if let consistency = configuration.consistency {
                 try checkResult {
@@ -77,8 +79,28 @@ extension CassandraClient {
             cass_batch_free(self.rawPointer)
         }
 
-        /// Add a statement to this batch.
+        /// Add a raw statement to this batch. Use this for non-prepared CQL statements only.
+        /// For prepared statements, use ``add(prepared:parameters:options:)`` instead.
         public mutating func add(statement: Statement) throws {
+            try checkResult {
+                cass_batch_add_statement(self.rawPointer, statement.rawPointer)
+            }
+        }
+
+        /// Add a prepared statement with parameters to this batch.
+        /// Handles encryption context resolution automatically when encryption is configured.
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        public mutating func add(
+            prepared: PreparedStatement,
+            parameters: [Statement.Value],
+            options: Statement.Options = .init()
+        ) throws {
+            guard let resolver = self.resolver else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Batch resolver not configured — use session.batch { } to get automatic encryption support"
+                )
+            }
+            let statement = try resolver(prepared, parameters, options)
             try checkResult {
                 cass_batch_add_statement(self.rawPointer, statement.rawPointer)
             }

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -158,6 +158,7 @@ public class CassandraClient: CassandraSession {
     ///
     /// - Parameters:
     ///   - query: The CQL query string with `?` placeholders.
+    ///   - encryptionTable: The table name for encryption context resolution. If provided, PK column names are looked up at prepare time.
     ///   - eventLoop: The `EventLoop` to use, or create a new one.
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
@@ -310,6 +311,7 @@ public class CassandraClient: CassandraSession {
     ///
     /// - Parameters:
     ///   - query: The CQL query string with `?` placeholders.
+    ///   - encryptionTable: The table name for encryption context resolution. If provided, PK column names are looked up at prepare time.
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
     /// - Returns: A ``PreparedStatement``.

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -154,6 +154,74 @@ public class CassandraClient: CassandraSession {
         )
     }
 
+    /// Prepare a CQL query for repeated execution using the default ``CassandraSession``.
+    ///
+    /// - Parameters:
+    ///   - query: The CQL query string with `?` placeholders.
+    ///   - eventLoop: The `EventLoop` to use, or create a new one.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///
+    /// - Returns: A ``PreparedStatement``.
+    public func prepare(
+        _ query: String,
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none
+    ) -> EventLoopFuture<PreparedStatement> {
+        self.defaultSession.prepare(query, on: eventLoop, logger: logger)
+    }
+
+    /// Execute a ``PreparedStatement`` with bound parameters using the default ``CassandraSession``.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - eventLoop: The `EventLoop` to use, or create a new one.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///
+    /// - Returns: The resulting ``Rows``.
+    public func execute(
+        prepared: PreparedStatement,
+        parameters: [Statement.Value] = [],
+        options: Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none
+    ) -> EventLoopFuture<Rows> {
+        self.defaultSession.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger
+        )
+    }
+
+    /// Execute a ``PreparedStatement`` and decode each row into a `Decodable` type using the default ``CassandraSession``.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - eventLoop: The `EventLoop` to use, or create a new one.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///
+    /// - Returns: The decoded rows.
+    public func execute<T: Decodable>(
+        prepared: PreparedStatement,
+        parameters: [Statement.Value] = [],
+        options: Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none
+    ) -> EventLoopFuture<[T]> {
+        self.defaultSession.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger
+        )
+    }
+
     /// Execute a batch of statements.
     ///
     /// - Parameters:

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -164,10 +164,11 @@ public class CassandraClient: CassandraSession {
     /// - Returns: A ``PreparedStatement``.
     public func prepare(
         _ query: String,
+        encryptionTable: String? = nil,
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
     ) -> EventLoopFuture<PreparedStatement> {
-        self.defaultSession.prepare(query, on: eventLoop, logger: logger)
+        self.defaultSession.prepare(query, encryptionTable: encryptionTable, on: eventLoop, logger: logger)
     }
 
     /// Execute a ``PreparedStatement`` with bound parameters using the default ``CassandraSession``.
@@ -315,9 +316,10 @@ public class CassandraClient: CassandraSession {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func prepare(
         _ query: String,
+        encryptionTable: String? = nil,
         logger: Logger? = .none
     ) async throws -> PreparedStatement {
-        try await self.defaultSession.prepare(query, logger: logger)
+        try await self.defaultSession.prepare(query, encryptionTable: encryptionTable, logger: logger)
     }
 
     /// Execute a ``PreparedStatement`` with bound parameters using the default ``CassandraSession``.

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -237,6 +237,69 @@ public class CassandraClient: CassandraSession {
         self.defaultSession.getMetrics()
     }
 
+    /// Prepare a CQL query for repeated execution using the default ``CassandraSession``.
+    ///
+    /// - Parameters:
+    ///   - query: The CQL query string with `?` placeholders.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///
+    /// - Returns: A ``PreparedStatement``.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func prepare(
+        _ query: String,
+        logger: Logger? = .none
+    ) async throws -> PreparedStatement {
+        try await self.defaultSession.prepare(query, logger: logger)
+    }
+
+    /// Execute a ``PreparedStatement`` with bound parameters using the default ``CassandraSession``.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///
+    /// - Returns: The resulting ``Rows``.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func execute(
+        prepared: PreparedStatement,
+        parameters: [Statement.Value] = [],
+        options: Statement.Options = .init(),
+        logger: Logger? = .none
+    ) async throws -> Rows {
+        try await self.defaultSession.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            logger: logger
+        )
+    }
+
+    /// Execute a ``PreparedStatement`` and decode each row into a `Decodable` type using the default ``CassandraSession``.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///
+    /// - Returns: The decoded rows.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func execute<T: Decodable>(
+        prepared: PreparedStatement,
+        parameters: [Statement.Value] = [],
+        options: Statement.Options = .init(),
+        logger: Logger? = .none
+    ) async throws -> [T] {
+        try await self.defaultSession.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            logger: logger
+        )
+    }
+
     /// A `EventLoopGroupProvider` defines how the underlying `EventLoopGroup` used to create the `EventLoop` is provided.
     ///
     /// When `shared`, the `EventLoopGroup` is provided externally and its lifecycle will be managed by the caller.

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import CDataStaxDriver
+
+extension CassandraClient {
+    /// A server-side prepared statement that can be efficiently executed multiple times with different parameters.
+    public final class PreparedStatement: @unchecked Sendable {
+        internal let rawPointer: OpaquePointer
+        private let _parameterCount: Int
+
+        internal init(rawPointer: OpaquePointer) {
+            self.rawPointer = rawPointer
+            // Count parameters by iterating until we get an error from parameterName.
+            var count = 0
+            var namePtr: UnsafePointer<CChar>?
+            var nameLength = Int()
+            while cass_prepared_parameter_name(rawPointer, count, &namePtr, &nameLength) == CASS_OK {
+                count += 1
+            }
+            self._parameterCount = count
+        }
+
+        deinit {
+            cass_prepared_free(self.rawPointer)
+        }
+
+        /// The number of bind parameters in this prepared statement.
+        public var parameterCount: Int {
+            self._parameterCount
+        }
+
+        /// Gets the column name for the parameter at the given index.
+        ///
+        /// - Parameter index: Zero-based parameter index.
+        /// - Returns: The column name, or `nil` if the index is out of bounds.
+        public func parameterName(at index: Int) -> String? {
+            var namePtr: UnsafePointer<CChar>?
+            var nameLength = Int()
+            let result = cass_prepared_parameter_name(self.rawPointer, index, &namePtr, &nameLength)
+            guard result == CASS_OK, let namePtr = namePtr else {
+                return nil
+            }
+            let buffer = UnsafeBufferPointer(start: namePtr, count: nameLength)
+            return buffer.withMemoryRebound(to: UInt8.self) {
+                String(decoding: $0, as: UTF8.self)
+            }
+        }
+
+        /// Creates a bound statement from this prepared statement, ready for parameter binding and execution.
+        ///
+        /// The returned `OpaquePointer` is a `CassStatement*` that must be freed with `cass_statement_free`.
+        internal func bind() -> OpaquePointer {
+            cass_prepared_bind(self.rawPointer)
+        }
+    }
+}

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -20,17 +20,16 @@ extension CassandraClient {
         internal let rawPointer: OpaquePointer
         private let _parameterCount: Int
 
-        /// The table name for encryption context resolution. Set at prepare time to avoid
-        /// passing `options.encryptionTable` on every execute call.
-        public var encryptionTable: String?
+        /// The table name for encryption context resolution.
+        public let encryptionTable: String?
 
-        /// PK column names (partition + clustering keys) for this statement's table.
-        /// Populated lazily on first encrypted execute to avoid repeated schema metadata lookups.
-        internal var primaryKeyColumnNames: [String]?
+        /// PK column names (partition + clustering keys), looked up once at prepare time to avoid repeated schema metadata queries.
+        internal let primaryKeyColumnNames: [String]
 
-        internal init(rawPointer: OpaquePointer) {
+        internal init(rawPointer: OpaquePointer, encryptionTable: String? = nil, primaryKeyColumnNames: [String] = []) {
             self.rawPointer = rawPointer
-            // Count parameters by iterating until we get an error from parameterName.
+            self.encryptionTable = encryptionTable
+            self.primaryKeyColumnNames = primaryKeyColumnNames
             var count = 0
             var namePtr: UnsafePointer<CChar>?
             var nameLength = Int()

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -20,6 +20,10 @@ extension CassandraClient {
         internal let rawPointer: OpaquePointer
         private let _parameterCount: Int
 
+        /// The table name for encryption context resolution. Set at prepare time to avoid
+        /// passing `options.encryptionTable` on every execute call.
+        public var encryptionTable: String?
+
         internal init(rawPointer: OpaquePointer) {
             self.rawPointer = rawPointer
             // Count parameters by iterating until we get an error from parameterName.

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -24,6 +24,10 @@ extension CassandraClient {
         /// passing `options.encryptionTable` on every execute call.
         public var encryptionTable: String?
 
+        /// PK column names (partition + clustering keys) for this statement's table.
+        /// Populated lazily on first encrypted execute to avoid repeated schema metadata lookups.
+        internal var primaryKeyColumnNames: [String]?
+
         internal init(rawPointer: OpaquePointer) {
             self.rawPointer = rawPointer
             // Count parameters by iterating until we get an error from parameterName.

--- a/Sources/CassandraClient/Session+Encryption.swift
+++ b/Sources/CassandraClient/Session+Encryption.swift
@@ -50,9 +50,10 @@ extension CassandraSession {
     /// For each `.encryptedXxx` value, extracts the column name from its `EncryptionContext`
     /// and checks that column is in the schema's `encryptedColumns` set.
     ///
-    /// This catches: encrypted values bound to wrong/unregistered columns (typos, copy-paste errors).
-    /// It does NOT catch: plaintext values bound to encrypted columns — that requires prepared statement
-    /// metadata to map positional parameters to column names.
+    /// This overload only checks one direction: encrypted values bound to unregistered columns.
+    /// Plaintext values bound to encrypted columns go undetected.
+    /// When executing prepared statements, ``validateEncryptionBindings(prepared:parameters:options:)``
+    /// checks both directions using parameter metadata.
     @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func validateEncryptionBindings(
         parameters: [CassandraClient.Statement.Value],
@@ -64,6 +65,39 @@ extension CassandraSession {
         for value in parameters {
             guard value.isEncrypted, let columnName = value.encryptedColumnName else { continue }
             guard schema.encryptedColumns.contains(columnName) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Column '\(columnName)' is not registered as encrypted but received an encrypted value"
+                )
+            }
+        }
+    }
+
+    /// Validate that bound parameter values match the encryption schema using prepared statement metadata.
+    /// Ensures encrypted columns receive encrypted values and plaintext columns receive plaintext values.
+    ///
+    /// This validation requires prepared statement metadata to map parameter indices to column names,
+    /// so it only runs for prepared statement execution.
+    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+    func validateEncryptionBindings(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value],
+        options: CassandraClient.Statement.Options
+    ) throws {
+        guard let tableName = options.encryptionTable else { return }
+        let schema = try self.resolveSchema(tableName: tableName)
+
+        for i in 0..<parameters.count {
+            guard let columnName = prepared.parameterName(at: i) else { continue }
+            let value = parameters[i]
+            let isEncryptedColumn = schema.encryptedColumns.contains(columnName)
+
+            if isEncryptedColumn {
+                guard value.isEncrypted else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Column '\(columnName)' is registered as encrypted but received a plaintext value"
+                    )
+                }
+            } else if value.isEncrypted {
                 throw CassandraClient.Error.encryptionConfigError(
                     "Column '\(columnName)' is not registered as encrypted but received an encrypted value"
                 )

--- a/Sources/CassandraClient/Session+Encryption.swift
+++ b/Sources/CassandraClient/Session+Encryption.swift
@@ -83,7 +83,7 @@ extension CassandraSession {
         parameters: [CassandraClient.Statement.Value],
         options: CassandraClient.Statement.Options
     ) throws {
-        guard let tableName = options.encryptionTable else { return }
+        guard let tableName = options.encryptionTable ?? prepared.encryptionTable else { return }
         let schema = try self.resolveSchema(tableName: tableName)
 
         for i in 0..<parameters.count {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -448,17 +448,23 @@ extension CassandraSession {
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
     ) -> EventLoopFuture<[T]> {
-        self.execute(
+        var effectiveOptions = options
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+            if effectiveOptions.encryptionTable == nil {
+                effectiveOptions.encryptionTable = prepared.encryptionTable
+            }
+        }
+        return self.execute(
             prepared: prepared,
             parameters: parameters,
-            options: options,
+            options: effectiveOptions,
             on: eventLoop,
             logger: logger
         ).flatMapThrowing { rows in
             let result = try rows.map { row in
-                try T(from: self.makeDecoder(row: row, options: options))
+                try T(from: self.makeDecoder(row: row, options: effectiveOptions))
             }
-            self.logDecryptedRows(count: result.count, options: options, logger: logger)
+            self.logDecryptedRows(count: result.count, options: effectiveOptions, logger: logger)
             return result
         }
     }
@@ -634,7 +640,6 @@ extension CassandraClient {
             }
         }
 
-
         /// Resolve encryption contexts for parameters that have `context: nil` using driver schema metadata.
         /// Discovers PK columns from Cassandra's metadata cache rather than requiring EncryptionSchema registration.
         @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
@@ -643,7 +648,8 @@ extension CassandraClient {
             parameters: [CassandraClient.Statement.Value],
             options: CassandraClient.Statement.Options
         ) throws -> [CassandraClient.Statement.Value] {
-            guard let tableName = options.encryptionTable else { return parameters }
+            let tableName = options.encryptionTable ?? prepared.encryptionTable
+            guard let tableName else { return parameters }
 
             let needsResolution = parameters.contains { $0.isEncrypted && $0.encryptionContext == nil }
             guard needsResolution else { return parameters }
@@ -845,6 +851,26 @@ extension CassandraClient {
         ) -> EventLoopFuture<Void> {
             do {
                 var batch = try Batch(configuration: configuration)
+                if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+                    batch.resolver = { [self] prepared, parameters, options in
+                        let resolvedParameters = try self.resolveEncryptionContexts(
+                            prepared: prepared,
+                            parameters: parameters,
+                            options: options
+                        )
+                        try self.validateEncryptionBindings(
+                            prepared: prepared,
+                            parameters: resolvedParameters,
+                            options: options
+                        )
+                        return try CassandraClient.Statement(
+                            preparedRawPointer: prepared.bind(),
+                            parameters: resolvedParameters,
+                            options: options,
+                            _encryptor: self.encryptor
+                        )
+                    }
+                }
                 try build(&batch)
                 return self.execute(batch: batch, on: eventLoop, logger: logger)
             } catch {
@@ -1033,16 +1059,22 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> [T] {
+        var effectiveOptions = options
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+            if effectiveOptions.encryptionTable == nil {
+                effectiveOptions.encryptionTable = prepared.encryptionTable
+            }
+        }
         let rows = try await self.execute(
             prepared: prepared,
             parameters: parameters,
-            options: options,
+            options: effectiveOptions,
             logger: logger
         )
         let result = try rows.map { row in
-            try T(from: self.makeDecoder(row: row, options: options))
+            try T(from: self.makeDecoder(row: row, options: effectiveOptions))
         }
-        self.logDecryptedRows(count: result.count, options: options, logger: logger)
+        self.logDecryptedRows(count: result.count, options: effectiveOptions, logger: logger)
         return result
     }
 }
@@ -1146,6 +1178,26 @@ extension CassandraClient.Session {
         _ build: (inout CassandraClient.Batch) async throws -> Void
     ) async throws {
         var batch = try CassandraClient.Batch(configuration: configuration)
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+            batch.resolver = { [self] prepared, parameters, options in
+                let resolvedParameters = try self.resolveEncryptionContexts(
+                    prepared: prepared,
+                    parameters: parameters,
+                    options: options
+                )
+                try self.validateEncryptionBindings(
+                    prepared: prepared,
+                    parameters: resolvedParameters,
+                    options: options
+                )
+                return try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    parameters: resolvedParameters,
+                    options: options,
+                    _encryptor: self.encryptor
+                )
+            }
+        }
         try await build(&batch)
         try await self.execute(batch: batch, logger: logger)
     }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -634,6 +634,145 @@ extension CassandraClient {
             }
         }
 
+
+        /// Resolve encryption contexts for parameters that have `context: nil` using driver schema metadata.
+        /// Discovers PK columns from Cassandra's metadata cache rather than requiring EncryptionSchema registration.
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        private func resolveEncryptionContexts(
+            prepared: CassandraClient.PreparedStatement,
+            parameters: [CassandraClient.Statement.Value],
+            options: CassandraClient.Statement.Options
+        ) throws -> [CassandraClient.Statement.Value] {
+            guard let tableName = options.encryptionTable else { return parameters }
+
+            let needsResolution = parameters.contains { $0.isEncrypted && $0.encryptionContext == nil }
+            guard needsResolution else { return parameters }
+
+            // Parse keyspace and table from encryptionTable option.
+            let keyspace: String
+            let table: String
+            if let dotIndex = tableName.firstIndex(of: ".") {
+                keyspace = String(tableName[tableName.startIndex..<dotIndex])
+                table = String(tableName[tableName.index(after: dotIndex)...])
+            } else {
+                guard let sessionKeyspace = self.keyspace else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "encryptionTable '\(tableName)' has no keyspace qualifier and session has no default keyspace"
+                    )
+                }
+                keyspace = sessionKeyspace
+                table = tableName
+            }
+
+            // Look up PK columns from driver schema metadata.
+            guard let schemaMeta = cass_session_get_schema_meta(self.rawPointer) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Cannot retrieve schema metadata from session"
+                )
+            }
+            defer { cass_schema_meta_free(schemaMeta) }
+
+            guard let keyspaceMeta = cass_schema_meta_keyspace_by_name(schemaMeta, keyspace) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Keyspace '\(keyspace)' not found in schema metadata"
+                )
+            }
+
+            guard let tableMeta = cass_keyspace_meta_table_by_name(keyspaceMeta, table) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Table '\(table)' not found in keyspace '\(keyspace)' schema metadata"
+                )
+            }
+
+            // Collect PK column names in order: partition keys first, then clustering keys.
+            var pkColumnNames: [String] = []
+
+            let partitionKeyCount = cass_table_meta_partition_key_count(tableMeta)
+            for i in 0..<partitionKeyCount {
+                guard let colMeta = cass_table_meta_partition_key(tableMeta, i) else { continue }
+                var namePtr: UnsafePointer<CChar>?
+                var nameLength = Int()
+                cass_column_meta_name(colMeta, &namePtr, &nameLength)
+                if let namePtr = namePtr {
+                    let name = String(cString: namePtr).prefix(nameLength)
+                    pkColumnNames.append(String(name))
+                }
+            }
+
+            let clusteringKeyCount = cass_table_meta_clustering_key_count(tableMeta)
+            for i in 0..<clusteringKeyCount {
+                guard let colMeta = cass_table_meta_clustering_key(tableMeta, i) else { continue }
+                var namePtr: UnsafePointer<CChar>?
+                var nameLength = Int()
+                cass_column_meta_name(colMeta, &namePtr, &nameLength)
+                if let namePtr = namePtr {
+                    let name = String(cString: namePtr).prefix(nameLength)
+                    pkColumnNames.append(String(name))
+                }
+            }
+
+            // Build a map of parameter name → index for the prepared statement.
+            var paramIndexByName: [String: Int] = [:]
+            for i in 0..<parameters.count {
+                if let name = prepared.parameterName(at: i) {
+                    paramIndexByName[name] = i
+                }
+            }
+
+            // Extract PK values from parameters.
+            var keyComponents: [CassandraClient.KeyComponent] = []
+            for pkCol in pkColumnNames {
+                guard let paramIdx = paramIndexByName[pkCol] else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Cannot auto-infer encryption context: key column '\(pkCol)' is not present in the prepared statement parameters. Provide context manually."
+                    )
+                }
+                let component = try Self.extractKeyComponent(from: parameters[paramIdx], columnName: pkCol)
+                keyComponents.append(component)
+            }
+
+            let primaryKey = CassandraClient.PrimaryKey(from: keyComponents)
+            let baseContext = CassandraClient.EncryptionContext.Base(
+                keyspace: keyspace,
+                table: table,
+                primaryKey: primaryKey
+            )
+
+            // Replace context-less encrypted values with context-resolved ones.
+            var resolved = parameters
+            for i in 0..<resolved.count {
+                guard resolved[i].isEncrypted, resolved[i].encryptionContext == nil else { continue }
+                guard let columnName = prepared.parameterName(at: i) else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Cannot auto-infer encryption context: no column name for parameter at index \(i)"
+                    )
+                }
+                resolved[i] = resolved[i].withContext(baseContext.forColumn(columnName))
+            }
+
+            return resolved
+        }
+
+        /// Extract a KeyComponent from a Statement.Value by inspecting its type.
+        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
+        private static func extractKeyComponent(
+            from value: CassandraClient.Statement.Value,
+            columnName: String
+        ) throws -> CassandraClient.KeyComponent {
+            switch value {
+            case .string(let v): return .string(v)
+            case .uuid(let v): return .uuid(v)
+            case .int32(let v): return .int32(v)
+            case .int64(let v): return .int64(v)
+            case .bytes(let v): return .data(Data(v))
+            case .date(let v): return .date(v)
+            default:
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Cannot extract key component for column '\(columnName)': unsupported value type for primary key"
+                )
+            }
+        }
+
         func execute(
             prepared: CassandraClient.PreparedStatement,
             parameters: [CassandraClient.Statement.Value] = [],
@@ -644,14 +783,19 @@ extension CassandraClient {
             do {
                 let statement: CassandraClient.Statement
                 if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                    try self.validateEncryptionBindings(
+                    let resolvedParameters = try self.resolveEncryptionContexts(
                         prepared: prepared,
                         parameters: parameters,
                         options: options
                     )
+                    try self.validateEncryptionBindings(
+                        prepared: prepared,
+                        parameters: resolvedParameters,
+                        options: options
+                    )
                     statement = try CassandraClient.Statement(
                         preparedRawPointer: prepared.bind(),
-                        parameters: parameters,
+                        parameters: resolvedParameters,
                         options: options,
                         _encryptor: self.encryptor
                     )
@@ -1031,14 +1175,19 @@ extension CassandraClient.Session {
     ) async throws -> CassandraClient.Rows {
         let statement: CassandraClient.Statement
         if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            try self.validateEncryptionBindings(
+            let resolvedParameters = try self.resolveEncryptionContexts(
                 prepared: prepared,
                 parameters: parameters,
                 options: options
             )
+            try self.validateEncryptionBindings(
+                prepared: prepared,
+                parameters: resolvedParameters,
+                options: options
+            )
             statement = try CassandraClient.Statement(
                 preparedRawPointer: prepared.bind(),
-                parameters: parameters,
+                parameters: resolvedParameters,
                 options: options,
                 _encryptor: self.encryptor
             )

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -77,6 +77,7 @@ public protocol CassandraSession {
     ///
     /// - Parameters:
     ///   - query: The CQL query string with `?` placeholders.
+    ///   - encryptionTable: The table name for encryption context resolution. If provided, PK column names are looked up at prepare time.
     ///   - eventLoop: The `EventLoop` to use. Optional.
     ///   - logger: The `Logger` to use. Optional.
     ///
@@ -149,6 +150,7 @@ public protocol CassandraSession {
     ///
     /// - Parameters:
     ///   - query: The CQL query string with `?` placeholders.
+    ///   - encryptionTable: The table name for encryption context resolution. If provided, PK column names are looked up at prepare time.
     ///   - logger: The `Logger` to use. Optional.
     ///
     /// - Returns: A ``CassandraClient/PreparedStatement``.
@@ -898,9 +900,9 @@ extension CassandraClient {
             _ build: (inout Batch) throws -> Void
         ) -> EventLoopFuture<Void> {
             do {
-                var batch = try Batch(configuration: configuration)
+                let resolver: ((CassandraClient.PreparedStatement, [CassandraClient.Statement.Value], CassandraClient.Statement.Options) throws -> CassandraClient.Statement)?
                 if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                    batch.resolver = { [self] prepared, parameters, options in
+                    resolver = { [self] prepared, parameters, options in
                         let resolvedParameters = try self.resolveEncryptionContexts(
                             prepared: prepared,
                             parameters: parameters,
@@ -918,7 +920,10 @@ extension CassandraClient {
                             _encryptor: self.encryptor
                         )
                     }
+                } else {
+                    resolver = nil
                 }
+                var batch = try Batch(configuration: configuration, resolver: resolver)
                 try build(&batch)
                 return self.execute(batch: batch, on: eventLoop, logger: logger)
             } catch {
@@ -1226,9 +1231,9 @@ extension CassandraClient.Session {
         logger: Logger? = .none,
         _ build: (inout CassandraClient.Batch) async throws -> Void
     ) async throws {
-        var batch = try CassandraClient.Batch(configuration: configuration)
+        let resolver: ((CassandraClient.PreparedStatement, [CassandraClient.Statement.Value], CassandraClient.Statement.Options) throws -> CassandraClient.Statement)?
         if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            batch.resolver = { [self] prepared, parameters, options in
+            resolver = { [self] prepared, parameters, options in
                 let resolvedParameters = try self.resolveEncryptionContexts(
                     prepared: prepared,
                     parameters: parameters,
@@ -1246,7 +1251,10 @@ extension CassandraClient.Session {
                     _encryptor: self.encryptor
                 )
             }
+        } else {
+            resolver = nil
         }
+        var batch = try CassandraClient.Batch(configuration: configuration, resolver: resolver)
         try await build(&batch)
         try await self.execute(batch: batch, logger: logger)
     }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -104,6 +104,39 @@ public protocol CassandraSession {
     )
         async throws -> CassandraClient.PaginatedRows
 
+    /// Prepare a CQL query for repeated execution.
+    ///
+    /// The server parses and validates the query once. The returned ``CassandraClient/PreparedStatement``
+    /// can then be bound with different parameters and executed multiple times without re-parsing.
+    ///
+    /// - Parameters:
+    ///   - query: The CQL query string with `?` placeholders.
+    ///   - logger: The `Logger` to use. Optional.
+    ///
+    /// - Returns: A ``CassandraClient/PreparedStatement``.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func prepare(
+        _ query: String,
+        logger: Logger?
+    ) async throws -> CassandraClient.PreparedStatement
+
+    /// Execute a prepared statement with bound parameters.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``CassandraClient/PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - logger: The `Logger` to use. Optional.
+    ///
+    /// - Returns: The resulting ``CassandraClient/Rows``.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func execute(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value],
+        options: CassandraClient.Statement.Options,
+        logger: Logger?
+    ) async throws -> CassandraClient.Rows
+
     /// Execute a batch of statements.
     ///
     /// - Parameters:
@@ -663,6 +696,47 @@ extension CassandraSession {
         }
         return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
     }
+
+    /// Prepare a CQL query for repeated execution.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func prepare(
+        _ query: String,
+        logger: Logger? = .none
+    ) async throws -> CassandraClient.PreparedStatement {
+        try await self.prepare(query, logger: logger)
+    }
+
+    /// Execute a prepared statement with bound parameters.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func execute(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none
+    ) async throws -> CassandraClient.Rows {
+        try await self.execute(prepared: prepared, parameters: parameters, options: options, logger: logger)
+    }
+
+    /// Execute a prepared statement and decode each row into a `Decodable` type.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func execute<T: Decodable>(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none
+    ) async throws -> [T] {
+        let rows = try await self.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            logger: logger
+        )
+        let result = try rows.map { row in
+            try T(from: self.makeDecoder(row: row, options: options))
+        }
+        self.logDecryptedRows(count: result.count, options: options, logger: logger)
+        return result
+    }
 }
 
 extension CassandraClient.Session {
@@ -769,6 +843,53 @@ extension CassandraClient.Session {
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func prepare(
+        _ query: String,
+        logger: Logger? = .none
+    ) async throws -> CassandraClient.PreparedStatement {
+        try await self.withConnection(logger: logger) { logger in
+            logger.debug("preparing: \(query)")
+            let future = cass_session_prepare(rawPointer, query)
+            return try await withCheckedThrowingContinuation { continuation in
+                futureSetPreparedCallback(future!) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func execute(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none
+    ) async throws -> CassandraClient.Rows {
+        let statement: CassandraClient.Statement
+        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+            try self.validateEncryptionBindings(
+                prepared: prepared,
+                parameters: parameters,
+                options: options
+            )
+            statement = try CassandraClient.Statement(
+                preparedRawPointer: prepared.bind(),
+                parameters: parameters,
+                options: options,
+                _encryptor: self.encryptor
+            )
+        } else {
+            statement = try CassandraClient.Statement(
+                preparedRawPointer: prepared.bind(),
+                parameters: parameters,
+                options: options,
+                _encryptor: nil
+            )
+        }
+        return try await self.execute(statement: statement, logger: logger)
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     private func connect(logger: Logger) -> Task<Void, Swift.Error> {
         Task {
             logger.debug("connecting to: \(self.configuration)")
@@ -832,6 +953,27 @@ private func futureSetResultCallback(
             let result: Result<CassandraClient.Rows, Error> =
                 resultCode == CASS_OK
                 ? .success(CassandraClient.Rows(future)) : .failure(CassandraClient.Error(future))
+            cass_future_free(future)
+            completion(result)
+        }
+    }
+    cass_future_set_callback(future, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
+}
+
+private func futureSetPreparedCallback(
+    _ future: OpaquePointer,
+    completion: @escaping (Result<CassandraClient.PreparedStatement, Error>) -> Void
+) {
+    let closure = unmanagedRetainedClosure {
+        DispatchQueue.global().async {
+            let resultCode = cass_future_error_code(future)
+            let result: Result<CassandraClient.PreparedStatement, Error>
+            if resultCode == CASS_OK {
+                let prepared = cass_future_get_prepared(future)!
+                result = .success(CassandraClient.PreparedStatement(rawPointer: prepared))
+            } else {
+                result = .failure(CassandraClient.Error(future))
+            }
             cass_future_free(future)
             completion(result)
         }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -70,6 +70,43 @@ public protocol CassandraSession {
         logger: Logger?
     ) -> EventLoopFuture<CassandraClient.PaginatedRows>
 
+    /// Prepare a CQL query for repeated execution.
+    ///
+    /// The server parses and validates the query once. The returned ``CassandraClient/PreparedStatement``
+    /// can then be bound with different parameters and executed multiple times without re-parsing.
+    ///
+    /// - Parameters:
+    ///   - query: The CQL query string with `?` placeholders.
+    ///   - eventLoop: The `EventLoop` to use. Optional.
+    ///   - logger: The `Logger` to use. Optional.
+    ///
+    /// - Returns: A ``CassandraClient/PreparedStatement``.
+    func prepare(
+        _ query: String,
+        on eventLoop: EventLoop?,
+        logger: Logger?
+    ) -> EventLoopFuture<CassandraClient.PreparedStatement>
+
+    /// Execute a prepared statement with bound parameters.
+    ///
+    /// **All** rows are returned.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``CassandraClient/PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - eventLoop: The `EventLoop` to use. Optional.
+    ///   - logger: The `Logger` to use. Optional.
+    ///
+    /// - Returns: The resulting ``CassandraClient/Rows``.
+    func execute(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value],
+        options: CassandraClient.Statement.Options,
+        on eventLoop: EventLoop?,
+        logger: Logger?
+    ) -> EventLoopFuture<CassandraClient.Rows>
+
     /// Execute a prepared statement.
     ///
     /// **All** rows are returned.
@@ -350,6 +387,81 @@ extension CassandraSession {
             return eventLoop.makeFailedFuture(error)
         }
     }
+
+    /// Prepare a CQL query for repeated execution.
+    ///
+    /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    public func prepare(
+        _ query: String,
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none
+    ) -> EventLoopFuture<CassandraClient.PreparedStatement> {
+        self.prepare(query, on: eventLoop, logger: logger)
+    }
+
+    /// Execute a prepared statement with bound parameters.
+    ///
+    /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    public func execute(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none
+    ) -> EventLoopFuture<CassandraClient.Rows> {
+        do {
+            let statement: CassandraClient.Statement
+            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+                try self.validateEncryptionBindings(
+                    prepared: prepared,
+                    parameters: parameters,
+                    options: options
+                )
+                statement = try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    parameters: parameters,
+                    options: options,
+                    _encryptor: self.encryptor
+                )
+            } else {
+                statement = try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    parameters: parameters,
+                    options: options,
+                    _encryptor: nil
+                )
+            }
+            return self.execute(statement: statement, on: eventLoop, logger: logger)
+        } catch {
+            let eventLoop = eventLoop ?? eventLoopGroup.next()
+            return eventLoop.makeFailedFuture(error)
+        }
+    }
+
+    /// Execute a prepared statement and decode each row into a `Decodable` type.
+    ///
+    /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    public func execute<T: Decodable>(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none
+    ) -> EventLoopFuture<[T]> {
+        self.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger
+        ).flatMapThrowing { rows in
+            let result = try rows.map { row in
+                try T(from: self.makeDecoder(row: row, options: options))
+            }
+            self.logDecryptedRows(count: result.count, options: options, logger: logger)
+            return result
+        }
+    }
 }
 
 extension CassandraClient {
@@ -504,6 +616,58 @@ extension CassandraClient {
             return eventLoop.makeSucceededFuture(
                 PaginatedRows(session: self, statement: statement, on: eventLoop, logger: logger)
             )
+        }
+
+        func prepare(
+            _ query: String,
+            on eventLoop: EventLoop?,
+            logger: Logger? = .none
+        ) -> EventLoopFuture<CassandraClient.PreparedStatement> {
+            self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
+                logger.debug("preparing: \(query)")
+                let promise = eventLoop.makePromise(of: CassandraClient.PreparedStatement.self)
+                let future = cass_session_prepare(self.rawPointer, query)
+                futureSetPreparedCallback(future!) { result in
+                    promise.completeWith(result)
+                }
+                return promise.futureResult
+            }
+        }
+
+        func execute(
+            prepared: CassandraClient.PreparedStatement,
+            parameters: [CassandraClient.Statement.Value] = [],
+            options: CassandraClient.Statement.Options = .init(),
+            on eventLoop: EventLoop? = .none,
+            logger: Logger? = .none
+        ) -> EventLoopFuture<CassandraClient.Rows> {
+            do {
+                let statement: CassandraClient.Statement
+                if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+                    try self.validateEncryptionBindings(
+                        prepared: prepared,
+                        parameters: parameters,
+                        options: options
+                    )
+                    statement = try CassandraClient.Statement(
+                        preparedRawPointer: prepared.bind(),
+                        parameters: parameters,
+                        options: options,
+                        _encryptor: self.encryptor
+                    )
+                } else {
+                    statement = try CassandraClient.Statement(
+                        preparedRawPointer: prepared.bind(),
+                        parameters: parameters,
+                        options: options,
+                        _encryptor: nil
+                    )
+                }
+                return self.execute(statement: statement, on: eventLoop, logger: logger)
+            } catch {
+                let eventLoop = eventLoop ?? self.eventLoopGroup.next()
+                return eventLoop.makeFailedFuture(error)
+            }
         }
 
         func execute(

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -900,7 +900,13 @@ extension CassandraClient {
             _ build: (inout Batch) throws -> Void
         ) -> EventLoopFuture<Void> {
             do {
-                let resolver: ((CassandraClient.PreparedStatement, [CassandraClient.Statement.Value], CassandraClient.Statement.Options) throws -> CassandraClient.Statement)?
+                let resolver:
+                    (
+                        (
+                            CassandraClient.PreparedStatement, [CassandraClient.Statement.Value],
+                            CassandraClient.Statement.Options
+                        ) throws -> CassandraClient.Statement
+                    )?
                 if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
                     resolver = { [self] prepared, parameters, options in
                         let resolvedParameters = try self.resolveEncryptionContexts(
@@ -1231,7 +1237,13 @@ extension CassandraClient.Session {
         logger: Logger? = .none,
         _ build: (inout CassandraClient.Batch) async throws -> Void
     ) async throws {
-        let resolver: ((CassandraClient.PreparedStatement, [CassandraClient.Statement.Value], CassandraClient.Statement.Options) throws -> CassandraClient.Statement)?
+        let resolver:
+            (
+                (
+                    CassandraClient.PreparedStatement, [CassandraClient.Statement.Value],
+                    CassandraClient.Statement.Options
+                ) throws -> CassandraClient.Statement
+            )?
         if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
             resolver = { [self] prepared, parameters, options in
                 let resolvedParameters = try self.resolveEncryptionContexts(

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -83,6 +83,7 @@ public protocol CassandraSession {
     /// - Returns: A ``CassandraClient/PreparedStatement``.
     func prepare(
         _ query: String,
+        encryptionTable: String?,
         on eventLoop: EventLoop?,
         logger: Logger?
     ) -> EventLoopFuture<CassandraClient.PreparedStatement>
@@ -154,6 +155,7 @@ public protocol CassandraSession {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func prepare(
         _ query: String,
+        encryptionTable: String?,
         logger: Logger?
     ) async throws -> CassandraClient.PreparedStatement
 
@@ -393,10 +395,11 @@ extension CassandraSession {
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
     public func prepare(
         _ query: String,
+        encryptionTable: String? = nil,
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.PreparedStatement> {
-        self.prepare(query, on: eventLoop, logger: logger)
+        self.prepare(query, encryptionTable: encryptionTable, on: eventLoop, logger: logger)
     }
 
     /// Execute a prepared statement with bound parameters.
@@ -626,6 +629,7 @@ extension CassandraClient {
 
         func prepare(
             _ query: String,
+            encryptionTable: String? = nil,
             on eventLoop: EventLoop?,
             logger: Logger? = .none
         ) -> EventLoopFuture<CassandraClient.PreparedStatement> {
@@ -633,11 +637,95 @@ extension CassandraClient {
                 logger.debug("preparing: \(query)")
                 let promise = eventLoop.makePromise(of: CassandraClient.PreparedStatement.self)
                 let future = cass_session_prepare(self.rawPointer, query)
-                futureSetPreparedCallback(future!) { result in
-                    promise.completeWith(result)
+                futureSetPreparedCallback(future!) { [self] result in
+                    switch result {
+                    case .success(let rawPointer):
+                        do {
+                            let pkColumns: [String]
+                            if let tableName = encryptionTable {
+                                pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+                            } else {
+                                pkColumns = []
+                            }
+                            let prepared = CassandraClient.PreparedStatement(
+                                rawPointer: rawPointer,
+                                encryptionTable: encryptionTable,
+                                primaryKeyColumnNames: pkColumns
+                            )
+                            promise.succeed(prepared)
+                        } catch {
+                            promise.fail(error)
+                        }
+                    case .failure(let error):
+                        promise.fail(error)
+                    }
                 }
                 return promise.futureResult
             }
+        }
+
+        private func lookupPrimaryKeyColumnNames(tableName: String) throws -> [String] {
+            let keyspace: String
+            let table: String
+            if let dotIndex = tableName.firstIndex(of: ".") {
+                keyspace = String(tableName[tableName.startIndex..<dotIndex])
+                table = String(tableName[tableName.index(after: dotIndex)...])
+            } else {
+                guard let sessionKeyspace = self.keyspace else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "encryptionTable '\(tableName)' has no keyspace qualifier and session has no default keyspace"
+                    )
+                }
+                keyspace = sessionKeyspace
+                table = tableName
+            }
+
+            guard let schemaMeta = cass_session_get_schema_meta(self.rawPointer) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Cannot retrieve schema metadata from session"
+                )
+            }
+            defer { cass_schema_meta_free(schemaMeta) }
+
+            guard let keyspaceMeta = cass_schema_meta_keyspace_by_name(schemaMeta, keyspace) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Keyspace '\(keyspace)' not found in schema metadata"
+                )
+            }
+
+            guard let tableMeta = cass_keyspace_meta_table_by_name(keyspaceMeta, table) else {
+                throw CassandraClient.Error.encryptionConfigError(
+                    "Table '\(table)' not found in keyspace '\(keyspace)' schema metadata"
+                )
+            }
+
+            var names: [String] = []
+
+            let partitionKeyCount = cass_table_meta_partition_key_count(tableMeta)
+            for i in 0..<partitionKeyCount {
+                guard let colMeta = cass_table_meta_partition_key(tableMeta, i) else { continue }
+                var namePtr: UnsafePointer<CChar>?
+                var nameLength = Int()
+                cass_column_meta_name(colMeta, &namePtr, &nameLength)
+                if let namePtr = namePtr {
+                    let name = String(cString: namePtr).prefix(nameLength)
+                    names.append(String(name))
+                }
+            }
+
+            let clusteringKeyCount = cass_table_meta_clustering_key_count(tableMeta)
+            for i in 0..<clusteringKeyCount {
+                guard let colMeta = cass_table_meta_clustering_key(tableMeta, i) else { continue }
+                var namePtr: UnsafePointer<CChar>?
+                var nameLength = Int()
+                cass_column_meta_name(colMeta, &namePtr, &nameLength)
+                if let namePtr = namePtr {
+                    let name = String(cString: namePtr).prefix(nameLength)
+                    names.append(String(name))
+                }
+            }
+
+            return names
         }
 
         /// Resolve encryption contexts for parameters that have `context: nil` using driver schema metadata.
@@ -671,56 +759,10 @@ extension CassandraClient {
             }
 
             let pkColumnNames: [String]
-            if let names = prepared.primaryKeyColumnNames {
-                pkColumnNames = names
+            if !prepared.primaryKeyColumnNames.isEmpty {
+                pkColumnNames = prepared.primaryKeyColumnNames
             } else {
-                guard let schemaMeta = cass_session_get_schema_meta(self.rawPointer) else {
-                    throw CassandraClient.Error.encryptionConfigError(
-                        "Cannot retrieve schema metadata from session"
-                    )
-                }
-                defer { cass_schema_meta_free(schemaMeta) }
-
-                guard let keyspaceMeta = cass_schema_meta_keyspace_by_name(schemaMeta, keyspace) else {
-                    throw CassandraClient.Error.encryptionConfigError(
-                        "Keyspace '\(keyspace)' not found in schema metadata"
-                    )
-                }
-
-                guard let tableMeta = cass_keyspace_meta_table_by_name(keyspaceMeta, table) else {
-                    throw CassandraClient.Error.encryptionConfigError(
-                        "Table '\(table)' not found in keyspace '\(keyspace)' schema metadata"
-                    )
-                }
-
-                var names: [String] = []
-
-                let partitionKeyCount = cass_table_meta_partition_key_count(tableMeta)
-                for i in 0..<partitionKeyCount {
-                    guard let colMeta = cass_table_meta_partition_key(tableMeta, i) else { continue }
-                    var namePtr: UnsafePointer<CChar>?
-                    var nameLength = Int()
-                    cass_column_meta_name(colMeta, &namePtr, &nameLength)
-                    if let namePtr = namePtr {
-                        let name = String(cString: namePtr).prefix(nameLength)
-                        names.append(String(name))
-                    }
-                }
-
-                let clusteringKeyCount = cass_table_meta_clustering_key_count(tableMeta)
-                for i in 0..<clusteringKeyCount {
-                    guard let colMeta = cass_table_meta_clustering_key(tableMeta, i) else { continue }
-                    var namePtr: UnsafePointer<CChar>?
-                    var nameLength = Int()
-                    cass_column_meta_name(colMeta, &namePtr, &nameLength)
-                    if let namePtr = namePtr {
-                        let name = String(cString: namePtr).prefix(nameLength)
-                        names.append(String(name))
-                    }
-                }
-
-                prepared.primaryKeyColumnNames = names
-                pkColumnNames = names
+                pkColumnNames = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
             }
 
             // Build a map of parameter name → index for the prepared statement.
@@ -1041,9 +1083,10 @@ extension CassandraSession {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func prepare(
         _ query: String,
+        encryptionTable: String? = nil,
         logger: Logger? = .none
     ) async throws -> CassandraClient.PreparedStatement {
-        try await self.prepare(query, logger: logger)
+        try await self.prepare(query, encryptionTable: encryptionTable, logger: logger)
     }
 
     /// Execute a prepared statement with bound parameters.
@@ -1211,9 +1254,10 @@ extension CassandraClient.Session {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func prepare(
         _ query: String,
+        encryptionTable: String? = nil,
         logger: Logger? = .none
     ) async throws -> CassandraClient.PreparedStatement {
-        try await self.withConnection(logger: logger) { logger in
+        let preparedRawPointer: OpaquePointer = try await self.withConnection(logger: logger) { logger in
             logger.debug("preparing: \(query)")
             let future = cass_session_prepare(rawPointer, query)
             return try await withCheckedThrowingContinuation { continuation in
@@ -1222,6 +1266,17 @@ extension CassandraClient.Session {
                 }
             }
         }
+        let pkColumns: [String]
+        if let tableName = encryptionTable {
+            pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+        } else {
+            pkColumns = []
+        }
+        return CassandraClient.PreparedStatement(
+            rawPointer: preparedRawPointer,
+            encryptionTable: encryptionTable,
+            primaryKeyColumnNames: pkColumns
+        )
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -1333,15 +1388,15 @@ private func futureSetResultCallback(
 
 private func futureSetPreparedCallback(
     _ future: OpaquePointer,
-    completion: @escaping (Result<CassandraClient.PreparedStatement, Error>) -> Void
+    completion: @escaping (Result<OpaquePointer, Error>) -> Void
 ) {
     let closure = unmanagedRetainedClosure {
         DispatchQueue.global().async {
             let resultCode = cass_future_error_code(future)
-            let result: Result<CassandraClient.PreparedStatement, Error>
+            let result: Result<OpaquePointer, Error>
             if resultCode == CASS_OK {
                 let prepared = cass_future_get_prepared(future)!
-                result = .success(CassandraClient.PreparedStatement(rawPointer: prepared))
+                result = .success(prepared)
             } else {
                 result = .failure(CassandraClient.Error(future))
             }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -670,51 +670,57 @@ extension CassandraClient {
                 table = tableName
             }
 
-            // Look up PK columns from driver schema metadata.
-            guard let schemaMeta = cass_session_get_schema_meta(self.rawPointer) else {
-                throw CassandraClient.Error.encryptionConfigError(
-                    "Cannot retrieve schema metadata from session"
-                )
-            }
-            defer { cass_schema_meta_free(schemaMeta) }
-
-            guard let keyspaceMeta = cass_schema_meta_keyspace_by_name(schemaMeta, keyspace) else {
-                throw CassandraClient.Error.encryptionConfigError(
-                    "Keyspace '\(keyspace)' not found in schema metadata"
-                )
-            }
-
-            guard let tableMeta = cass_keyspace_meta_table_by_name(keyspaceMeta, table) else {
-                throw CassandraClient.Error.encryptionConfigError(
-                    "Table '\(table)' not found in keyspace '\(keyspace)' schema metadata"
-                )
-            }
-
-            // Collect PK column names in order: partition keys first, then clustering keys.
-            var pkColumnNames: [String] = []
-
-            let partitionKeyCount = cass_table_meta_partition_key_count(tableMeta)
-            for i in 0..<partitionKeyCount {
-                guard let colMeta = cass_table_meta_partition_key(tableMeta, i) else { continue }
-                var namePtr: UnsafePointer<CChar>?
-                var nameLength = Int()
-                cass_column_meta_name(colMeta, &namePtr, &nameLength)
-                if let namePtr = namePtr {
-                    let name = String(cString: namePtr).prefix(nameLength)
-                    pkColumnNames.append(String(name))
+            let pkColumnNames: [String]
+            if let names = prepared.primaryKeyColumnNames {
+                pkColumnNames = names
+            } else {
+                guard let schemaMeta = cass_session_get_schema_meta(self.rawPointer) else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Cannot retrieve schema metadata from session"
+                    )
                 }
-            }
+                defer { cass_schema_meta_free(schemaMeta) }
 
-            let clusteringKeyCount = cass_table_meta_clustering_key_count(tableMeta)
-            for i in 0..<clusteringKeyCount {
-                guard let colMeta = cass_table_meta_clustering_key(tableMeta, i) else { continue }
-                var namePtr: UnsafePointer<CChar>?
-                var nameLength = Int()
-                cass_column_meta_name(colMeta, &namePtr, &nameLength)
-                if let namePtr = namePtr {
-                    let name = String(cString: namePtr).prefix(nameLength)
-                    pkColumnNames.append(String(name))
+                guard let keyspaceMeta = cass_schema_meta_keyspace_by_name(schemaMeta, keyspace) else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Keyspace '\(keyspace)' not found in schema metadata"
+                    )
                 }
+
+                guard let tableMeta = cass_keyspace_meta_table_by_name(keyspaceMeta, table) else {
+                    throw CassandraClient.Error.encryptionConfigError(
+                        "Table '\(table)' not found in keyspace '\(keyspace)' schema metadata"
+                    )
+                }
+
+                var names: [String] = []
+
+                let partitionKeyCount = cass_table_meta_partition_key_count(tableMeta)
+                for i in 0..<partitionKeyCount {
+                    guard let colMeta = cass_table_meta_partition_key(tableMeta, i) else { continue }
+                    var namePtr: UnsafePointer<CChar>?
+                    var nameLength = Int()
+                    cass_column_meta_name(colMeta, &namePtr, &nameLength)
+                    if let namePtr = namePtr {
+                        let name = String(cString: namePtr).prefix(nameLength)
+                        names.append(String(name))
+                    }
+                }
+
+                let clusteringKeyCount = cass_table_meta_clustering_key_count(tableMeta)
+                for i in 0..<clusteringKeyCount {
+                    guard let colMeta = cass_table_meta_clustering_key(tableMeta, i) else { continue }
+                    var namePtr: UnsafePointer<CChar>?
+                    var nameLength = Int()
+                    cass_column_meta_name(colMeta, &namePtr, &nameLength)
+                    if let namePtr = namePtr {
+                        let name = String(cString: namePtr).prefix(nameLength)
+                        names.append(String(name))
+                    }
+                }
+
+                prepared.primaryKeyColumnNames = names
+                pkColumnNames = names
             }
 
             // Build a map of parameter name → index for the prepared statement.

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -43,6 +43,22 @@ extension CassandraClient {
             try self.bindParameters()
         }
 
+        /// Internal init for prepared statements. Takes a pre-bound `CassStatement*` from `cass_prepared_bind()`.
+        internal init(
+            preparedRawPointer: OpaquePointer,
+            parameters: [Value],
+            options: Options,
+            _encryptor: AnyObject?
+        ) throws {
+            self.query = "(prepared)"
+            self.parameters = parameters
+            self.options = options
+            self._encryptor = _encryptor
+            self.rawPointer = preparedRawPointer
+
+            try self.bindParameters()
+        }
+
         private func bindParameters() throws {
             for (index, parameter) in parameters.enumerated() {
                 let result: CassError

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -111,18 +111,33 @@ extension CassandraClient {
                         buffer.count
                     )
                 case .encryptedString(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     result = try self.bindEncrypted(
                         Data(wrapped.value.utf8),
                         context: context,
                         at: index
                     )
                 case .encryptedBytes(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     result = try self.bindEncrypted(
                         Data(wrapped.value),
                         context: context,
                         at: index
                     )
                 case .encryptedInt32(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     var bigEndian = wrapped.value.bigEndian
                     result = try self.bindEncrypted(
                         Data(bytes: &bigEndian, count: 4),
@@ -130,6 +145,11 @@ extension CassandraClient {
                         at: index
                     )
                 case .encryptedInt64(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     var bigEndian = wrapped.value.bigEndian
                     result = try self.bindEncrypted(
                         Data(bytes: &bigEndian, count: 8),
@@ -137,6 +157,11 @@ extension CassandraClient {
                         at: index
                     )
                 case .encryptedDouble(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     var bits = wrapped.value.bitPattern.bigEndian
                     result = try self.bindEncrypted(
                         Data(bytes: &bits, count: 8),
@@ -144,6 +169,11 @@ extension CassandraClient {
                         at: index
                     )
                 case .encryptedUUID(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     let u = wrapped.value.uuid
                     let plaintext = Data([
                         u.0, u.1, u.2, u.3, u.4, u.5, u.6, u.7,
@@ -155,6 +185,11 @@ extension CassandraClient {
                         at: index
                     )
                 case .encryptedDate(let wrapped, let context):
+                    guard let context = context else {
+                        throw CassandraClient.Error.encryptionConfigError(
+                            "Encrypted value at index \(index) has no encryption context. Use prepared statement execution with encryptionTable option, or provide context manually."
+                        )
+                    }
                     var bigEndian = Int64(wrapped.value.timeIntervalSince1970 * 1000).bigEndian
                     result = try self.bindEncrypted(
                         Data(bytes: &bigEndian, count: 8),
@@ -303,13 +338,13 @@ extension CassandraClient {
             case bytes([UInt8])
             case bytesUnsafe(UnsafeBufferPointer<UInt8>)
 
-            case encryptedString(Encrypted<String>, context: EncryptionContext)
-            case encryptedBytes(Encrypted<[UInt8]>, context: EncryptionContext)
-            case encryptedInt32(Encrypted<Int32>, context: EncryptionContext)
-            case encryptedInt64(Encrypted<Int64>, context: EncryptionContext)
-            case encryptedDouble(Encrypted<Double>, context: EncryptionContext)
-            case encryptedUUID(Encrypted<Foundation.UUID>, context: EncryptionContext)
-            case encryptedDate(Encrypted<Foundation.Date>, context: EncryptionContext)
+            case encryptedString(Encrypted<String>, context: EncryptionContext? = nil)
+            case encryptedBytes(Encrypted<[UInt8]>, context: EncryptionContext? = nil)
+            case encryptedInt32(Encrypted<Int32>, context: EncryptionContext? = nil)
+            case encryptedInt64(Encrypted<Int64>, context: EncryptionContext? = nil)
+            case encryptedDouble(Encrypted<Double>, context: EncryptionContext? = nil)
+            case encryptedUUID(Encrypted<Foundation.UUID>, context: EncryptionContext? = nil)
+            case encryptedDate(Encrypted<Foundation.Date>, context: EncryptionContext? = nil)
 
             case int8Array([Int8])
             case int16Array([Int16])
@@ -411,9 +446,39 @@ extension CassandraClient {
                     .encryptedDouble(_, let ctx),
                     .encryptedUUID(_, let ctx),
                     .encryptedDate(_, let ctx):
-                    return ctx.column
+                    return ctx?.column
                 default:
                     return nil
+                }
+            }
+
+            /// The encryption context, if this is an encrypted value with an explicit context.
+            internal var encryptionContext: CassandraClient.EncryptionContext? {
+                switch self {
+                case .encryptedString(_, let ctx),
+                    .encryptedBytes(_, let ctx),
+                    .encryptedInt32(_, let ctx),
+                    .encryptedInt64(_, let ctx),
+                    .encryptedDouble(_, let ctx),
+                    .encryptedUUID(_, let ctx),
+                    .encryptedDate(_, let ctx):
+                    return ctx
+                default:
+                    return nil
+                }
+            }
+
+            /// Returns a copy of this value with the given encryption context applied.
+            internal func withContext(_ context: CassandraClient.EncryptionContext) -> Self {
+                switch self {
+                case .encryptedString(let v, _): return .encryptedString(v, context: context)
+                case .encryptedBytes(let v, _): return .encryptedBytes(v, context: context)
+                case .encryptedInt32(let v, _): return .encryptedInt32(v, context: context)
+                case .encryptedInt64(let v, _): return .encryptedInt64(v, context: context)
+                case .encryptedDouble(let v, _): return .encryptedDouble(v, context: context)
+                case .encryptedUUID(let v, _): return .encryptedUUID(v, context: context)
+                case .encryptedDate(let v, _): return .encryptedDate(v, context: context)
+                default: return self
                 }
             }
         }

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -1432,6 +1432,95 @@ final class Tests: XCTestCase {
         }
         return buffer
     }
+
+    // MARK: - Prepared statements
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPreparedStatementRoundtrip() throws {
+        runAsyncAndWaitFor {
+            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
+
+            let insertStmt = try await self.cassandraClient.prepare(
+                "insert into \(tableName) (id, name) values (?, ?)"
+            )
+            try await self.cassandraClient.execute(
+                prepared: insertStmt,
+                parameters: [.int32(1), .string("alice")]
+            )
+
+            let selectStmt = try await self.cassandraClient.prepare(
+                "select id, name from \(tableName) where id = ?"
+            )
+            let rows = try await self.cassandraClient.execute(
+                prepared: selectStmt,
+                parameters: [.int32(1)]
+            )
+            let result = Array(rows)
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result[0].column(0)?.int32, 1)
+            XCTAssertEqual(result[0].column(1)?.string, "alice")
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPreparedStatementReuse() throws {
+        runAsyncAndWaitFor {
+            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
+
+            let insertStmt = try await self.cassandraClient.prepare(
+                "insert into \(tableName) (id, name) values (?, ?)"
+            )
+            for i: Int32 in 0..<10 {
+                try await self.cassandraClient.execute(
+                    prepared: insertStmt,
+                    parameters: [.int32(i), .string("user-\(i)")]
+                )
+            }
+
+            let rows = try await self.cassandraClient.query("select * from \(tableName);")
+            XCTAssertEqual(Array(rows).count, 10)
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPreparedStatementMetadata() throws {
+        runAsyncAndWaitFor {
+            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.cassandraClient.run(
+                "create table \(tableName) (id int primary key, name text, score double);"
+            )
+
+            let stmt = try await self.cassandraClient.prepare(
+                "insert into \(tableName) (id, name, score) values (?, ?, ?)"
+            )
+            XCTAssertEqual(stmt.parameterCount, 3)
+            XCTAssertEqual(stmt.parameterName(at: 0), "id")
+            XCTAssertEqual(stmt.parameterName(at: 1), "name")
+            XCTAssertEqual(stmt.parameterName(at: 2), "score")
+            XCTAssertNil(stmt.parameterName(at: 3))
+            XCTAssertNil(stmt.parameterName(at: -1))
+
+            let noParamsStmt = try await self.cassandraClient.prepare(
+                "select * from \(tableName)"
+            )
+            XCTAssertEqual(noParamsStmt.parameterCount, 0)
+            XCTAssertNil(noParamsStmt.parameterName(at: 0))
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPreparedStatementInvalidQuery() throws {
+        runAsyncAndWaitFor {
+            do {
+                _ = try await self.cassandraClient.prepare("select * from nonexistent_table_xyz")
+                XCTFail("Expected prepare to throw for invalid query")
+            } catch {
+                XCTAssertTrue(error is CassandraClient.Error)
+            }
+        }
+    }
 }
 
 extension XCTestCase {

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -1435,8 +1435,82 @@ final class Tests: XCTestCase {
 
     // MARK: - Prepared statements
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testPreparedStatementRoundtrip() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run("create table \(tableName) (id int primary key, name text);").wait()
+
+        let insertStmt = try self.cassandraClient.prepare(
+            "insert into \(tableName) (id, name) values (?, ?)"
+        ).wait()
+        try self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [.int32(1), .string("alice")]
+        ).wait()
+
+        let selectStmt = try self.cassandraClient.prepare(
+            "select id, name from \(tableName) where id = ?"
+        ).wait()
+        let rows = try self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.int32(1)]
+        ).wait()
+        let result = Array(rows)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].column(0)?.int32, 1)
+        XCTAssertEqual(result[0].column(1)?.string, "alice")
+    }
+
+    func testPreparedStatementReuse() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run("create table \(tableName) (id int primary key, name text);").wait()
+
+        let insertStmt = try self.cassandraClient.prepare(
+            "insert into \(tableName) (id, name) values (?, ?)"
+        ).wait()
+        for i: Int32 in 0..<10 {
+            try self.cassandraClient.execute(
+                prepared: insertStmt,
+                parameters: [.int32(i), .string("user-\(i)")]
+            ).wait()
+        }
+
+        let rows = try self.cassandraClient.query("select * from \(tableName);").wait()
+        XCTAssertEqual(Array(rows).count, 10)
+    }
+
+    func testPreparedStatementMetadata() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id int primary key, name text, score double);"
+        ).wait()
+
+        let stmt = try self.cassandraClient.prepare(
+            "insert into \(tableName) (id, name, score) values (?, ?, ?)"
+        ).wait()
+        XCTAssertEqual(stmt.parameterCount, 3)
+        XCTAssertEqual(stmt.parameterName(at: 0), "id")
+        XCTAssertEqual(stmt.parameterName(at: 1), "name")
+        XCTAssertEqual(stmt.parameterName(at: 2), "score")
+        XCTAssertNil(stmt.parameterName(at: 3))
+        XCTAssertNil(stmt.parameterName(at: -1))
+
+        let noParamsStmt = try self.cassandraClient.prepare(
+            "select * from \(tableName)"
+        ).wait()
+        XCTAssertEqual(noParamsStmt.parameterCount, 0)
+        XCTAssertNil(noParamsStmt.parameterName(at: 0))
+    }
+
+    func testPreparedStatementInvalidQuery() throws {
+        XCTAssertThrowsError(
+            try self.cassandraClient.prepare("select * from nonexistent_table_xyz").wait()
+        ) { error in
+            XCTAssertTrue(error is CassandraClient.Error)
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPreparedStatementAsyncRoundtrip() throws {
         runAsyncAndWaitFor {
             let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
             try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
@@ -1460,65 +1534,6 @@ final class Tests: XCTestCase {
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].column(0)?.int32, 1)
             XCTAssertEqual(result[0].column(1)?.string, "alice")
-        }
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func testPreparedStatementReuse() throws {
-        runAsyncAndWaitFor {
-            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
-
-            let insertStmt = try await self.cassandraClient.prepare(
-                "insert into \(tableName) (id, name) values (?, ?)"
-            )
-            for i: Int32 in 0..<10 {
-                try await self.cassandraClient.execute(
-                    prepared: insertStmt,
-                    parameters: [.int32(i), .string("user-\(i)")]
-                )
-            }
-
-            let rows = try await self.cassandraClient.query("select * from \(tableName);")
-            XCTAssertEqual(Array(rows).count, 10)
-        }
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func testPreparedStatementMetadata() throws {
-        runAsyncAndWaitFor {
-            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.cassandraClient.run(
-                "create table \(tableName) (id int primary key, name text, score double);"
-            )
-
-            let stmt = try await self.cassandraClient.prepare(
-                "insert into \(tableName) (id, name, score) values (?, ?, ?)"
-            )
-            XCTAssertEqual(stmt.parameterCount, 3)
-            XCTAssertEqual(stmt.parameterName(at: 0), "id")
-            XCTAssertEqual(stmt.parameterName(at: 1), "name")
-            XCTAssertEqual(stmt.parameterName(at: 2), "score")
-            XCTAssertNil(stmt.parameterName(at: 3))
-            XCTAssertNil(stmt.parameterName(at: -1))
-
-            let noParamsStmt = try await self.cassandraClient.prepare(
-                "select * from \(tableName)"
-            )
-            XCTAssertEqual(noParamsStmt.parameterCount, 0)
-            XCTAssertNil(noParamsStmt.parameterName(at: 0))
-        }
-    }
-
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func testPreparedStatementInvalidQuery() throws {
-        runAsyncAndWaitFor {
-            do {
-                _ = try await self.cassandraClient.prepare("select * from nonexistent_table_xyz")
-                XCTFail("Expected prepare to throw for invalid query")
-            } catch {
-                XCTAssertTrue(error is CassandraClient.Error)
-            }
         }
     }
 }

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -593,6 +593,66 @@ final class EncryptionIntegrationTests: XCTestCase {
         XCTAssertEqual(results[0].secret.value, secretValue)
     }
 
+    /// Prepared statement read path with column registration — execute<T>(prepared:) decodes via makeDecoder.
+    func testColumnRegistrationWithPreparedStatement() async throws {
+        let tableName = "test_colreg_prep_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        // Create table using a session from the current client
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        self.recreateClient()
+
+        let userId = "user-prep"
+        let secretValue = "prepared-secret"
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string(userId))
+        )
+
+        // Write using a prepared statement with explicit context
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: baseContext.forColumn("secret")),
+            ]
+        )
+
+        // Read using a prepared statement with column registration
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select user_id, secret from \(tableName) where user_id = ?"
+        )
+        var readOptions = CassandraClient.Statement.Options()
+        readOptions.encryptionTable = tableName
+
+        let results: [UserWithSecret] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string(userId)],
+            options: readOptions
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].user_id, userId)
+        XCTAssertEqual(results[0].secret.value, secretValue)
+    }
+
     /// Both encryptionContextBuilder and encryptionTable are set — builder wins.
     func testColumnRegistrationBuilderTakesPrecedence() throws {
         let tableName = "test_colreg_prec_\(DispatchTime.now().uptimeNanoseconds)"
@@ -696,8 +756,50 @@ final class EncryptionIntegrationTests: XCTestCase {
 
     // MARK: - Write-path enforcement
 
+    /// Binding a plaintext value to a column registered as encrypted should throw.
+    func testWritePathRejectsPlaintextForEncryptedColumn() async throws {
+        let tableName = "test_wp_reject_pt_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        self.recreateClient()
+
+        let prepared = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        do {
+            // Bind plaintext bytes to an encrypted column — should be rejected
+            _ = try await self.cassandraClient.execute(
+                prepared: prepared,
+                parameters: [.string("user-1"), .bytes([0x01, 0x02])],
+                options: options
+            )
+            XCTFail("Expected encryptionConfigError for plaintext value on encrypted column")
+        } catch let error as CassandraClient.Error {
+            let msg = error.description
+            XCTAssertTrue(msg.contains("secret"), "Error should mention column name: \(msg)")
+        }
+    }
+
     /// Binding an encrypted value to a column NOT registered as encrypted should throw.
-    func testWritePathRejectsEncryptedForPlaintextColumn() throws {
+    func testWritePathRejectsEncryptedForPlaintextColumn() async throws {
         let tableName = "test_wp_reject_enc_\(DispatchTime.now().uptimeNanoseconds)"
         let keyspace = self.configuration.keyspace!
 
@@ -717,6 +819,10 @@ final class EncryptionIntegrationTests: XCTestCase {
 
         self.recreateClient()
 
+        let prepared = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, name) values (?, ?)"
+        )
+
         let baseContext = CassandraClient.EncryptionContext.Base(
             keyspace: keyspace,
             table: tableName,
@@ -728,14 +834,14 @@ final class EncryptionIntegrationTests: XCTestCase {
 
         do {
             // Bind encrypted value to a plaintext column — should be rejected
-            try self.cassandraClient.run(
-                "insert into \(tableName) (user_id, name) values (?, ?)",
+            _ = try await self.cassandraClient.execute(
+                prepared: prepared,
                 parameters: [
                     .string("user-1"),
                     .encryptedString(CassandraClient.Encrypted("oops"), context: baseContext.forColumn("name")),
                 ],
                 options: options
-            ).wait()
+            )
             XCTFail("Expected encryptionConfigError for encrypted value on plaintext column")
         } catch let error as CassandraClient.Error {
             let msg = error.description

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -1273,9 +1273,194 @@ final class EncryptionIntegrationTests: XCTestCase {
         }
     }
 
-}
+    // MARK: - Batch + encryption tests
 
-// MARK: - Test models
+    /// Batch insert multiple rows with encrypted values, read back and verify each decrypts correctly.
+    func testBatchEncryptedPreparedStatements() async throws {
+        let tableName = "test_batch_enc_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+        insertStmt.encryptionTable = tableName
+
+        try await self.cassandraClient.batch { batch in
+            try batch.add(
+                prepared: insertStmt,
+                parameters: [
+                    .string("alice"),
+                    .encryptedString(CassandraClient.Encrypted("alice-secret")),
+                ]
+            )
+            try batch.add(
+                prepared: insertStmt,
+                parameters: [
+                    .string("bob"),
+                    .encryptedString(CassandraClient.Encrypted("bob-secret")),
+                ]
+            )
+            try batch.add(
+                prepared: insertStmt,
+                parameters: [
+                    .string("carol"),
+                    .encryptedString(CassandraClient.Encrypted("carol-secret")),
+                ]
+            )
+        }
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select user_id, secret from \(tableName) where user_id = ?"
+        )
+        selectStmt.encryptionTable = tableName
+
+        for (userId, expected) in [("alice", "alice-secret"), ("bob", "bob-secret"), ("carol", "carol-secret")] {
+            let results: [UserWithSecret] = try await self.cassandraClient.execute(
+                prepared: selectStmt,
+                parameters: [.string(userId)]
+            )
+            XCTAssertEqual(results.count, 1)
+            XCTAssertEqual(results[0].secret.value, expected)
+        }
+    }
+
+    /// Batch with composite key — each row gets its own encryption context based on its PK values.
+    func testBatchEncryptedCompositeKey() async throws {
+        let tableName = "test_batch_enc_comp_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run(
+                "create table \(tableName) (partition_id text, cluster_id int, secret blob, PRIMARY KEY (partition_id, cluster_id))"
+            ).wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [
+                .init(name: "partition_id", type: .string),
+                .init(name: "cluster_id", type: .int32),
+            ],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (partition_id, cluster_id, secret) values (?, ?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        try await self.cassandraClient.batch { batch in
+            try batch.add(
+                prepared: insertStmt,
+                parameters: [
+                    .string("part-1"), .int32(1),
+                    .encryptedString(CassandraClient.Encrypted("secret-1-1")),
+                ],
+                options: options
+            )
+            try batch.add(
+                prepared: insertStmt,
+                parameters: [
+                    .string("part-1"), .int32(2),
+                    .encryptedString(CassandraClient.Encrypted("secret-1-2")),
+                ],
+                options: options
+            )
+            try batch.add(
+                prepared: insertStmt,
+                parameters: [
+                    .string("part-2"), .int32(1),
+                    .encryptedString(CassandraClient.Encrypted("secret-2-1")),
+                ],
+                options: options
+            )
+        }
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select partition_id, cluster_id, secret from \(tableName) where partition_id = ? and cluster_id = ?"
+        )
+
+        let r1: [CompositeKeyUser] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string("part-1"), .int32(1)],
+            options: options
+        )
+        XCTAssertEqual(r1.count, 1)
+        XCTAssertEqual(r1[0].secret.value, "secret-1-1")
+
+        let r2: [CompositeKeyUser] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string("part-1"), .int32(2)],
+            options: options
+        )
+        XCTAssertEqual(r2.count, 1)
+        XCTAssertEqual(r2[0].secret.value, "secret-1-2")
+
+        let r3: [CompositeKeyUser] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string("part-2"), .int32(1)],
+            options: options
+        )
+        XCTAssertEqual(r3.count, 1)
+        XCTAssertEqual(r3[0].secret.value, "secret-2-1")
+    }
+
+    /// Batch with non-encrypted prepared statement — resolver skips resolution, works normally.
+    func testBatchPreparedNoEncryption() async throws {
+        let tableName = "test_batch_no_enc_\(DispatchTime.now().uptimeNanoseconds)"
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (id text primary key, value text)").wait()
+        }
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (id, value) values (?, ?)"
+        )
+
+        try await self.cassandraClient.batch { batch in
+            try batch.add(prepared: insertStmt, parameters: [.string("a"), .string("val-a")])
+            try batch.add(prepared: insertStmt, parameters: [.string("b"), .string("val-b")])
+        }
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select id, value from \(tableName) where id = ?"
+        )
+
+        let rows = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string("a")]
+        )
+        let rowArray = Array(rows)
+        XCTAssertEqual(rowArray.count, 1)
+        let value: String? = rowArray[0].column("value")
+        XCTAssertEqual(value, "val-a")
+    }
+
+}
 
 struct UserWithSecret: Decodable {
     let user_id: String

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -1460,6 +1460,103 @@ final class EncryptionIntegrationTests: XCTestCase {
         XCTAssertEqual(value, "val-a")
     }
 
+    /// Batch mixing different prepared statements: two encrypted tables, one plaintext table.
+    func testBatchMixedEncryptedAndPlaintextTables() async throws {
+        let encTable1 = "test_batch_mix_enc1_\(DispatchTime.now().uptimeNanoseconds)"
+        let encTable2 = "test_batch_mix_enc2_\(DispatchTime.now().uptimeNanoseconds)"
+        let plainTable = "test_batch_mix_plain_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(encTable1) (user_id text primary key, secret blob)").wait()
+            try session.run("create table \(encTable2) (item_id text primary key, data blob)").wait()
+            try session.run("create table \(plainTable) (id text primary key, value text)").wait()
+        }
+
+        let schema1 = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: encTable1,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        let schema2 = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: encTable2,
+            keyColumns: [.init(name: "item_id", type: .string)],
+            encryptedColumns: ["data"]
+        )
+        self.configuration.registerEncryptionSchema(schema1)
+        self.configuration.registerEncryptionSchema(schema2)
+        self.recreateClient()
+
+        let encInsert1 = try await self.cassandraClient.prepare(
+            "insert into \(encTable1) (user_id, secret) values (?, ?)"
+        )
+        encInsert1.encryptionTable = encTable1
+
+        let encInsert2 = try await self.cassandraClient.prepare(
+            "insert into \(encTable2) (item_id, data) values (?, ?)"
+        )
+        encInsert2.encryptionTable = encTable2
+
+        let plainInsert = try await self.cassandraClient.prepare(
+            "insert into \(plainTable) (id, value) values (?, ?)"
+        )
+
+        try await self.cassandraClient.batch { batch in
+            try batch.add(prepared: encInsert1, parameters: [
+                .string("alice"),
+                .encryptedString(CassandraClient.Encrypted("alice-secret")),
+            ])
+            try batch.add(prepared: encInsert2, parameters: [
+                .string("item-42"),
+                .encryptedBytes(CassandraClient.Encrypted([0xDE, 0xAD])),
+            ])
+            try batch.add(prepared: plainInsert, parameters: [
+                .string("row-1"),
+                .string("plain-value"),
+            ])
+        }
+
+        let encSelect1 = try await self.cassandraClient.prepare(
+            "select user_id, secret from \(encTable1) where user_id = ?"
+        )
+        encSelect1.encryptionTable = encTable1
+
+        let aliceResults: [UserWithSecret] = try await self.cassandraClient.execute(
+            prepared: encSelect1,
+            parameters: [.string("alice")]
+        )
+        XCTAssertEqual(aliceResults.count, 1)
+        XCTAssertEqual(aliceResults[0].secret.value, "alice-secret")
+
+        let encSelect2 = try await self.cassandraClient.prepare(
+            "select item_id, data from \(encTable2) where item_id = ?"
+        )
+        encSelect2.encryptionTable = encTable2
+
+        let itemResults: [ItemWithData] = try await self.cassandraClient.execute(
+            prepared: encSelect2,
+            parameters: [.string("item-42")]
+        )
+        XCTAssertEqual(itemResults.count, 1)
+        XCTAssertEqual(itemResults[0].data.value, [0xDE, 0xAD])
+
+        let plainSelect = try await self.cassandraClient.prepare(
+            "select id, value from \(plainTable) where id = ?"
+        )
+        let plainRows = try await self.cassandraClient.execute(
+            prepared: plainSelect,
+            parameters: [.string("row-1")]
+        )
+        let rowArray = Array(plainRows)
+        XCTAssertEqual(rowArray.count, 1)
+        let plainValue: String? = rowArray[0].column("value")
+        XCTAssertEqual(plainValue, "plain-value")
+    }
+
 }
 
 struct UserWithSecret: Decodable {
@@ -1477,4 +1574,9 @@ struct CompositeKeyUser: Decodable {
     let partition_id: String
     let cluster_id: Int32
     let secret: CassandraClient.Encrypted<String>
+}
+
+struct ItemWithData: Decodable {
+    let item_id: String
+    let data: CassandraClient.Encrypted<[UInt8]>
 }

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -849,9 +849,433 @@ final class EncryptionIntegrationTests: XCTestCase {
         }
     }
 
+    // MARK: - Auto context inference tests (metadata-based)
+
+    /// Auto-inferred context: write with .encryptedString (no context) and read back successfully.
+    func testAutoContextInferenceBasic() async throws {
+        let tableName = "test_auto_ctx_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let userId = "user-auto"
+        let secretValue = "auto-secret"
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue)),
+            ],
+            options: options
+        )
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select user_id, secret from \(tableName) where user_id = ?"
+        )
+
+        let results: [UserWithSecret] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string(userId)],
+            options: options
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].user_id, userId)
+        XCTAssertEqual(results[0].secret.value, secretValue)
+    }
+
+    /// Auto-inferred context with composite primary key (partition + clustering).
+    func testAutoContextInferenceCompositeKey() async throws {
+        let tableName = "test_auto_ctx_comp_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run(
+                "create table \(tableName) (partition_id text, cluster_id int, secret blob, PRIMARY KEY (partition_id, cluster_id))"
+            ).wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [
+                .init(name: "partition_id", type: .string),
+                .init(name: "cluster_id", type: .int32),
+            ],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let partitionId = "part-1"
+        let clusterId: Int32 = 42
+        let secretValue = "composite-secret"
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (partition_id, cluster_id, secret) values (?, ?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(partitionId),
+                .int32(clusterId),
+                .encryptedString(CassandraClient.Encrypted(secretValue)),
+            ],
+            options: options
+        )
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select partition_id, cluster_id, secret from \(tableName) where partition_id = ? and cluster_id = ?"
+        )
+
+        let results: [CompositeKeyUser] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string(partitionId), .int32(clusterId)],
+            options: options
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].secret.value, secretValue)
+    }
+
+    /// Auto-inferred context with multiple encrypted columns.
+    func testAutoContextInferenceMultipleEncryptedColumns() async throws {
+        let tableName = "test_auto_ctx_multi_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run(
+                "create table \(tableName) (user_id text primary key, secret_name blob, secret_age blob)"
+            ).wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret_name", "secret_age"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let userId = "user-multi"
+        let nameValue = "Alice"
+        let ageValue: Int32 = 30
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret_name, secret_age) values (?, ?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(nameValue)),
+                .encryptedInt32(CassandraClient.Encrypted(ageValue)),
+            ],
+            options: options
+        )
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select user_id, secret_name, secret_age from \(tableName) where user_id = ?"
+        )
+
+        let results: [UserWithMultipleSecrets] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string(userId)],
+            options: options
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].secret_name.value, nameValue)
+        XCTAssertEqual(results[0].secret_age.value, ageValue)
+    }
+
+    /// Mixed: one encrypted column with explicit context, another auto-inferred.
+    func testAutoContextInferenceMixedExplicitAndAuto() async throws {
+        let tableName = "test_auto_ctx_mixed_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run(
+                "create table \(tableName) (user_id text primary key, secret_name blob, secret_age blob)"
+            ).wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret_name", "secret_age"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let userId = "user-mixed"
+        let nameValue = "Alice"
+        let ageValue: Int32 = 30
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string(userId))
+        )
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret_name, secret_age) values (?, ?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(nameValue), context: baseContext.forColumn("secret_name")),
+                .encryptedInt32(CassandraClient.Encrypted(ageValue)),
+            ],
+            options: options
+        )
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select user_id, secret_name, secret_age from \(tableName) where user_id = ?"
+        )
+
+        let results: [UserWithMultipleSecrets] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string(userId)],
+            options: options
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].secret_name.value, nameValue)
+        XCTAssertEqual(results[0].secret_age.value, ageValue)
+    }
+
+    /// Missing PK column in parameters should produce a clear error.
+    func testAutoContextInferenceErrorsOnMissingPKColumn() async throws {
+        let tableName = "test_auto_ctx_missing_pk_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run(
+                "create table \(tableName) (part_id text, clust_id int, secret blob, PRIMARY KEY (part_id, clust_id))"
+            ).wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [
+                .init(name: "part_id", type: .string),
+                .init(name: "clust_id", type: .int32),
+            ],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        // part_id is hardcoded in the query — not a bind parameter
+        let updateStmt = try await self.cassandraClient.prepare(
+            "update \(tableName) set secret = ? where part_id = 'fixed' and clust_id = ?"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        do {
+            _ = try await self.cassandraClient.execute(
+                prepared: updateStmt,
+                parameters: [
+                    .encryptedString(CassandraClient.Encrypted("value")),
+                    .int32(1),
+                ],
+                options: options
+            )
+            XCTFail("Expected error for missing PK column")
+        } catch let error as CassandraClient.Error {
+            let msg = error.description
+            XCTAssertTrue(msg.contains("part_id"), "Error should mention missing key column: \(msg)")
+        }
+    }
+
+    /// NULL PK value should produce a clear error.
+    func testAutoContextInferenceErrorsOnNullPKValue() async throws {
+        let tableName = "test_auto_ctx_null_pk_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        do {
+            _ = try await self.cassandraClient.execute(
+                prepared: insertStmt,
+                parameters: [
+                    .null,
+                    .encryptedString(CassandraClient.Encrypted("value")),
+                ],
+                options: options
+            )
+            XCTFail("Expected error for null PK value")
+        } catch let error as CassandraClient.Error {
+            let msg = error.description
+            XCTAssertTrue(msg.contains("user_id"), "Error should mention the key column: \(msg)")
+        }
+    }
+
+    /// Two rows with different PKs: each gets its own context and decrypts independently.
+    func testAutoContextInferenceDistinctKeysPerRow() async throws {
+        let tableName = "test_auto_ctx_distinct_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+        self.recreateClient()
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionTable = tableName
+
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string("alice"),
+                .encryptedString(CassandraClient.Encrypted("alice-secret")),
+            ],
+            options: options
+        )
+
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string("bob"),
+                .encryptedString(CassandraClient.Encrypted("bob-secret")),
+            ],
+            options: options
+        )
+
+        let selectStmt = try await self.cassandraClient.prepare(
+            "select user_id, secret from \(tableName) where user_id = ?"
+        )
+
+        let aliceResults: [UserWithSecret] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string("alice")],
+            options: options
+        )
+        XCTAssertEqual(aliceResults.count, 1)
+        XCTAssertEqual(aliceResults[0].secret.value, "alice-secret")
+
+        let bobResults: [UserWithSecret] = try await self.cassandraClient.execute(
+            prepared: selectStmt,
+            parameters: [.string("bob")],
+            options: options
+        )
+        XCTAssertEqual(bobResults.count, 1)
+        XCTAssertEqual(bobResults[0].secret.value, "bob-secret")
+    }
+
+    /// No encryptionTable in options — context-less encrypted value should error at bind time.
+    func testAutoContextInferenceErrorsWithoutEncryptionTable() async throws {
+        let tableName = "test_auto_ctx_no_table_\(DispatchTime.now().uptimeNanoseconds)"
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+
+        do {
+            _ = try await self.cassandraClient.execute(
+                prepared: insertStmt,
+                parameters: [
+                    .string("user-1"),
+                    .encryptedString(CassandraClient.Encrypted("value")),
+                ]
+            )
+            XCTFail("Expected error for context-less encrypted value without encryptionTable")
+        } catch let error as CassandraClient.Error {
+            let msg = error.description
+            XCTAssertTrue(msg.contains("no encryption context"), "Error should explain missing context: \(msg)")
+        }
+    }
+
 }
 
-// MARK: - Test model
+// MARK: - Test models
 
 struct UserWithSecret: Decodable {
     let user_id: String
@@ -862,4 +1286,10 @@ struct UserWithMultipleSecrets: Decodable {
     let user_id: String
     let secret_name: CassandraClient.Encrypted<String>
     let secret_age: CassandraClient.Encrypted<Int32>
+}
+
+struct CompositeKeyUser: Decodable {
+    let partition_id: String
+    let cluster_id: Int32
+    let secret: CassandraClient.Encrypted<String>
 }

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -1296,9 +1296,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         self.recreateClient()
 
         let insertStmt = try await self.cassandraClient.prepare(
-            "insert into \(tableName) (user_id, secret) values (?, ?)"
+            "insert into \(tableName) (user_id, secret) values (?, ?)",
+            encryptionTable: tableName
         )
-        insertStmt.encryptionTable = tableName
 
         try await self.cassandraClient.batch { batch in
             try batch.add(
@@ -1325,9 +1325,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         }
 
         let selectStmt = try await self.cassandraClient.prepare(
-            "select user_id, secret from \(tableName) where user_id = ?"
+            "select user_id, secret from \(tableName) where user_id = ?",
+            encryptionTable: tableName
         )
-        selectStmt.encryptionTable = tableName
 
         for (userId, expected) in [("alice", "alice-secret"), ("bob", "bob-secret"), ("carol", "carol-secret")] {
             let results: [UserWithSecret] = try await self.cassandraClient.execute(
@@ -1492,38 +1492,47 @@ final class EncryptionIntegrationTests: XCTestCase {
         self.recreateClient()
 
         let encInsert1 = try await self.cassandraClient.prepare(
-            "insert into \(encTable1) (user_id, secret) values (?, ?)"
+            "insert into \(encTable1) (user_id, secret) values (?, ?)",
+            encryptionTable: encTable1
         )
-        encInsert1.encryptionTable = encTable1
 
         let encInsert2 = try await self.cassandraClient.prepare(
-            "insert into \(encTable2) (item_id, data) values (?, ?)"
+            "insert into \(encTable2) (item_id, data) values (?, ?)",
+            encryptionTable: encTable2
         )
-        encInsert2.encryptionTable = encTable2
 
         let plainInsert = try await self.cassandraClient.prepare(
             "insert into \(plainTable) (id, value) values (?, ?)"
         )
 
         try await self.cassandraClient.batch { batch in
-            try batch.add(prepared: encInsert1, parameters: [
-                .string("alice"),
-                .encryptedString(CassandraClient.Encrypted("alice-secret")),
-            ])
-            try batch.add(prepared: encInsert2, parameters: [
-                .string("item-42"),
-                .encryptedBytes(CassandraClient.Encrypted([0xDE, 0xAD])),
-            ])
-            try batch.add(prepared: plainInsert, parameters: [
-                .string("row-1"),
-                .string("plain-value"),
-            ])
+            try batch.add(
+                prepared: encInsert1,
+                parameters: [
+                    .string("alice"),
+                    .encryptedString(CassandraClient.Encrypted("alice-secret")),
+                ]
+            )
+            try batch.add(
+                prepared: encInsert2,
+                parameters: [
+                    .string("item-42"),
+                    .encryptedBytes(CassandraClient.Encrypted([0xDE, 0xAD])),
+                ]
+            )
+            try batch.add(
+                prepared: plainInsert,
+                parameters: [
+                    .string("row-1"),
+                    .string("plain-value"),
+                ]
+            )
         }
 
         let encSelect1 = try await self.cassandraClient.prepare(
-            "select user_id, secret from \(encTable1) where user_id = ?"
+            "select user_id, secret from \(encTable1) where user_id = ?",
+            encryptionTable: encTable1
         )
-        encSelect1.encryptionTable = encTable1
 
         let aliceResults: [UserWithSecret] = try await self.cassandraClient.execute(
             prepared: encSelect1,
@@ -1533,9 +1542,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         XCTAssertEqual(aliceResults[0].secret.value, "alice-secret")
 
         let encSelect2 = try await self.cassandraClient.prepare(
-            "select item_id, data from \(encTable2) where item_id = ?"
+            "select item_id, data from \(encTable2) where item_id = ?",
+            encryptionTable: encTable2
         )
-        encSelect2.encryptionTable = encTable2
 
         let itemResults: [ItemWithData] = try await self.cassandraClient.execute(
             prepared: encSelect2,


### PR DESCRIPTION
Adding support for prepared statements in Swift driver.

### Motivation:

The client had no way to prepare CQL queries server-side and reuse them. Every query was parsed fresh on each execution. For encrypted workloads, this also meant write-path validation could only check one direction — encrypted values bound to wrong columns — because inline queries lack column name metadata for positional parameters.    

### Modifications:

- PreparedStatement wrapper class around the C driver's CassPrepared*, exposing parameter count and column name metadata.                                                                                                                                         - prepare() and execute(prepared:) on CassandraSession protocol, with both EventLoopFuture and async variants, plus Codable decoding overload.                                                                                                                     
- Bidirectional encryption validation using prepared statement parameter metadata — catches both plaintext→encrypted and encrypted→plaintext mismatches.
- 5 integration tests (4 ELF, 1 async) and 3 encryption integration tests using prepared statements.   

### Result:

Users can prepare queries once and execute them repeatedly with different parameters, avoiding repeated server-side parsing. Encrypted workloads get full bidirectional write-path validation when using prepared statements with column registration.     