### PR TITLE
Allow higher swift-crypto versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.36.0"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
         .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "2.0.0")),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.36.0"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "2.0.0")),
     ],
     targets: [


### PR DESCRIPTION
Allow crypto 4.x

### Motivation:

Users might want to use 4.x in their dependency tree, but this library limits them to 3.x

### Modifications:

Change the version requirements to 3.0.0..<5.0.0

This should be ok since there's almost no api break between crypto versions, as documented in the swift-crypto readme

### Result:

Users can use 3.x or 4.x
