### PR TITLE
Make a nominal type for CassSession and CassFuture

### DIFF
--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -55,8 +55,8 @@ extension CassandraClient {
     public final class Rows: Sequence {
         internal let rawPointer: OpaquePointer
 
-        internal init(_ resultFutureRawPointer: OpaquePointer) {
-            self.rawPointer = cass_future_get_result(resultFutureRawPointer)
+        internal init(_ resultRawPointer: OpaquePointer) {
+            self.rawPointer = resultRawPointer
         }
 
         deinit {

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -97,15 +97,6 @@ extension CassandraClient {
             self.code = code
         }
 
-        init(_ future: OpaquePointer) {
-            let errorCode = cass_future_error_code(future)
-            var messageRaw: UnsafePointer<CChar>?
-            var messageLength = Int()
-            cass_future_error_message(future, &messageRaw, &messageLength)
-            let message = messageRaw.map { String(cString: $0) }
-            self.init(errorCode, message: message)
-        }
-
         init(_ error: CassError, message: String? = .none) {
             let message = message ?? ""
             switch error {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -298,6 +298,119 @@ extension CassandraSession {
     }
 }
 
+final class CassFuture<T>: Sendable {
+    /// This can be nonisolated because the docs state that a CassFuture is thread-safe.
+    /// See Sources/CDataStaxDriver/datastax-cpp-driver/topics/README.md
+    private nonisolated(unsafe) let rawPointer: OpaquePointer
+    private let mapper: @Sendable (OpaquePointer?) -> T
+
+    init(rawPointer: OpaquePointer, mapper: @escaping @Sendable (OpaquePointer?) -> T) {
+        self.rawPointer = rawPointer
+        self.mapper = mapper
+    }
+
+    func complete(to promise: EventLoopPromise<T>) {
+        setResultCallback { result in
+            promise.completeWith(result)
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func await() async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            setResultCallback { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    func syncWait() throws -> T {
+        var result: Result<T, any Error>?
+        let semaphore = DispatchSemaphore(value: 0)
+        self.setResultCallback {
+            result = $0
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return try result!.get()
+    }
+
+    private func setResultCallback(
+        completion: @escaping (Result<T, any Error>) -> Void
+    ) {
+        let closure = unmanagedRetainedClosure {
+            DispatchQueue.global().async {
+                let result = self.result()
+                cass_future_free(self.rawPointer)
+                completion(result)
+            }
+        }
+        cass_future_set_callback(self.rawPointer, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
+    }
+
+    private func result() -> Result<T, any Error> {
+        let resultCode = cass_future_error_code(self.rawPointer)
+        if resultCode == CASS_OK {
+            let resultPointer = cass_future_get_result(self.rawPointer)
+            return .success(self.mapper(resultPointer))
+        } else {
+            var messageRaw: UnsafePointer<CChar>?
+            var messageLength = Int()
+            cass_future_error_message(self.rawPointer, &messageRaw, &messageLength)
+            let message = messageRaw.map { String(cString: $0) }
+            let error = CassandraClient.Error(resultCode, message: message)
+            return .failure(error)
+        }
+    }
+}
+
+extension CassFuture where T == Void {
+    convenience init(rawPointer: OpaquePointer) {
+        self.init(rawPointer: rawPointer, mapper: { _ in })
+    }
+}
+
+struct CassSession: Sendable, ~Copyable {
+    /// This can be nonisolated because the docs state that a CassSession is thread-safe.
+    /// See Sources/CDataStaxDriver/datastax-cpp-driver/topics/README.md
+    private nonisolated(unsafe) let rawPointer: OpaquePointer
+
+    init() {
+        self.rawPointer = cass_session_new()
+    }
+
+    deinit {
+        cass_session_free(self.rawPointer)
+    }
+
+    func connect(cluster: Cluster, keyspace: String?) -> CassFuture<Void> {
+        let futurePointer =
+            if let keyspace {
+                cass_session_connect_keyspace(self.rawPointer, cluster.rawPointer, keyspace)
+            } else {
+                cass_session_connect(self.rawPointer, cluster.rawPointer)
+            }
+        return CassFuture(rawPointer: futurePointer!)
+    }
+
+    func execute(statement: CassandraClient.Statement) -> CassFuture<CassandraClient.Rows> {
+        let futurePointer = cass_session_execute(self.rawPointer, statement.rawPointer)
+        return CassFuture(rawPointer: futurePointer!, mapper: { CassandraClient.Rows($0!) })
+    }
+
+    func getMetrics() -> CassandraMetrics {
+        var metrics = CDataStaxDriver.CassMetrics()
+        cass_session_get_metrics(self.rawPointer, &metrics)
+        return CassandraMetrics(metrics: metrics)
+    }
+
+    func close() -> CassFuture<Void> {
+        let futurePointer = cass_session_close(self.rawPointer)
+        return CassFuture(rawPointer: futurePointer!)
+    }
+
+}
+
 extension CassandraClient {
     internal final class Session: CassandraSession {
         private let eventLoopGroupContainer: EventLoopGroupContainer
@@ -324,7 +437,7 @@ extension CassandraClient {
         private var state = State.idle
         private let lock = Lock()
 
-        private let rawPointer: OpaquePointer
+        private let underlying: CassSession
 
         private enum State {
             case idle
@@ -342,7 +455,7 @@ extension CassandraClient {
             self.configuration = configuration
             self.logger = logger
             self.eventLoopGroupContainer = eventLoopGroupContainer
-            self.rawPointer = cass_session_new()
+            self.underlying = .init()
         }
 
         deinit {
@@ -351,7 +464,6 @@ extension CassandraClient {
                     "Session not shut down before the deinit. Please call session.shutdown() when no longer needed."
                 )
             }
-            cass_session_free(self.rawPointer)
         }
 
         func shutdown() throws {
@@ -410,10 +522,8 @@ extension CassandraClient {
                 logger.debug("executing: \(statement.query)")
                 logger.trace("\(statement.parameters)")
                 let promise = eventLoop.makePromise(of: Rows.self)
-                let future = cass_session_execute(rawPointer, statement.rawPointer)
-                futureSetResultCallback(future!) { result in
-                    promise.completeWith(result)
-                }
+                let future = self.underlying.execute(statement: statement)
+                future.complete(to: promise)
                 return promise.futureResult
             case .disconnected:
                 self.lock.unlock()
@@ -450,42 +560,19 @@ extension CassandraClient {
             return self.configuration.makeCluster(on: eventLoop)
                 .flatMap { cluster in
                     let promise = eventLoop.makePromise(of: Void.self)
-
-                    let future: OpaquePointer
-                    if let keyspace = self.configuration.keyspace {
-                        future = cass_session_connect_keyspace(self.rawPointer, cluster.rawPointer, keyspace)
-                    } else {
-                        future = cass_session_connect(self.rawPointer, cluster.rawPointer)
-                    }
-
-                    futureSetCallback(future) { result in
-                        promise.completeWith(result)
-                    }
-
+                    let future = self.underlying.connect(cluster: cluster, keyspace: self.configuration.keyspace)
+                    future.complete(to: promise)
                     return promise.futureResult
                 }
         }
 
         private func disconnect() throws {
-            var error: Swift.Error?
-            let semaphore = DispatchSemaphore(value: 0)
-            let future = cass_session_close(rawPointer)
-            futureSetCallback(future!) { result in
-                defer { semaphore.signal() }
-                if case .failure(let e) = result {
-                    error = e
-                }
-            }
-            semaphore.wait()
-            if let error = error {
-                throw error
-            }
+            let future = self.underlying.close()
+            try future.syncWait()
         }
 
         func getMetrics() -> CassandraMetrics {
-            var metrics = CDataStaxDriver.CassMetrics()
-            cass_session_get_metrics(self.rawPointer, &metrics)
-            return CassandraMetrics(metrics: metrics)
+            self.underlying.getMetrics()
         }
 
         private struct ConnectionTask {
@@ -631,12 +718,8 @@ extension CassandraClient.Session {
             lock.unlock()
             logger.debug("executing: \(statement.query)")
             logger.trace("\(statement.parameters)")
-            let future = cass_session_execute(rawPointer, statement.rawPointer)
-            return try await withCheckedThrowingContinuation { continuation in
-                futureSetResultCallback(future!) { result in
-                    continuation.resume(with: result)
-                }
-            }
+            let future = self.underlying.execute(statement: statement)
+            return try await future.await()
         case .disconnected:
             lock.unlock()
             if eventLoopGroupContainer.managed {
@@ -665,19 +748,8 @@ extension CassandraClient.Session {
             logger.debug("connecting to: \(self.configuration)")
 
             let cluster = try await self.configuration.makeCluster()
-
-            let future: OpaquePointer
-            if let keyspace = self.configuration.keyspace {
-                future = cass_session_connect_keyspace(self.rawPointer, cluster.rawPointer, keyspace)
-            } else {
-                future = cass_session_connect(self.rawPointer, cluster.rawPointer)
-            }
-
-            try await withCheckedThrowingContinuation { continuation in
-                futureSetCallback(future) { result in
-                    continuation.resume(with: result)
-                }
-            }
+            let future = self.underlying.connect(cluster: cluster, keyspace: self.configuration.keyspace)
+            return try await future.await()
         }
     }
 }
@@ -695,39 +767,6 @@ private func callAndReleaseUnmanagedClosure(_ opaque: UnsafeRawPointer) {
     let unmanaged = Unmanaged<Box<() -> Void>>.fromOpaque(opaque)
     let closure = unmanaged.takeRetainedValue()
     closure.value()
-}
-
-private func futureSetCallback(
-    _ future: OpaquePointer,
-    completion: @escaping (Result<Void, Error>) -> Void
-) {
-    let closure = unmanagedRetainedClosure {
-        DispatchQueue.global().async {
-            let resultCode = cass_future_error_code(future)
-            let result: Result<Void, Error> =
-                resultCode == CASS_OK ? .success(()) : .failure(CassandraClient.Error(future))
-            cass_future_free(future)
-            completion(result)
-        }
-    }
-    cass_future_set_callback(future, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
-}
-
-private func futureSetResultCallback(
-    _ future: OpaquePointer,
-    completion: @escaping (Result<CassandraClient.Rows, Error>) -> Void
-) {
-    let closure = unmanagedRetainedClosure {
-        DispatchQueue.global().async {
-            let resultCode = cass_future_error_code(future)
-            let result: Result<CassandraClient.Rows, Error> =
-                resultCode == CASS_OK
-                ? .success(CassandraClient.Rows(future)) : .failure(CassandraClient.Error(future))
-            cass_future_free(future)
-            completion(result)
-        }
-    }
-    cass_future_set_callback(future, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
 }
 
 private final class Box<T> {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -479,10 +479,19 @@ final class CassFuture<T>: Sendable {
     /// This can be nonisolated because the docs state that a CassFuture is thread-safe.
     /// See Sources/CDataStaxDriver/datastax-cpp-driver/topics/README.md
     private nonisolated(unsafe) let rawPointer: OpaquePointer
+    /// Extracts the value pointer from the completed future. This keeps the choice of C
+    /// extraction API (`cass_future_get_result` vs `cass_future_get_prepared`) out of the
+    /// mapper, which only ever sees the already-extracted value — never the future itself.
+    private let extract: @Sendable (OpaquePointer) -> OpaquePointer?
     private let mapper: @Sendable (OpaquePointer?) -> T
 
-    init(rawPointer: OpaquePointer, mapper: @escaping @Sendable (OpaquePointer?) -> T) {
+    private init(
+        rawPointer: OpaquePointer,
+        extract: @escaping @Sendable (OpaquePointer) -> OpaquePointer?,
+        mapper: @escaping @Sendable (OpaquePointer?) -> T
+    ) {
         self.rawPointer = rawPointer
+        self.extract = extract
         self.mapper = mapper
     }
 
@@ -524,7 +533,11 @@ final class CassFuture<T>: Sendable {
                 completion(result)
             }
         }
-        let error = cass_future_set_callback(self.rawPointer, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
+        let error = cass_future_set_callback(
+            self.rawPointer,
+            { _, data in callAndReleaseUnmanagedClosure(data!) },
+            closure
+        )
         if error == CASS_ERROR_LIB_CALLBACK_ALREADY_SET {
             assertionFailure("setResultCallback called multiple times. Only the first callback will be registered")
         }
@@ -533,8 +546,7 @@ final class CassFuture<T>: Sendable {
     private func result() -> Result<T, any Error> {
         let resultCode = cass_future_error_code(self.rawPointer)
         if resultCode == CASS_OK {
-            let resultPointer = cass_future_get_result(self.rawPointer)
-            return .success(self.mapper(resultPointer))
+            return .success(self.mapper(self.extract(self.rawPointer)))
         } else {
             var messageRaw: UnsafePointer<CChar>?
             var messageLength = Int()
@@ -546,9 +558,23 @@ final class CassFuture<T>: Sendable {
     }
 }
 
+extension CassFuture {
+    /// Wraps a future whose value is a query result (extracted via `cass_future_get_result`).
+    convenience init(rawPointer: OpaquePointer, mapper: @escaping @Sendable (OpaquePointer?) -> T) {
+        self.init(rawPointer: rawPointer, extract: { cass_future_get_result($0) }, mapper: mapper)
+    }
+}
+
+extension CassFuture where T == OpaquePointer {
+    /// Wraps a future whose value is a prepared statement (extracted via `cass_future_get_prepared`).
+    convenience init(preparedFrom rawPointer: OpaquePointer) {
+        self.init(rawPointer: rawPointer, extract: { cass_future_get_prepared($0) }, mapper: { $0! })
+    }
+}
+
 extension CassFuture where T == Void {
     convenience init(rawPointer: OpaquePointer) {
-        self.init(rawPointer: rawPointer, mapper: { _ in })
+        self.init(rawPointer: rawPointer, extract: { _ in nil }, mapper: { _ in })
     }
 }
 
@@ -577,7 +603,7 @@ struct CassSession: Sendable, ~Copyable {
 
     func prepare(query: String) -> CassFuture<OpaquePointer> {
         let futurePointer = cass_session_prepare(self.rawPointer, query)
-        return CassFuture(rawPointer: futurePointer!, mapper: { cass_future_get_prepared($0!) })
+        return CassFuture(preparedFrom: futurePointer!)
     }
 
     func execute(statement: CassandraClient.Statement) -> CassFuture<CassandraClient.Rows> {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -345,7 +345,10 @@ final class CassFuture<T>: Sendable {
                 completion(result)
             }
         }
-        cass_future_set_callback(self.rawPointer, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
+        let error = cass_future_set_callback(self.rawPointer, { _, data in callAndReleaseUnmanagedClosure(data!) }, closure)
+        if error == CASS_ERROR_LIB_CALLBACK_ALREADY_SET {
+            assertionFailure("setResultCallback called multiple times. Only the first callback will be registered")
+        }
     }
 
     private func result() -> Result<T, any Error> {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -523,7 +523,7 @@ final class CassFuture<T>: Sendable {
         return try result!.get()
     }
 
-    func setResultCallback(
+    private func setResultCallback(
         completion: @escaping (Result<T, any Error>) -> Void
     ) {
         let closure = unmanagedRetainedClosure {
@@ -790,32 +790,21 @@ extension CassandraClient {
         ) -> EventLoopFuture<CassandraClient.PreparedStatement> {
             self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("preparing: \(query)")
-                let promise = eventLoop.makePromise(of: CassandraClient.PreparedStatement.self)
                 let future = self.underlying.prepare(query: query)
-                future.setResultCallback { [self] result in
-                    switch result {
-                    case .success(let rawPointer):
-                        do {
-                            let pkColumns: [String]
-                            if let tableName = encryptionTable {
-                                pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
-                            } else {
-                                pkColumns = []
-                            }
-                            let prepared = CassandraClient.PreparedStatement(
-                                rawPointer: rawPointer,
-                                encryptionTable: encryptionTable,
-                                primaryKeyColumnNames: pkColumns
-                            )
-                            promise.succeed(prepared)
-                        } catch {
-                            promise.fail(error)
-                        }
-                    case .failure(let error):
-                        promise.fail(error)
+                return future.asNIOFuture(eventLoop: eventLoop).flatMapThrowing { rawPointer in
+                    let pkColumns: [String]
+                    if let tableName = encryptionTable {
+                        pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+                    } else {
+                        pkColumns = []
                     }
+                    let prepared = CassandraClient.PreparedStatement(
+                        rawPointer: rawPointer,
+                        encryptionTable: encryptionTable,
+                        primaryKeyColumnNames: pkColumns
+                    )
+                    return prepared
                 }
-                return promise.futureResult
             }
         }
 


### PR DESCRIPTION
To make it easier to understand where and how each pointer is used, wrap it in a type

The CassSession type is a non copyable struct to allow us to make a deinit. The CassFuture type cannot be non copyable because it has to capture self in closures, so it's class

This makes the type much easier to hold than a raw poitner, because these new types expose helpful functions

Furthermore, the new types are Sendable, unchecked but easily to validate because they have a small api