### PR TITLE
Conform various types to Sendable

### DIFF
--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -17,7 +17,7 @@ import Foundation
 
 extension CassandraClient {
     /// The type of a batch operation.
-    public struct BatchType: Equatable {
+    public struct BatchType: Sendable, Equatable {
         let rawValue: CassBatchType
 
         /// All statements are applied atomically with a write to the batch log.
@@ -110,7 +110,7 @@ extension CassandraClient {
         }
 
         /// Batch configuration options.
-        public struct Configuration {
+        public struct Configuration: Sendable {
             /// The batch type. Defaults to `.logged`.
             public var type: CassandraClient.BatchType = .logged
             /// The batch's consistency level.

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -20,7 +20,7 @@ import NIOConcurrencyHelpers
 
 /// `CassandraClient` is a wrapper around the [Datastax Cassandra C++ Driver](https://github.com/datastax/cpp-driver)
 ///  and can be used to run queries against a Cassandra database.
-public class CassandraClient: CassandraSession {
+public final class CassandraClient: CassandraSession, Sendable {
     private let eventLoopGroupContainer: EventLoopGroupContainer
     public var eventLoopGroup: EventLoopGroup {
         self.eventLoopGroupContainer.value
@@ -376,7 +376,7 @@ public class CassandraClient: CassandraSession {
     ///
     /// When `shared`, the `EventLoopGroup` is provided externally and its lifecycle will be managed by the caller.
     /// When `createNew`, the library will create a new `EventLoopGroup` and manage its lifecycle.
-    public enum EventLoopGroupProvider {
+    public enum EventLoopGroupProvider: Sendable {
         case shared(EventLoopGroup)
         case createNew
     }

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -18,12 +18,13 @@ import NIO
 // TODO: add more config option per C++ cluster impl
 extension CassandraClient {
     /// Configuration for the ``CassandraClient``.
-    public struct Configuration: CustomStringConvertible {
+    public struct Configuration: Sendable, CustomStringConvertible {
         public typealias ContactPoints = [String]
 
         /// Provides the initial `ContactPoints` of the Cassandra cluster.
         /// This can be a subset since each Cassandra instance is capable of discovering its peers.
-        public var contactPointsProvider: (@escaping (Result<ContactPoints, Swift.Error>) -> Void) -> Void
+        public var contactPointsProvider:
+            @Sendable (@escaping @Sendable (Result<ContactPoints, Swift.Error>) -> Void) -> Void
 
         public var port: Int32
         public var protocolVersion: ProtocolVersion
@@ -55,7 +56,7 @@ extension CassandraClient {
             set { self._encryptor = newValue }
         }
 
-        private var _encryptor: AnyObject?
+        private var _encryptor: (any Sendable)?
 
         /// Registered encryption schemas.
         @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
@@ -64,7 +65,7 @@ extension CassandraClient {
             set { self._encryptionSchemas = newValue }
         }
 
-        private var _encryptionSchemas: Any = [String: EncryptionSchema]()
+        private var _encryptionSchemas: any Sendable = [String: EncryptionSchema]()
 
         /// Register an encryption schema for automatic context building during decoding.
         @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
@@ -85,15 +86,15 @@ extension CassandraClient {
         public var loadBalancingStrategy: LoadBalancingStrategy?
 
         /// A struct representing the load balancing strategy.
-        public struct LoadBalancingStrategy: Hashable {
+        public struct LoadBalancingStrategy: Sendable, Hashable {
             enum Backing: Hashable {
                 case roundRobin(RoundRobin)
                 case dataCenterAware(DataCenterAware)
             }
-            public struct RoundRobin: Hashable {
+            public struct RoundRobin: Sendable, Hashable {
                 public init() {}
             }
-            public struct DataCenterAware: Hashable {
+            public struct DataCenterAware: Sendable, Hashable {
                 /// Sets the local data center name for DC-aware routing policy.
                 /// When set, a DC-aware load balancing policy will be used that prioritizes hosts from this data center.
                 public var localDataCenter: String?
@@ -123,17 +124,17 @@ extension CassandraClient {
 
         }
 
-        public enum SpeculativeExecutionPolicy: Hashable {
+        public enum SpeculativeExecutionPolicy: Sendable, Hashable {
             case constant(delayInMillseconds: Int64, maxExecutions: Int32)
             case disabled
         }
 
-        public enum PrepareStrategy: Hashable {
+        public enum PrepareStrategy: Sendable, Hashable {
             case allHosts
             case upOrAddHost
         }
 
-        public enum ProtocolVersion: Int32 {
+        public enum ProtocolVersion: Int32, Sendable {
             case v1 = 1
             case v2 = 2
             case v3 = 3
@@ -141,9 +142,9 @@ extension CassandraClient {
             case v5 = 5
         }
 
-        public init(
+        @preconcurrency public init(
             contactPointsProvider:
-                @escaping (@escaping (Result<ContactPoints, Swift.Error>) -> Void) ->
+                @escaping @Sendable (@escaping @Sendable (Result<ContactPoints, Swift.Error>) -> Void) ->
                 Void,
             port: Int32,
             protocolVersion: ProtocolVersion
@@ -158,11 +159,14 @@ extension CassandraClient {
             self.contactPointsProvider { result in
                 switch result {
                 case .success(let contactPoints):
-                    do {
-                        let cluster = try self.makeCluster(contactPoints: contactPoints)
-                        clusterPromise.succeed(cluster)
-                    } catch {
-                        clusterPromise.fail(error)
+                    // cluster is not Sendable, so it needs to be created on the eventloop
+                    eventLoop.execute {
+                        do {
+                            let cluster = try self.makeCluster(contactPoints: contactPoints)
+                            clusterPromise.assumeIsolated().succeed(cluster)
+                        } catch {
+                            clusterPromise.fail(error)
+                        }
                     }
                 case .failure(let error):
                     clusterPromise.fail(error)
@@ -415,7 +419,7 @@ internal final class Cluster {
 
     func setLoadBalancingStrategy(_ strategy: CassandraClient.Configuration.LoadBalancingStrategy) throws {
         switch strategy.backing {
-        case .roundRobin(let roundRobin):
+        case .roundRobin:
             cass_cluster_set_load_balance_round_robin(self.rawPointer)
         case .dataCenterAware(let dataCenterAware):
             cass_cluster_set_load_balance_dc_aware(
@@ -450,14 +454,14 @@ internal final class Cluster {
 // MARK: - SSL
 
 extension CassandraClient.Configuration {
-    public struct SSL {
+    public struct SSL: Sendable {
         public var trustedCertificates: [String]?
         public var verifyFlag: VerifyFlag = .default
         public var cert: String?
         public var privateKey: (key: String, password: String)?
 
         /// Verification performed on the peer's certificate.
-        public enum VerifyFlag {
+        public enum VerifyFlag: Sendable {
             /// Use DataStax driver's default, which is .peerCert
             case `default`
 

--- a/Sources/CassandraClient/Consistency.swift
+++ b/Sources/CassandraClient/Consistency.swift
@@ -16,7 +16,7 @@ internal import CDataStaxDriver
 
 extension CassandraClient {
     /// Consistency levels
-    public enum Consistency: Hashable {
+    public enum Consistency: Sendable, Hashable {
         case any
         case one
         case two
@@ -58,7 +58,7 @@ extension CassandraClient {
     }
 
     /// Serial consistency levels
-    public enum SerialConsistency: Hashable {
+    public enum SerialConsistency: Sendable, Hashable {
         case serial
         case localSerial
 

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -220,7 +220,7 @@ extension CassandraClient {
 
     /// A reusable page token that can be used by `Statement` to resume querying
     /// at a specific position.
-    public struct OpaquePagingStateToken: PagingStateToken {
+    public struct OpaquePagingStateToken: PagingStateToken, Sendable {
         let token: [UInt8]
 
         public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
@@ -452,7 +452,7 @@ extension CassandraClient.Row {
 // MARK: - UUID
 
 /// Time-based UUID (version 1).
-public struct TimeBasedUUID: Codable, Hashable, Equatable, CustomStringConvertible {
+public struct TimeBasedUUID: Sendable, Codable, Hashable, Equatable, CustomStringConvertible {
     private let underlying: Foundation.UUID
 
     internal var uuid: uuid_t {
@@ -478,10 +478,11 @@ public struct TimeBasedUUID: Codable, Hashable, Equatable, CustomStringConvertib
     /// Wrapper around `CassUuidGen` for generating time-based UUID.
     ///
     /// - SeeAlso: https://docs.datastax.com/en/developer/cpp-driver/2.15/topics/basics/uuids/
-    private class UUIDGenerator {
+    private final class UUIDGenerator: Sendable {
         static let instance = UUIDGenerator()
 
-        let rawPointer: OpaquePointer
+        // Docs state "Instances of the UUID generator object are thread-safe to generate UUIDs."
+        nonisolated(unsafe) let rawPointer: OpaquePointer
 
         init() {
             self.rawPointer = cass_uuid_gen_new()

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -43,7 +43,7 @@ extension CassandraClient {
         internal var contextString: String { "\(self.keyspace).\(self.table).\(self.column)" }
 
         /// Base context without a column name. Use ``forColumn(_:)`` to produce a full ``EncryptionContext``.
-        public struct Base {
+        public struct Base: Sendable {
             public let keyspace: String
             public let table: String
             public let primaryKey: PrimaryKey

--- a/Sources/CassandraClient/Metrics.swift
+++ b/Sources/CassandraClient/Metrics.swift
@@ -15,7 +15,7 @@
 internal import CDataStaxDriver
 
 /// ``CassandraClient`` metrics.
-public struct CassandraMetrics: Codable {
+public struct CassandraMetrics: Sendable, Codable {
     // MARK: - Requests
 
     /// Minimum in microseconds

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -16,8 +16,10 @@ internal import CDataStaxDriver
 
 extension CassandraClient {
     /// A server-side prepared statement that can be efficiently executed multiple times with different parameters.
-    public final class PreparedStatement: @unchecked Sendable {
-        internal let rawPointer: OpaquePointer
+    public final class PreparedStatement: Sendable {
+        /// A pointer to CassPrepared. The docs state " A prepared statement is read-only and it is thread-safe to concurrently bind new statements".
+        /// Therefore, this field is `nonisolated(unsafe)`
+        nonisolated(unsafe) let rawPointer: OpaquePointer
         private let _parameterCount: Int
 
         /// The table name for encryption context resolution.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -634,7 +634,7 @@ struct CassSession: Sendable, ~Copyable {
 }
 
 extension CassandraClient {
-    internal final class Session: CassandraSession {
+    internal final class Session: CassandraSession, Sendable {
         private let eventLoopGroupContainer: EventLoopGroupContainer
         public var eventLoopGroup: EventLoopGroup {
             self.eventLoopGroupContainer.value

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -21,7 +21,7 @@ import NIOConcurrencyHelpers
 import NIOCore  // for async-await bridge
 
 /// API for executing statements against Cassandra.
-public protocol CassandraSession {
+@preconcurrency public protocol CassandraSession: Sendable {
     var eventLoopGroup: EventLoopGroup { get }
 
     /// Encryptor for transparent column encryption.


### PR DESCRIPTION
Types which are already Sendable should be marked as such

This PR avoids behaviour changes, except one small change in the Configuration struct to ensure we run on the right eventloop to satisfy the compiler that we are not sending the `cluster` object, which is not Sendable