### PR TITLE
Replace @_implementationOnly with internal import

### DIFF
--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Foundation
 
 extension CassandraClient {

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Logging
 import NIO
 import NIOConcurrencyHelpers

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import NIO
 
 // TODO: add more config option per C++ cluster impl

--- a/Sources/CassandraClient/Consistency.swift
+++ b/Sources/CassandraClient/Consistency.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 
 extension CassandraClient {
     /// Consistency levels

--- a/Sources/CassandraClient/Data+Maps.swift
+++ b/Sources/CassandraClient/Data+Maps.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Foundation
 
 extension CassandraClient.Column {

--- a/Sources/CassandraClient/Data+PaginatedRows.swift
+++ b/Sources/CassandraClient/Data+PaginatedRows.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Logging
 import NIO
 

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Foundation
 import Logging
 import NIO

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 
 extension CassandraClient {
     /// Possible ``CassandraClient`` errors.

--- a/Sources/CassandraClient/Metrics.swift
+++ b/Sources/CassandraClient/Metrics.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 
 /// ``CassandraClient`` metrics.
 public struct CassandraMetrics: Codable {

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 
 extension CassandraClient {
     /// A server-side prepared statement that can be efficiently executed multiple times with different parameters.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Dispatch
 import Foundation
 import Logging

--- a/Sources/CassandraClient/Statement+Maps.swift
+++ b/Sources/CassandraClient/Statement+Maps.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Foundation
 
 extension CassandraClient.Statement {

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CDataStaxDriver
+internal import CDataStaxDriver
 import Foundation  // for date and uuid
 
 extension CassandraClient {


### PR DESCRIPTION
Replace deprecated `@_implementationOnly import CDataStaxDriver` with `internal import CDataStaxDriver` across all 13 source files (SE-0409).

  ### Motivation:

  Swift 6.0 deprecated `@_implementationOnly` in favor of the official `internal import` access-level modifier (SE-0409). Removing the `.swiftLanguageMode(.v5)` opt-out surfaces 13 deprecation warnings for this old spelling. This PR clears them so subsequent
  strict concurrency work only shows concurrency-related diagnostics.

  ### Modifications:

  Replaced `@_implementationOnly import CDataStaxDriver` with `internal import CDataStaxDriver` in all 13 source files under `Sources/CassandraClient/`.

  ### Result:

  No runtime behavior change. The `CDataStaxDriver` module remains internal-only — downstream consumers cannot access it. The 13 `@_implementationOnly` deprecation warnings are eliminated.