### PR TITLE
Add support for user-defined types (UDTs)

### DIFF
--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -196,6 +196,9 @@ extension CassandraClient {
         // Used to make sure the row isn't freed while a reference to one
         // of its columns still exists
         private let parent: Row
+        // For sub-values (UDT fields, collection/map values), the driver returns a pointer that
+        // lives inside the iterator it came from. Retaining the iterator keeps that pointer valid.
+        private let iterator: CassIteratorBox?
 
         internal init?(row: Row, index: Int) {
             guard let rawPointer = cass_row_get_column(row.rawPointer, index) else {
@@ -203,6 +206,7 @@ extension CassandraClient {
             }
             self.rawPointer = rawPointer
             self.parent = row
+            self.iterator = nil
         }
 
         internal init?(row: Row, name: String) {
@@ -211,10 +215,33 @@ extension CassandraClient {
             }
             self.rawPointer = rawPointer
             self.parent = row
+            self.iterator = nil
+        }
+
+        /// Wrap a sub-value (UDT field, collection element, or map value). Retains the originating
+        /// `Row` so the result data stays alive, and the `iterator` whose internal value it points to.
+        internal init(rawPointer: OpaquePointer, parent: Row, iterator: CassIteratorBox) {
+            self.rawPointer = rawPointer
+            self.parent = parent
+            self.iterator = iterator
         }
 
         func isNull() -> Bool {
             cass_value_is_null(self.rawPointer) == cass_true
+        }
+    }
+
+    /// Owns a `CassIterator` and frees it on deinit, keeping the values it yields alive while a
+    /// ``Column`` derived from it is in use.
+    internal final class CassIteratorBox {
+        let rawPointer: OpaquePointer
+
+        init(_ rawPointer: OpaquePointer) {
+            self.rawPointer = rawPointer
+        }
+
+        deinit {
+            cass_iterator_free(self.rawPointer)
         }
     }
 
@@ -753,6 +780,181 @@ extension CassandraClient.Column {
         }
 
         return array
+    }
+}
+
+// MARK: - UDT
+
+extension CassandraClient.Column {
+    /// Access a field of a UDT column by name, as a ``CassandraClient/Column``.
+    ///
+    /// Returns `nil` if the column is null, not a UDT, or has no field with that name.
+    /// The returned column exposes the usual scalar getters, e.g. `column.field("a")?.string`.
+    public func field(_ name: String) -> CassandraClient.Column? {
+        guard cass_value_is_null(self.rawPointer) == cass_false else {
+            return nil
+        }
+        guard let iterator = cass_iterator_fields_from_user_type(self.rawPointer) else {
+            return nil
+        }
+        let box = CassandraClient.CassIteratorBox(iterator)
+
+        while cass_iterator_next(iterator) == cass_true {
+            var fieldNamePointer: UnsafePointer<CChar>?
+            var fieldNameSize = 0
+            guard
+                cass_iterator_get_user_type_field_name(iterator, &fieldNamePointer, &fieldNameSize) == CASS_OK,
+                let fieldNamePointer = fieldNamePointer
+            else {
+                continue
+            }
+            let fieldName = UnsafeBufferPointer(start: fieldNamePointer, count: fieldNameSize)
+                .withMemoryRebound(to: UInt8.self) { String(decoding: $0, as: UTF8.self) }
+            guard fieldName == name, let valuePointer = cass_iterator_get_user_type_field_value(iterator)
+            else {
+                continue
+            }
+            return CassandraClient.Column(rawPointer: valuePointer, parent: self.parent, iterator: box)
+        }
+        return nil
+    }
+
+    /// Get a `list<udt>` / `set<udt>` column as an array of UDT ``CassandraClient/Column`` elements.
+    public var udtArray: [CassandraClient.Column]? {
+        guard cass_value_is_null(self.rawPointer) == cass_false else {
+            return nil
+        }
+        let count = self.collectionCount()
+        var elements: [CassandraClient.Column] = []
+        elements.reserveCapacity(count)
+        for index in 0..<count {
+            guard let column = self.collectionElement(at: index) else {
+                return nil
+            }
+            elements.append(column)
+        }
+        return elements
+    }
+
+    /// Get a `map<K, udt>` column as a dictionary of keys to UDT ``CassandraClient/Column`` values.
+    public func udtMap<K: Hashable>(keyType _: K.Type) -> [K: CassandraClient.Column]? {
+        guard cass_value_is_null(self.rawPointer) == cass_false else {
+            return nil
+        }
+        var map: [K: CassandraClient.Column] = [:]
+        for index in 0..<self.mapCount() {
+            guard let entry: (key: K, value: CassandraClient.Column) = self.mapEntry(at: index) else {
+                continue
+            }
+            map[entry.key] = entry.value
+        }
+        return map.isEmpty ? nil : map
+    }
+
+    /// Get a `map<text, udt>` column.
+    public var stringUDTMap: [String: CassandraClient.Column]? {
+        self.udtMap(keyType: String.self)
+    }
+
+    /// Get a `map<int, udt>` column.
+    public var int32UDTMap: [Int32: CassandraClient.Column]? {
+        self.udtMap(keyType: Int32.self)
+    }
+
+    /// Get a `map<uuid, udt>` column.
+    public var uuidUDTMap: [Foundation.UUID: CassandraClient.Column]? {
+        self.udtMap(keyType: Foundation.UUID.self)
+    }
+
+    private func collectionCount() -> Int {
+        guard let iterator = cass_iterator_from_collection(self.rawPointer) else {
+            return 0
+        }
+        defer { cass_iterator_free(iterator) }
+        var count = 0
+        while cass_iterator_next(iterator) == cass_true {
+            count += 1
+        }
+        return count
+    }
+
+    // Each element gets its own iterator positioned at its value, since the driver invalidates an
+    // iterator's value when it advances. Collections are small, so the repeated scan is acceptable.
+    private func collectionElement(at index: Int) -> CassandraClient.Column? {
+        guard let iterator = cass_iterator_from_collection(self.rawPointer) else {
+            return nil
+        }
+        let box = CassandraClient.CassIteratorBox(iterator)
+        var position = 0
+        while cass_iterator_next(iterator) == cass_true {
+            if position == index {
+                guard let value = cass_iterator_get_value(iterator) else { return nil }
+                return CassandraClient.Column(rawPointer: value, parent: self.parent, iterator: box)
+            }
+            position += 1
+        }
+        return nil
+    }
+
+    private func mapCount() -> Int {
+        guard let iterator = cass_iterator_from_map(self.rawPointer) else {
+            return 0
+        }
+        defer { cass_iterator_free(iterator) }
+        var count = 0
+        while cass_iterator_next(iterator) == cass_true {
+            count += 1
+        }
+        return count
+    }
+
+    private func mapEntry<K>(at index: Int) -> (key: K, value: CassandraClient.Column)? {
+        guard let iterator = cass_iterator_from_map(self.rawPointer) else {
+            return nil
+        }
+        let box = CassandraClient.CassIteratorBox(iterator)
+        var position = 0
+        while cass_iterator_next(iterator) == cass_true {
+            if position == index {
+                guard let key = self.extractUDTMapKey(cass_iterator_get_map_key(iterator), as: K.self),
+                    let value = cass_iterator_get_map_value(iterator)
+                else {
+                    return nil
+                }
+                return (key, CassandraClient.Column(rawPointer: value, parent: self.parent, iterator: box))
+            }
+            position += 1
+        }
+        return nil
+    }
+
+    private func extractUDTMapKey<K>(_ pointer: OpaquePointer?, as type: K.Type) -> K? {
+        guard let pointer = pointer else {
+            return nil
+        }
+        switch type {
+        case is String.Type:
+            return toString(cassValue: pointer) as? K
+        case is Int32.Type:
+            var value: Int32 = 0
+            return cass_value_get_int32(pointer, &value) == CASS_OK ? value as? K : nil
+        case is Foundation.UUID.Type:
+            var value = CassUuid()
+            return cass_value_get_uuid(pointer, &value) == CASS_OK ? value.uuid() as? K : nil
+        default:
+            return nil
+        }
+    }
+
+    /// Whether this column's value is a UDT.
+    public var valueIsUDT: Bool {
+        cass_value_type(self.rawPointer) == CASS_VALUE_TYPE_UDT
+    }
+
+    /// Whether this column's value is a list or set.
+    public var valueIsList: Bool {
+        let type = cass_value_type(self.rawPointer)
+        return type == CASS_VALUE_TYPE_LIST || type == CASS_VALUE_TYPE_SET
     }
 }
 

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -311,7 +311,15 @@ extension CassandraClient {
                 }
                 return value as! T
             } else {
-                throw DecodingError.notSupported("Decoding of \(type) is not supported.")
+                guard let column: Column = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch(
+                        "value for \(key.stringValue) not found or of incorrect data type."
+                    )
+                }
+                guard column.valueIsUDT || column.valueIsList else {
+                    throw DecodingError.notSupported("Decoding of \(type) is not supported.")
+                }
+                return try T(from: CassandraClient.UDTDecoder(column: column))
             }
         }
 
@@ -368,4 +376,224 @@ extension CassandraClient {
 private enum DecodingError: Error {
     case typeMismatch(String)
     case notSupported(String? = nil)
+}
+
+// MARK: - UDT decoding
+
+extension CassandraClient {
+    /// Decodes a UDT column (or a `list`/`set` of UDTs) into a `Decodable` value.
+    internal struct UDTDecoder: Decoder {
+        private let column: Column
+
+        var codingPath = [CodingKey]()
+        var userInfo = [CodingUserInfoKey: Any]()
+
+        init(column: Column) {
+            self.column = column
+        }
+
+        func container<Key>(keyedBy _: Key.Type) throws -> KeyedDecodingContainer<Key> {
+            KeyedDecodingContainer(UDTFieldContainer<Key>(column: self.column))
+        }
+
+        func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+            guard let elements = self.column.udtArray else {
+                throw DecodingError.typeMismatch("expected a list of UDTs")
+            }
+            return UDTArrayContainer(elements: elements)
+        }
+
+        func singleValueContainer() throws -> SingleValueDecodingContainer {
+            throw DecodingError.notSupported("singleValueContainer not supported")
+        }
+    }
+
+    private struct UDTFieldContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+        private let column: Column
+
+        var codingPath = [CodingKey]()
+        var allKeys: [Key] { [] }
+
+        init(column: Column) {
+            self.column = column
+        }
+
+        private func field(_ key: Key) throws -> Column {
+            guard let field = self.column.field(key.stringValue) else {
+                throw DecodingError.typeMismatch("field \(key.stringValue) not found.")
+            }
+            return field
+        }
+
+        func contains(_ key: Key) -> Bool {
+            self.column.field(key.stringValue) != nil
+        }
+
+        func decodeNil(forKey key: Key) throws -> Bool {
+            guard let field = self.column.field(key.stringValue) else { return true }
+            return field.isNull()
+        }
+
+        func decode(_: Bool.Type, forKey key: Key) throws -> Bool {
+            try unwrap(try self.field(key).bool, key)
+        }
+
+        func decode(_: Int.Type, forKey key: Key) throws -> Int {
+            Int(try unwrap(try self.field(key).int32, key))
+        }
+
+        func decode(_: Int8.Type, forKey key: Key) throws -> Int8 {
+            try unwrap(try self.field(key).int8, key)
+        }
+
+        func decode(_: Int16.Type, forKey key: Key) throws -> Int16 {
+            try unwrap(try self.field(key).int16, key)
+        }
+
+        func decode(_: Int32.Type, forKey key: Key) throws -> Int32 {
+            try unwrap(try self.field(key).int32, key)
+        }
+
+        func decode(_: Int64.Type, forKey key: Key) throws -> Int64 {
+            try unwrap(try self.field(key).int64, key)
+        }
+
+        func decode(_: Float.Type, forKey key: Key) throws -> Float {
+            try unwrap(try self.field(key).float32, key)
+        }
+
+        func decode(_: Double.Type, forKey key: Key) throws -> Double {
+            try unwrap(try self.field(key).double, key)
+        }
+
+        func decode(_: String.Type, forKey key: Key) throws -> String {
+            try unwrap(try self.field(key).string, key)
+        }
+
+        func decode(_: UInt.Type, forKey _: Key) throws -> UInt { throw DecodingError.notSupported("UInt") }
+        func decode(_: UInt8.Type, forKey _: Key) throws -> UInt8 { throw DecodingError.notSupported("UInt8") }
+        func decode(_: UInt16.Type, forKey _: Key) throws -> UInt16 { throw DecodingError.notSupported("UInt16") }
+        func decode(_: UInt32.Type, forKey _: Key) throws -> UInt32 { throw DecodingError.notSupported("UInt32") }
+        func decode(_: UInt64.Type, forKey _: Key) throws -> UInt64 { throw DecodingError.notSupported("UInt64") }
+
+        func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+            let field = try self.field(key)
+            if let value = decodeKnownType(type, from: field) {
+                return value
+            }
+            guard field.valueIsUDT || field.valueIsList else {
+                throw DecodingError.notSupported("Decoding of \(type) is not supported.")
+            }
+            return try T(from: UDTDecoder(column: field))
+        }
+
+        func nestedContainer<NestedKey>(
+            keyedBy _: NestedKey.Type,
+            forKey _: Key
+        ) throws
+            -> KeyedDecodingContainer<NestedKey>
+        {
+            throw DecodingError.notSupported()
+        }
+
+        func nestedUnkeyedContainer(forKey _: Key) throws -> UnkeyedDecodingContainer {
+            throw DecodingError.notSupported()
+        }
+
+        func superDecoder() throws -> Decoder { throw DecodingError.notSupported() }
+        func superDecoder(forKey _: Key) throws -> Decoder { throw DecodingError.notSupported() }
+    }
+
+    private struct UDTArrayContainer: UnkeyedDecodingContainer {
+        private let elements: [Column]
+
+        var codingPath = [CodingKey]()
+        var count: Int? { self.elements.count }
+        var isAtEnd: Bool { self.currentIndex >= self.elements.count }
+        private(set) var currentIndex = 0
+
+        init(elements: [Column]) {
+            self.elements = elements
+        }
+
+        mutating func decodeNil() throws -> Bool {
+            guard self.elements[self.currentIndex].isNull() else { return false }
+            self.currentIndex += 1
+            return true
+        }
+
+        mutating func decode<T: Decodable>(_: T.Type) throws -> T {
+            let element = self.elements[self.currentIndex]
+            self.currentIndex += 1
+            return try T(from: UDTDecoder(column: element))
+        }
+
+        mutating func decode(_: Bool.Type) throws -> Bool { throw DecodingError.notSupported() }
+        mutating func decode(_: String.Type) throws -> String { throw DecodingError.notSupported() }
+        mutating func decode(_: Double.Type) throws -> Double { throw DecodingError.notSupported() }
+        mutating func decode(_: Float.Type) throws -> Float { throw DecodingError.notSupported() }
+        mutating func decode(_: Int.Type) throws -> Int { throw DecodingError.notSupported() }
+        mutating func decode(_: Int8.Type) throws -> Int8 { throw DecodingError.notSupported() }
+        mutating func decode(_: Int16.Type) throws -> Int16 { throw DecodingError.notSupported() }
+        mutating func decode(_: Int32.Type) throws -> Int32 { throw DecodingError.notSupported() }
+        mutating func decode(_: Int64.Type) throws -> Int64 { throw DecodingError.notSupported() }
+        mutating func decode(_: UInt.Type) throws -> UInt { throw DecodingError.notSupported() }
+        mutating func decode(_: UInt8.Type) throws -> UInt8 { throw DecodingError.notSupported() }
+        mutating func decode(_: UInt16.Type) throws -> UInt16 { throw DecodingError.notSupported() }
+        mutating func decode(_: UInt32.Type) throws -> UInt32 { throw DecodingError.notSupported() }
+        mutating func decode(_: UInt64.Type) throws -> UInt64 { throw DecodingError.notSupported() }
+
+        mutating func nestedContainer<NestedKey>(
+            keyedBy _: NestedKey.Type
+        ) throws
+            -> KeyedDecodingContainer<NestedKey>
+        {
+            throw DecodingError.notSupported()
+        }
+
+        mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+            throw DecodingError.notSupported()
+        }
+
+        mutating func superDecoder() throws -> Decoder { throw DecodingError.notSupported() }
+    }
+}
+
+/// Decode the scalar/array types a UDT field may hold; returns `nil` if `type` is not one of them.
+private func decodeKnownType<T: Decodable>(_ type: T.Type, from column: CassandraClient.Column) -> T? {
+    switch type {
+    case is Foundation.UUID.Type:
+        return column.uuid as? T
+    case is TimeBasedUUID.Type:
+        return column.timeuuid as? T
+    case is Foundation.Date.Type:
+        return column.timestamp.map { Foundation.Date(timeIntervalSince1970: Double($0) / 1000) } as? T
+    case is [UInt8].Type:
+        return column.bytes as? T
+    case is [Int8].Type:
+        return column.int8Array as? T
+    case is [Int16].Type:
+        return column.int16Array as? T
+    case is [Int32].Type:
+        return column.int32Array as? T
+    case is [Int64].Type:
+        return column.int64Array as? T
+    case is [Float32].Type:
+        return column.float32Array as? T
+    case is [Double].Type:
+        return column.doubleArray as? T
+    case is [String].Type:
+        return column.stringArray as? T
+    default:
+        return nil
+    }
+}
+
+private func unwrap<T>(_ value: T?, _ key: CodingKey) throws -> T {
+    guard let value = value else {
+        throw DecodingError.typeMismatch(
+            "value for \(key.stringValue) not found or of incorrect data type."
+        )
+    }
+    return value
 }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -809,9 +809,27 @@ extension CassandraClient {
             self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing: \(statement.query)")
                 logger.trace("\(statement.parameters)")
+                do {
+                    try self.bindUDTsIfNeeded(statement)
+                } catch {
+                    return eventLoop.makeFailedFuture(error)
+                }
                 let future = self.underlying.execute(statement: statement)
                 return future.asNIOFuture(eventLoop: eventLoop)
             }
+        }
+
+        /// Resolve and bind any UDT parameters from the connected session's schema metadata.
+        /// No-op when the statement has no UDT parameters.
+        private func bindUDTsIfNeeded(_ statement: Statement) throws {
+            guard statement.needsUDTBinding else { return }
+            guard let schemaMeta = self.underlying.getSchemaMeta() else {
+                throw CassandraClient.Error.badParams(
+                    "Cannot retrieve schema metadata to resolve UDT types"
+                )
+            }
+            defer { cass_schema_meta_free(schemaMeta) }
+            try statement.bindUDTs(schemaMeta: schemaMeta, keyspace: self.keyspace)
         }
 
         func execute(
@@ -1374,6 +1392,7 @@ extension CassandraClient.Session {
         try await self.withConnection(logger: logger) { logger in
             logger.debug("executing: \(statement.query)")
             logger.trace("\(statement.parameters)")
+            try self.bindUDTsIfNeeded(statement)
             let future = self.underlying.execute(statement: statement)
             return try await future.await()
         }

--- a/Sources/CassandraClient/Statement+Maps.swift
+++ b/Sources/CassandraClient/Statement+Maps.swift
@@ -205,4 +205,44 @@ extension CassandraClient.Statement {
             throw CassandraClient.Error.badParams("Map element of type \(T.self) is not supported")
         }
     }
+
+    func bindUDTMapCases(_ parameter: Value, at index: Int, keyspaceMeta: OpaquePointer) throws -> CassError {
+        switch parameter {
+        case .stringUDTMap(let map):
+            return try self.bindUDTMap(map, at: index, keyspaceMeta: keyspaceMeta)
+        case .int32UDTMap(let map):
+            return try self.bindUDTMap(map, at: index, keyspaceMeta: keyspaceMeta)
+        case .uuidUDTMap(let map):
+            return try self.bindUDTMap(map, at: index, keyspaceMeta: keyspaceMeta)
+        default:
+            fatalError("Not a UDT map case")
+        }
+    }
+
+    private func bindUDTMap<K>(
+        _ map: [K: CassandraClient.UDT],
+        at index: Int,
+        keyspaceMeta: OpaquePointer
+    ) throws -> CassError {
+        guard let collection = cass_collection_new(CASS_COLLECTION_TYPE_MAP, map.count * 2) else {
+            throw CassandraClient.Error.badParams("Failed to create collection")
+        }
+        defer { cass_collection_free(collection) }
+
+        for (key, udt) in map {
+            let keyResult = try self.appendToCollection(collection, element: key)
+            guard keyResult == CASS_OK else {
+                throw CassandraClient.Error(keyResult)
+            }
+
+            let userType = try self.makeUserType(udt, keyspaceMeta: keyspaceMeta)
+            defer { cass_user_type_free(userType) }
+            let valueResult = cass_collection_append_user_type(collection, userType)
+            guard valueResult == CASS_OK else {
+                throw CassandraClient.Error(valueResult)
+            }
+        }
+
+        return cass_statement_bind_collection(self.rawPointer, index, collection)
+    }
 }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -61,6 +61,11 @@ extension CassandraClient {
 
         private func bindParameters() throws {
             for (index, parameter) in parameters.enumerated() {
+                // UDT values are bound later by the session, once the type can be
+                // resolved from schema metadata. See `bindUDTs(schemaMeta:keyspace:)`.
+                if parameter.isUDT {
+                    continue
+                }
                 let result: CassError
                 switch parameter {
                 case .null:
@@ -286,6 +291,132 @@ extension CassandraClient {
             return cass_statement_bind_collection(self.rawPointer, index, collection)
         }
 
+        /// Whether this statement has UDT parameters that still need schema-resolved binding.
+        internal var needsUDTBinding: Bool {
+            self.parameters.contains { $0.isUDT }
+        }
+
+        /// Bind UDT parameters using the keyspace's schema metadata.
+        ///
+        /// UDT data types are only resolvable from a connected session, so the session calls
+        /// this just before execution. `schemaMeta` must outlive this call (the caller owns it).
+        internal func bindUDTs(schemaMeta: OpaquePointer, keyspace: String?) throws {
+            guard let keyspace = keyspace,
+                let keyspaceMeta = cass_schema_meta_keyspace_by_name(schemaMeta, keyspace)
+            else {
+                throw CassandraClient.Error.badParams("Cannot resolve keyspace for UDT binding")
+            }
+            for (index, parameter) in parameters.enumerated() where parameter.isUDT {
+                let result = try self.bindUDTValue(parameter, at: index, keyspaceMeta: keyspaceMeta)
+                guard result == CASS_OK else {
+                    throw CassandraClient.Error(result)
+                }
+            }
+        }
+
+        private func bindUDTValue(_ parameter: Value, at index: Int, keyspaceMeta: OpaquePointer) throws -> CassError {
+            switch parameter {
+            case .udt(let udt):
+                return try self.bindUDT(udt, at: index, keyspaceMeta: keyspaceMeta)
+            case .udtArray(let udts):
+                return try self.bindUDTArray(udts, at: index, keyspaceMeta: keyspaceMeta)
+            default:
+                return try self.bindUDTMapCases(parameter, at: index, keyspaceMeta: keyspaceMeta)
+            }
+        }
+
+        /// Create a `CassUserType` from a `UDT`, resolving its data type from the keyspace metadata.
+        /// The caller takes ownership and must free it with `cass_user_type_free`.
+        internal func makeUserType(_ udt: UDT, keyspaceMeta: OpaquePointer) throws -> OpaquePointer {
+            guard let dataType = cass_keyspace_meta_user_type_by_name(keyspaceMeta, udt.typeName) else {
+                throw CassandraClient.Error.badParams("UDT type '\(udt.typeName)' not found in keyspace")
+            }
+            guard let userType = cass_user_type_new_from_data_type(dataType) else {
+                throw CassandraClient.Error.badParams("Failed to create user type '\(udt.typeName)'")
+            }
+            for field in udt.fields {
+                let result = try self.setUDTField(
+                    userType,
+                    name: field.name,
+                    value: field.value,
+                    keyspaceMeta: keyspaceMeta
+                )
+                guard result == CASS_OK else {
+                    cass_user_type_free(userType)
+                    throw CassandraClient.Error(result)
+                }
+            }
+            return userType
+        }
+
+        private func setUDTField(
+            _ userType: OpaquePointer,
+            name: String,
+            value: Value,
+            keyspaceMeta: OpaquePointer
+        ) throws -> CassError {
+            switch value {
+            case .null:
+                return cass_user_type_set_null_by_name(userType, name)
+            case .int8(let v):
+                return cass_user_type_set_int8_by_name(userType, name, v)
+            case .int16(let v):
+                return cass_user_type_set_int16_by_name(userType, name, v)
+            case .int32(let v):
+                return cass_user_type_set_int32_by_name(userType, name, v)
+            case .int64(let v):
+                return cass_user_type_set_int64_by_name(userType, name, cass_int64_t(v))
+            case .float32(let v):
+                return cass_user_type_set_float_by_name(userType, name, v)
+            case .double(let v):
+                return cass_user_type_set_double_by_name(userType, name, v)
+            case .bool(let v):
+                return cass_user_type_set_bool_by_name(userType, name, v ? cass_true : cass_false)
+            case .string(let v):
+                return cass_user_type_set_string_by_name(userType, name, v)
+            case .uuid(let v):
+                return cass_user_type_set_uuid_by_name(userType, name, CassUuid(v.uuid))
+            case .timeuuid(let v):
+                return cass_user_type_set_uuid_by_name(userType, name, CassUuid(v.uuid))
+            case .bytes(let v):
+                return v.withUnsafeBufferPointer {
+                    cass_user_type_set_bytes_by_name(userType, name, $0.baseAddress, $0.count)
+                }
+            case .date(let v):
+                let milliseconds = Int64(v.timeIntervalSince1970 * 1000)
+                return cass_user_type_set_int64_by_name(userType, name, cass_int64_t(milliseconds))
+            case .udt(let nested):
+                let nestedUserType = try self.makeUserType(nested, keyspaceMeta: keyspaceMeta)
+                defer { cass_user_type_free(nestedUserType) }
+                return cass_user_type_set_user_type_by_name(userType, name, nestedUserType)
+            default:
+                throw CassandraClient.Error.badParams("UDT field '\(name)' of type \(value) is not supported")
+            }
+        }
+
+        private func bindUDT(_ udt: UDT, at index: Int, keyspaceMeta: OpaquePointer) throws -> CassError {
+            let userType = try self.makeUserType(udt, keyspaceMeta: keyspaceMeta)
+            defer { cass_user_type_free(userType) }
+            return cass_statement_bind_user_type(self.rawPointer, index, userType)
+        }
+
+        private func bindUDTArray(_ udts: [UDT], at index: Int, keyspaceMeta: OpaquePointer) throws -> CassError {
+            guard let collection = cass_collection_new(CASS_COLLECTION_TYPE_LIST, udts.count) else {
+                throw CassandraClient.Error.badParams("Failed to create collection")
+            }
+            defer { cass_collection_free(collection) }
+
+            for udt in udts {
+                let userType = try self.makeUserType(udt, keyspaceMeta: keyspaceMeta)
+                defer { cass_user_type_free(userType) }
+                let result = cass_collection_append_user_type(collection, userType)
+                guard result == CASS_OK else {
+                    throw CassandraClient.Error(result)
+                }
+            }
+            return cass_statement_bind_collection(self.rawPointer, index, collection)
+        }
+
         func setPagingSize(_ pagingSize: Int32) throws {
             try checkResult { cass_statement_set_paging_size(self.rawPointer, pagingSize) }
         }
@@ -353,6 +484,12 @@ extension CassandraClient {
             case float32Array([Float32])
             case doubleArray([Double])
             case stringArray([String])
+
+            case udt(UDT)
+            case udtArray([UDT])
+            case stringUDTMap([String: UDT])
+            case int32UDTMap([Int32: UDT])
+            case uuidUDTMap([Foundation.UUID: UDT])
 
             case int8Int8Map([Int8: Int8])
             case int8Int16Map([Int8: Int16])
@@ -423,6 +560,16 @@ extension CassandraClient {
             case timeuuidBoolMap([TimeBasedUUID: Bool])
             case timeuuidStringMap([TimeBasedUUID: String])
             case timeuuidUUIDMap([TimeBasedUUID: Foundation.UUID])
+
+            /// Whether this value is a UDT, or a collection of UDTs, that needs schema-resolved binding.
+            internal var isUDT: Bool {
+                switch self {
+                case .udt, .udtArray, .stringUDTMap, .int32UDTMap, .uuidUDTMap:
+                    return true
+                default:
+                    return false
+                }
+            }
 
             /// Whether this value is an encrypted regular column value (`.encryptedXxx` cases).
             internal var isEncrypted: Bool {

--- a/Sources/CassandraClient/UDT.swift
+++ b/Sources/CassandraClient/UDT.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension CassandraClient {
+    /// A value for a Cassandra user-defined type (UDT) column.
+    ///
+    /// Field values reuse ``CassandraClient/Statement/Value``, so scalars, collections, and
+    /// nested UDTs all compose. The `typeName` must match a UDT registered in the session's
+    /// keyspace; its data type is resolved from schema metadata at execution time.
+    public struct UDT {
+        public let typeName: String
+        public let fields: [(name: String, value: Statement.Value)]
+
+        public init(typeName: String, fields: [(String, Statement.Value)]) {
+            self.typeName = typeName
+            self.fields = fields.map { (name: $0.0, value: $0.1) }
+        }
+    }
+}

--- a/Tests/CassandraClientTests/UDTTests.swift
+++ b/Tests/CassandraClientTests/UDTTests.swift
@@ -1,0 +1,316 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+final class UDTTests: XCTestCase {
+    var cassandraClient: CassandraClient!
+    var configuration: CassandraClient.Configuration!
+
+    override func setUp() {
+        super.setUp()
+
+        let env = ProcessInfo.processInfo.environment
+        let keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        self.configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        self.configuration.username = env["CASSANDRA_USER"]
+        self.configuration.password = env["CASSANDRA_PASSWORD"]
+        self.configuration.keyspace = keyspace
+        self.configuration.requestTimeoutMillis = UInt32(24_000)
+        self.configuration.connectTimeoutMillis = UInt32(10_000)
+
+        var logger = Logger(label: "test")
+        logger.logLevel = .debug
+
+        self.cassandraClient = CassandraClient(configuration: self.configuration, logger: logger)
+        XCTAssertNoThrow(
+            try self.cassandraClient.withSession(keyspace: .none) { session in
+                try session
+                    .run(
+                        "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+                    )
+                    .wait()
+            }
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        XCTAssertNoThrow(try self.cassandraClient.shutdown())
+        self.cassandraClient = nil  // FIXME: for tsan
+    }
+
+    private func uniqueSuffix() -> String {
+        "\(DispatchTime.now().uptimeNanoseconds)"
+    }
+
+    private func makeType() throws -> String {
+        let typeName = "udt_test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create type \(typeName) (a text, b int, c double, d boolean)"
+        ).wait()
+        return typeName
+    }
+
+    private func value(a: String?, b: Int32, c: Double, d: Bool, typeName: String) -> CassandraClient.UDT {
+        CassandraClient.UDT(
+            typeName: typeName,
+            fields: [
+                ("a", a.map { .string($0) } ?? .null),
+                ("b", .int32(b)),
+                ("c", .double(c)),
+                ("d", .bool(d)),
+            ]
+        )
+    }
+
+    func testListRoundtrip() throws {
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, items list<frozen<\(typeName)>>)"
+        ).wait()
+
+        let id = UUID()
+        let items = [
+            self.value(a: "first", b: 1, c: 1.5, d: true, typeName: typeName),
+            self.value(a: nil, b: 2, c: 2.5, d: false, typeName: typeName),
+        ]
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, items) values (?, ?)",
+            parameters: [.uuid(id), .udtArray(items)]
+        ).wait()
+
+        let rows = try self.cassandraClient.query(
+            "select items from \(tableName) where id = ?",
+            parameters: [.uuid(id)]
+        ).wait()
+        let row = try XCTUnwrap(rows.first)
+        let read = try XCTUnwrap(row.column("items")?.udtArray)
+
+        XCTAssertEqual(read.count, 2)
+        XCTAssertEqual(read[0].field("a")?.string, "first")
+        XCTAssertEqual(read[0].field("b")?.int32, 1)
+        XCTAssertEqual(read[0].field("c")?.double, 1.5)
+        XCTAssertEqual(read[0].field("d")?.bool, true)
+        XCTAssertNil(read[1].field("a")?.string)
+        XCTAssertEqual(read[1].field("b")?.int32, 2)
+    }
+
+    func testScalarRoundtrip() throws {
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, item frozen<\(typeName)>)"
+        ).wait()
+
+        let id = UUID()
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, item) values (?, ?)",
+            parameters: [.uuid(id), .udt(self.value(a: "solo", b: 7, c: 3.25, d: true, typeName: typeName))]
+        ).wait()
+
+        let rows = try self.cassandraClient.query("select item from \(tableName) where id = ?", parameters: [.uuid(id)])
+            .wait()
+        let row = try XCTUnwrap(rows.first)
+
+        XCTAssertEqual(row.column("item")?.field("a")?.string, "solo")
+        XCTAssertEqual(row.column("item")?.field("b")?.int32, 7)
+        XCTAssertEqual(row.column("item")?.field("c")?.double, 3.25)
+        XCTAssertEqual(row.column("item")?.field("d")?.bool, true)
+    }
+
+    func testNullHandling() throws {
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, item frozen<\(typeName)>, items list<frozen<\(typeName)>>)"
+        ).wait()
+
+        let id = UUID()
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id) values (?)",
+            parameters: [.uuid(id)]
+        ).wait()
+
+        let rows = try self.cassandraClient.query(
+            "select item, items from \(tableName) where id = ?",
+            parameters: [.uuid(id)]
+        ).wait()
+        let row = try XCTUnwrap(rows.first)
+
+        XCTAssertNil(row.column("item")?.field("a"))
+        XCTAssertNil(row.column("items")?.udtArray)
+    }
+
+    func testMapRoundtrip() throws {
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, items map<text, frozen<\(typeName)>>)"
+        ).wait()
+
+        let id = UUID()
+        let items = [
+            "one": self.value(a: "x", b: 10, c: 1.0, d: false, typeName: typeName)
+        ]
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, items) values (?, ?)",
+            parameters: [.uuid(id), .stringUDTMap(items)]
+        ).wait()
+
+        let rows = try self.cassandraClient.query(
+            "select items from \(tableName) where id = ?",
+            parameters: [.uuid(id)]
+        ).wait()
+        let row = try XCTUnwrap(rows.first)
+        let read = try XCTUnwrap(row.column("items")?.stringUDTMap)
+
+        XCTAssertEqual(read["one"]?.field("a")?.string, "x")
+        XCTAssertEqual(read["one"]?.field("b")?.int32, 10)
+    }
+
+    func testUnknownTypeNameThrows() throws {
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, items list<frozen<\(typeName)>>)"
+        ).wait()
+
+        let bad = CassandraClient.UDT(typeName: "does_not_exist", fields: [("a", .string("x"))])
+        XCTAssertThrowsError(
+            try self.cassandraClient.run(
+                "insert into \(tableName) (id, items) values (?, ?)",
+                parameters: [.uuid(UUID()), .udtArray([bad])]
+            ).wait()
+        )
+    }
+
+    func testCodableDecode() throws {
+        struct Item: Codable, Equatable {
+            let a: String?
+            let b: Int32
+            let c: Double
+            let d: Bool
+        }
+        struct Model: Codable, Equatable {
+            let id: UUID
+            let items: [Item]
+        }
+
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, items list<frozen<\(typeName)>>)"
+        ).wait()
+
+        let id = UUID()
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, items) values (?, ?)",
+            parameters: [
+                .uuid(id),
+                .udtArray([
+                    self.value(a: "alpha", b: 1, c: 1.5, d: true, typeName: typeName),
+                    self.value(a: nil, b: 2, c: 2.5, d: false, typeName: typeName),
+                ]),
+            ]
+        ).wait()
+
+        let result: [Model] = try self.cassandraClient.query(
+            "select id, items from \(tableName) where id = ?",
+            parameters: [.uuid(id)]
+        ).wait()
+
+        XCTAssertEqual(
+            result,
+            [
+                Model(
+                    id: id,
+                    items: [
+                        Item(a: "alpha", b: 1, c: 1.5, d: true),
+                        Item(a: nil, b: 2, c: 2.5, d: false),
+                    ]
+                )
+            ]
+        )
+    }
+
+    func testDateFieldRoundtrip() throws {
+        let typeName = "udt_date_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create type \(typeName) (a text, when timestamp)"
+        ).wait()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, item frozen<\(typeName)>)"
+        ).wait()
+
+        let id = UUID()
+        let millis: Int64 = 1_700_000_000_000
+        let when = Date(timeIntervalSince1970: Double(millis) / 1000.0)
+        let udt = CassandraClient.UDT(
+            typeName: typeName,
+            fields: [("a", .string("dated")), ("when", .date(when))]
+        )
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, item) values (?, ?)",
+            parameters: [.uuid(id), .udt(udt)]
+        ).wait()
+
+        let rows = try self.cassandraClient.query(
+            "select item from \(tableName) where id = ?",
+            parameters: [.uuid(id)]
+        ).wait()
+        let row = try XCTUnwrap(rows.first)
+
+        XCTAssertEqual(row.column("item")?.field("a")?.string, "dated")
+        XCTAssertEqual(row.column("item")?.field("when")?.timestamp, millis)
+    }
+
+    func testPreparedRoundtrip() throws {
+        let typeName = try self.makeType()
+        let tableName = "test_\(self.uniqueSuffix())"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id uuid primary key, items list<frozen<\(typeName)>>)"
+        ).wait()
+
+        let id = UUID()
+        let prepared = try self.cassandraClient.prepare(
+            "insert into \(tableName) (id, items) values (?, ?)"
+        ).wait()
+        _ = try self.cassandraClient.execute(
+            prepared: prepared,
+            parameters: [.uuid(id), .udtArray([self.value(a: "p", b: 9, c: 9.5, d: true, typeName: typeName)])]
+        ).wait()
+
+        let rows = try self.cassandraClient.query(
+            "select items from \(tableName) where id = ?",
+            parameters: [.uuid(id)]
+        ).wait()
+        let read = try XCTUnwrap(try XCTUnwrap(rows.first).column("items")?.udtArray)
+        XCTAssertEqual(read.first?.field("a")?.string, "p")
+        XCTAssertEqual(read.first?.field("b")?.int32, 9)
+    }
+}


### PR DESCRIPTION
Add binding and reading of Cassandra user-defined types (UDTs), including UDTs nested in lists, sets, and maps, with Codable decoding support.

### Motivation:

The client could bind and read scalars, lists, and maps, but had no support for Cassandra user-defined types. Columns such as `list<frozen<my_type>>` and `map<text, frozen<my_type>>` could neither be written nor read.

### Modifications:

Added a `CassandraClient.UDT` value type carrying a type name and an ordered set of fields (reusing `Statement.Value`, so scalars and nested UDTs compose).

Added `.udt`, `.udtArray`, and `.stringUDTMap`/`.int32UDTMap`/ `.uuidUDTMap` cases to `Statement.Value`. Binding a UDT needs a data type resolved from the keyspace schema, which is only available from a connected session, so UDT parameters are skipped during statement construction and bound by the session just before execution - mirroring how encryption contexts are resolved today. 

All run, query, and prepared paths funnel through the session's `execute(statement:)`, where the resolver is applied.

For reading, `Column` itself is the reader: `field(_:)` returns a UDT field as a `Column`, and `udtArray` / `udtMap(keyType:)` expose collections of UDTs. 

Each returned `Column` retains the iterator whose value it points to, since the driver invalidates an iterator's value once it advances. 

The Codable decoder was extended so a UDT column decodes into a struct and a `list<udt>` column into an array of structs, matching the existing `query() -> [Model]` flow.

### Result:

UDTs can be written and read, standalone and inside lists, sets, and maps, both through the low-level column accessors and through Codable decoding. Decimal fields and a Codable encoder for UDT writes are not included.