### PR TITLE
Add support for the DECIMAL type

### DIFF
--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -647,6 +647,39 @@ extension CassandraClient.Row {
     }
 }
 
+// MARK: - Decimal
+
+extension CassandraClient.Column {
+    /// Get column value as `Foundation.Decimal`.
+    public var decimal: Foundation.Decimal? {
+        decimalValue(from: self.rawPointer)
+    }
+}
+
+/// Read a DECIMAL value from any `CassValue` pointer (a column, or a collection element).
+private func decimalValue(from pointer: OpaquePointer?) -> Foundation.Decimal? {
+    var varint: UnsafePointer<UInt8>?
+    var varintSize = 0
+    var scale: Int32 = 0
+    guard cass_value_get_decimal(pointer, &varint, &varintSize, &scale) == CASS_OK, let varint = varint else {
+        return nil
+    }
+    let bytes = Array(UnsafeBufferPointer(start: varint, count: varintSize))
+    return CassandraClient.varintToDecimal(varint: bytes, scale: scale)
+}
+
+extension CassandraClient.Row {
+    /// Get column value as `Foundation.Decimal`.
+    public func column(_ name: String) -> Foundation.Decimal? {
+        self.column(name)?.decimal
+    }
+
+    /// Get column value as `Foundation.Decimal`.
+    public func column(_ index: Int) -> Foundation.Decimal? {
+        self.column(index)?.decimal
+    }
+}
+
 // MARK: - Unsafe bytes
 
 extension CassandraClient.Column {
@@ -701,6 +734,11 @@ extension CassandraClient.Column {
         self.toArray(type: String.self)
     }
 
+    /// Get column value as `[Foundation.Decimal]`.
+    public var decimalArray: [Foundation.Decimal]? {
+        self.toArray(type: Foundation.Decimal.self)
+    }
+
     private func toArray<T>(type: T.Type) -> [T]? {
         guard cass_value_is_null(self.rawPointer) == cass_false else {
             return nil
@@ -743,6 +781,8 @@ extension CassandraClient.Column {
                 value = error == CASS_OK ? v as? T : nil
             case is String.Type:
                 value = valuePointer.flatMap { toString(cassValue: $0) as? T }
+            case is Foundation.Decimal.Type:
+                value = decimalValue(from: valuePointer) as? T
             default:
                 value = nil
             }
@@ -825,6 +865,16 @@ extension CassandraClient.Row {
     /// Get column value as `[String]`.
     public func column(_ index: Int) -> [String]? {
         self.column(index)?.stringArray
+    }
+
+    /// Get column value as `[Foundation.Decimal]`.
+    public func column(_ name: String) -> [Foundation.Decimal]? {
+        self.column(name)?.decimalArray
+    }
+
+    /// Get column value as `[Foundation.Decimal]`.
+    public func column(_ index: Int) -> [Foundation.Decimal]? {
+        self.column(index)?.decimalArray
     }
 }
 

--- a/Sources/CassandraClient/Decimal.swift
+++ b/Sources/CassandraClient/Decimal.swift
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension CassandraClient {
+    /// Convert a `Foundation.Decimal` to Cassandra's DECIMAL wire form: a big-endian two's-complement
+    /// unscaled integer (`varint`) and an `Int32` `scale`, where value = unscaled * 10^(-scale).
+    internal static func decimalToVarint(_ value: Foundation.Decimal) -> (varint: [UInt8], scale: Int32) {
+        if value.isZero {
+            return ([0x00], 0)
+        }
+
+        let negative = value < 0
+        var magnitude = negative ? -value : value
+
+        // Scale up until the magnitude is integer-valued; this avoids relying on the decimal's
+        // internal exponent and never yields a negative scale.
+        var scale: Int32 = 0
+        while !isInteger(magnitude) {
+            magnitude *= 10
+            scale += 1
+        }
+
+        var bytes = magnitudeBytes(magnitude)
+        if negative {
+            bytes = twosComplement(bytes)
+        }
+        return (bytes, scale)
+    }
+
+    /// Convert Cassandra's DECIMAL wire form back to a `Foundation.Decimal`.
+    /// Returns `nil` if the value exceeds `Foundation.Decimal`'s representable range.
+    internal static func varintToDecimal(varint: [UInt8], scale: Int32) -> Foundation.Decimal? {
+        guard let first = varint.first else {
+            return nil
+        }
+        // Foundation.Decimal holds a 128-bit (16-byte) mantissa; anything wider cannot be
+        // represented, so return nil rather than risk an overflowed, wrong value.
+        guard varint.count <= 16 else {
+            return nil
+        }
+
+        let negative = (first & 0x80) != 0
+
+        var unsigned = Foundation.Decimal(0)
+        for byte in varint {
+            unsigned = unsigned * 256 + Foundation.Decimal(UInt(byte))
+            if unsigned.isNaN { return nil }
+        }
+
+        var value: Foundation.Decimal
+        if negative {
+            let modulus = pow(Foundation.Decimal(256), varint.count)
+            if modulus.isNaN { return nil }
+            value = unsigned - modulus
+        } else {
+            value = unsigned
+        }
+
+        if scale != 0 {
+            let power = pow(Foundation.Decimal(10), abs(Int(scale)))
+            if power.isNaN { return nil }
+            value = scale > 0 ? value / power : value * power
+        }
+
+        return value.isNaN ? nil : value
+    }
+
+    /// Whether a non-negative decimal has no fractional part.
+    private static func isInteger(_ value: Foundation.Decimal) -> Bool {
+        var input = value
+        var rounded = Foundation.Decimal()
+        NSDecimalRound(&rounded, &input, 0, .down)
+        return rounded == input
+    }
+
+    /// Truncating (round-toward-zero) integer division behavior, reused across conversions.
+    private static let roundDown = NSDecimalNumberHandler(
+        roundingMode: .down,
+        scale: 0,
+        raiseOnExactness: false,
+        raiseOnOverflow: false,
+        raiseOnUnderflow: false,
+        raiseOnDivideByZero: false
+    )
+
+    /// Big-endian magnitude bytes of a non-negative, integer-valued decimal, with a leading `0x00`
+    /// inserted when the high bit is set so the value is not misread as negative two's complement.
+    private static func magnitudeBytes(_ magnitude: Foundation.Decimal) -> [UInt8] {
+        let divisor = NSDecimalNumber(value: 256)
+
+        var value = NSDecimalNumber(decimal: magnitude)
+        var bytes: [UInt8] = []
+        while value.compare(NSDecimalNumber.zero) == .orderedDescending {
+            let quotient = value.dividing(by: divisor, withBehavior: self.roundDown)
+            let remainder = value.subtracting(quotient.multiplying(by: divisor))
+            bytes.append(UInt8(remainder.intValue))
+            value = quotient
+        }
+
+        if bytes.isEmpty {
+            bytes = [0x00]
+        }
+        bytes.reverse()
+        if bytes[0] & 0x80 != 0 {
+            bytes.insert(0x00, at: 0)
+        }
+        return bytes
+    }
+
+    /// Two's complement of big-endian magnitude bytes (invert and add one). The input is guaranteed
+    /// to have a clear high bit, so the result's high bit is set, marking it negative.
+    private static func twosComplement(_ bytes: [UInt8]) -> [UInt8] {
+        var result = bytes.map { ~$0 }
+        var carry: UInt16 = 1
+        for index in stride(from: result.count - 1, through: 0, by: -1) {
+            let sum = UInt16(result[index]) + carry
+            result[index] = UInt8(sum & 0xFF)
+            carry = sum >> 8
+        }
+        if result[0] & 0x80 == 0 {
+            result.insert(0xFF, at: 0)
+        }
+        return result
+    }
+}

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -310,6 +310,20 @@ extension CassandraClient {
                     )
                 }
                 return value as! T
+            } else if type == Foundation.Decimal.self {
+                guard let value: Foundation.Decimal = row.column(key.stringValue)?.decimal else {
+                    throw DecodingError.typeMismatch(
+                        "value for \(key.stringValue) not found or of incorrect data type."
+                    )
+                }
+                return value as! T
+            } else if type == [Foundation.Decimal].self {
+                guard let value: [Foundation.Decimal] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch(
+                        "value for \(key.stringValue) not found or of incorrect data type."
+                    )
+                }
+                return value as! T
             } else {
                 throw DecodingError.notSupported("Decoding of \(type) is not supported.")
             }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -110,6 +110,8 @@ extension CassandraClient {
                         buffer.baseAddress,
                         buffer.count
                     )
+                case .decimal(let value):
+                    result = self.bindDecimal(value, at: index)
                 case .encryptedString(let wrapped, let context):
                     guard let context = context else {
                         throw CassandraClient.Error.encryptionConfigError(
@@ -210,6 +212,8 @@ extension CassandraClient {
                     result = try self.bindArray(array, at: index)
                 case .stringArray(let array):
                     result = try self.bindArray(array, at: index)
+                case .decimalArray(let array):
+                    result = try self.bindArray(array, at: index)
                 default:
                     result = try self.bindMapCases(parameter, index)
                 }
@@ -275,6 +279,11 @@ extension CassandraClient {
                     appendResult = cass_collection_append_double(collection, value)
                 case let value as String:
                     appendResult = cass_collection_append_string(collection, value)
+                case let value as Foundation.Decimal:
+                    let (varint, scale) = CassandraClient.decimalToVarint(value)
+                    appendResult = varint.withUnsafeBufferPointer { buffer in
+                        cass_collection_append_decimal(collection, buffer.baseAddress, buffer.count, scale)
+                    }
                 default:
                     throw CassandraClient.Error.badParams("Array of \(T.self) is not supported")
                 }
@@ -284,6 +293,14 @@ extension CassandraClient {
                 }
             }
             return cass_statement_bind_collection(self.rawPointer, index, collection)
+        }
+
+        private func bindDecimal(_ value: Foundation.Decimal, at index: Int) -> CassError {
+            let (varint, scale) = CassandraClient.decimalToVarint(value)
+            let this = self
+            return varint.withUnsafeBufferPointer { buffer in
+                cass_statement_bind_decimal(this.rawPointer, index, buffer.baseAddress, buffer.count, scale)
+            }
         }
 
         func setPagingSize(_ pagingSize: Int32) throws {
@@ -337,6 +354,7 @@ extension CassandraClient {
             case rawTimestamp(millisecondsSinceEpoch: Int64)
             case bytes([UInt8])
             case bytesUnsafe(UnsafeBufferPointer<UInt8>)
+            case decimal(Foundation.Decimal)
 
             case encryptedString(Encrypted<String>, context: EncryptionContext? = nil)
             case encryptedBytes(Encrypted<[UInt8]>, context: EncryptionContext? = nil)
@@ -353,6 +371,7 @@ extension CassandraClient {
             case float32Array([Float32])
             case doubleArray([Double])
             case stringArray([String])
+            case decimalArray([Foundation.Decimal])
 
             case int8Int8Map([Int8: Int8])
             case int8Int16Map([Int8: Int16])

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -699,7 +699,7 @@ final class Tests: XCTestCase {
             let int32 = Int32.random(in: Int32.min...Int32.max)
             let int64 = Int64.random(in: Int64.min...Int64.max)
             // let varint = // FIXME: implement varint
-            // let decimal = // FIXME: implement decimal
+            let decimal = Decimal(sign: .plus, exponent: -3, significand: Decimal(Int.random(in: 0...999_999_999)))
             let float32 = Float32.random(in: Float(Int32.min)...Float(Int32.max))
             let double = Double.random(in: Double(Int64.min)...Double(Int64.max))
             let text = UUID().uuidString
@@ -732,7 +732,7 @@ final class Tests: XCTestCase {
                 .int32(int32),  // int
                 .int64(int64),  // bigint
                 .null,  // varint
-                .null,  // decimal
+                .decimal(decimal),  // decimal
                 .float32(float32),  // float
                 .double(double),  // double
                 .string(text),  // text
@@ -772,7 +772,7 @@ final class Tests: XCTestCase {
             XCTAssertEqual(row.column("col3"), int32, "expected value to match")
             XCTAssertEqual(row.column("col4"), int64, "expected value to match")
             // XCTAssertEqual(row.column("col5"), varint, "expected value to match")
-            // XCTAssertEqual(row.column("col6"), decimal, "expected value to match")
+            XCTAssertEqual(row.column("col6"), decimal, "expected value to match")
             XCTAssertEqual(row.column("col7"), float32, "expected value to match")
             XCTAssertEqual(row.column("col8"), double, "expected value to match")
             XCTAssertEqual(row.column("col9"), text, "expected value to match")

--- a/Tests/CassandraClientTests/DecimalTests.swift
+++ b/Tests/CassandraClientTests/DecimalTests.swift
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+/// Conversion logic between `Foundation.Decimal` and Cassandra's varint+scale wire form.
+/// These run without a Cassandra connection.
+final class DecimalConversionTests: XCTestCase {
+    func testConversionRoundtrip() {
+        let values: [Foundation.Decimal] = [
+            Decimal(string: "0")!,
+            Decimal(string: "1")!,
+            Decimal(string: "123.45")!,
+            Decimal(string: "-123.45")!,
+            Decimal(string: "-0.001")!,
+            Decimal(string: "128")!,
+            Decimal(string: "-128")!,
+            Decimal(string: "1000000")!,
+            Decimal(string: "0.0000001")!,
+            Decimal(string: "123456789012345678901234567890")!,
+            Decimal(string: "-987654321.123456789")!,
+        ]
+        for value in values {
+            let (varint, scale) = CassandraClient.decimalToVarint(value)
+            let decoded = CassandraClient.varintToDecimal(varint: varint, scale: scale)
+            XCTAssertEqual(decoded, value, "round-trip failed for \(value)")
+        }
+    }
+
+    func testKnownWireVectors() {
+        // 123.45 = unscaled 12345 (0x3039), scale 2
+        let (positive, positiveScale) = CassandraClient.decimalToVarint(Decimal(string: "123.45")!)
+        XCTAssertEqual(positive, [0x30, 0x39])
+        XCTAssertEqual(positiveScale, 2)
+
+        // 128 has its high bit set, so a leading 0x00 must be prepended to keep it positive.
+        let (sign, signScale) = CassandraClient.decimalToVarint(Decimal(string: "128")!)
+        XCTAssertEqual(sign, [0x00, 0x80])
+        XCTAssertEqual(signScale, 0)
+
+        // -1 with scale 3 is the two's complement of 1: 0xFF.
+        let (negative, negativeScale) = CassandraClient.decimalToVarint(Decimal(string: "-0.001")!)
+        XCTAssertEqual(negative, [0xFF])
+        XCTAssertEqual(negativeScale, 3)
+
+        XCTAssertEqual(CassandraClient.varintToDecimal(varint: [0x30, 0x39], scale: 2), Decimal(string: "123.45"))
+        XCTAssertEqual(CassandraClient.varintToDecimal(varint: [0xFF], scale: 3), Decimal(string: "-0.001"))
+    }
+
+    func testOutOfRangeReturnsNil() {
+        let tooWide = [UInt8](repeating: 0x7F, count: 24)
+        XCTAssertNil(CassandraClient.varintToDecimal(varint: tooWide, scale: 0))
+        XCTAssertNil(CassandraClient.varintToDecimal(varint: [], scale: 0))
+    }
+}
+
+final class DecimalTests: XCTestCase {
+    var cassandraClient: CassandraClient!
+    var configuration: CassandraClient.Configuration!
+
+    override func setUp() {
+        super.setUp()
+
+        let env = ProcessInfo.processInfo.environment
+        let keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        self.configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        self.configuration.username = env["CASSANDRA_USER"]
+        self.configuration.password = env["CASSANDRA_PASSWORD"]
+        self.configuration.keyspace = keyspace
+        self.configuration.requestTimeoutMillis = UInt32(24_000)
+        self.configuration.connectTimeoutMillis = UInt32(10_000)
+
+        var logger = Logger(label: "test")
+        logger.logLevel = .debug
+
+        self.cassandraClient = CassandraClient(configuration: self.configuration, logger: logger)
+        XCTAssertNoThrow(
+            try self.cassandraClient.withSession(keyspace: .none) { session in
+                try session
+                    .run(
+                        "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+                    )
+                    .wait()
+            }
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        XCTAssertNoThrow(try self.cassandraClient.shutdown())
+        self.cassandraClient = nil  // FIXME: for tsan
+    }
+
+    // MARK: - Integration tests
+
+    func testScalarRoundtrip() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id int primary key, amount decimal)"
+        ).wait()
+
+        let values: [(Int32, Foundation.Decimal?)] = [
+            (1, Decimal(string: "123.45")),
+            (2, Decimal(string: "-987654321.123456789")),
+            (3, nil),
+        ]
+        for (id, amount) in values {
+            try self.cassandraClient.run(
+                "insert into \(tableName) (id, amount) values (?, ?)",
+                parameters: [.int32(id), amount.map { .decimal($0) } ?? .null]
+            ).wait()
+        }
+
+        for (id, amount) in values {
+            let rows = try self.cassandraClient.query(
+                "select amount from \(tableName) where id = ?",
+                parameters: [.int32(id)]
+            ).wait()
+            let read = try XCTUnwrap(rows.first).column("amount")?.decimal
+            XCTAssertEqual(read, amount, "mismatch for id \(id)")
+        }
+    }
+
+    func testListRoundtrip() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id int primary key, amounts list<decimal>)"
+        ).wait()
+
+        let amounts = [Decimal(string: "1.1")!, Decimal(string: "-2.22")!, Decimal(string: "300")!]
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, amounts) values (?, ?)",
+            parameters: [.int32(1), .decimalArray(amounts)]
+        ).wait()
+
+        let rows = try self.cassandraClient.query(
+            "select amounts from \(tableName) where id = ?",
+            parameters: [.int32(1)]
+        ).wait()
+        let read = try XCTUnwrap(try XCTUnwrap(rows.first).column("amounts")?.decimalArray)
+        XCTAssertEqual(read, amounts)
+    }
+
+    func testCodableDecode() throws {
+        struct Model: Codable, Equatable {
+            let id: Int32
+            let amount: Foundation.Decimal
+            let amounts: [Foundation.Decimal]
+        }
+
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run(
+            "create table \(tableName) (id int primary key, amount decimal, amounts list<decimal>)"
+        ).wait()
+
+        let expected = Model(
+            id: 1,
+            amount: Decimal(string: "42.42")!,
+            amounts: [Decimal(string: "0.5")!, Decimal(string: "-1.25")!]
+        )
+        try self.cassandraClient.run(
+            "insert into \(tableName) (id, amount, amounts) values (?, ?, ?)",
+            parameters: [.int32(expected.id), .decimal(expected.amount), .decimalArray(expected.amounts)]
+        ).wait()
+
+        let result: [Model] = try self.cassandraClient.query(
+            "select id, amount, amounts from \(tableName) where id = ?",
+            parameters: [.int32(1)]
+        ).wait()
+        XCTAssertEqual(result, [expected])
+    }
+}


### PR DESCRIPTION
Bind and read Cassandra DECIMAL values as Foundation.Decimal, as scalars and in lists, with Codable support.

### Motivation:

The client supported all common scalar types plus lists and maps, but had no DECIMAL support: `Statement.Value` had no decimal case, `Column` had no decimal getter, and the decoder rejected `Decimal`. The data-type test documented the gap with a `// FIXME: implement decimal` and bound `.null` for its `decimal` column, so any schema using `decimal` could not be written or read.

### Modifications:

Surfaced DECIMAL as `Foundation.Decimal`, following the convention of mapping each Cassandra type to its native Swift/Foundation counterpart (`uuid` -> `Foundation.UUID`, `timestamp` -> `Foundation.Date`), and handled it like `.date`: convert at the bind/read boundary.

Added internal `decimalToVarint`/`varintToDecimal` helpers that convert between `Foundation.Decimal` and the wire form (a big-endian two's complement unscaled integer plus an `Int32` scale). Added `.decimal` and `.decimalArray` `Statement.Value` cases and their binding, a `Column.decimal` getter, `Column.decimalArray`, the `Row` overloads, and `Foundation.Decimal` / `[Foundation.Decimal]` branches in the decoder. Filled in the previously stubbed `decimal` column in the data-type test.

### Result:

DECIMAL can be written and read, standalone and in lists and sets, both through the column accessors and through Codable decoding. Values beyond `Foundation.Decimal`'s representable range read back as nil rather than a wrong value. Maps (`map<K, decimal>`) and a standalone VARINT type are not included.