### PR TITLE
Annotate closures and generics as Sendable for strict concurrency

### DIFF
--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -208,7 +208,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
     /// - Returns: The decoded rows.
-    public func execute<T: Decodable>(
+    public func execute<T: Decodable & Sendable>(
         prepared: PreparedStatement,
         parameters: [Statement.Value] = [],
         options: Statement.Options = .init(),

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -208,6 +208,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
     /// - Returns: The decoded rows.
+    @preconcurrency
     public func execute<T: Decodable & Sendable>(
         prepared: PreparedStatement,
         parameters: [Statement.Value] = [],

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -208,8 +208,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
     /// - Returns: The decoded rows.
-    @preconcurrency
-    public func execute<T: Decodable & Sendable>(
+    public func execute<T: Decodable>(
         prepared: PreparedStatement,
         parameters: [Statement.Value] = [],
         options: Statement.Options = .init(),

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -208,7 +208,8 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
     /// - Returns: The decoded rows.
-    public func execute<T: Decodable>(
+    @preconcurrency
+    public func execute<T: Decodable & Sendable>(
         prepared: PreparedStatement,
         parameters: [Statement.Value] = [],
         options: Statement.Options = .init(),

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1149,8 +1149,9 @@ extension CassandraClient {
             self.underlying.getMetrics()
         }
 
-        fileprivate struct ConnectionTask {
-            private let _task: Any
+        fileprivate struct ConnectionTask: Sendable {
+            // `_task` only ever holds a Sendable `Task`, erased to `Any` for availability — safe to treat as Sendable.
+            nonisolated(unsafe) private let _task: Any
 
             @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
             var task: Task<Void, Swift.Error> {

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -311,7 +311,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none,
-        transform: @escaping @Sendable (CassandraClient.Row) -> T?
+        transform: @escaping (CassandraClient.Row) -> T?
     ) -> EventLoopFuture<[T]> {
         self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger).map {
             rows in
@@ -322,8 +322,7 @@ extension CassandraSession {
     /// Query small data-sets that fit into memory. Only use this when it's safe to buffer the entire data-set into memory.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
-    @preconcurrency
-    public func query<T: Decodable & Sendable>(
+    public func query<T: Decodable>(
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
@@ -447,8 +446,7 @@ extension CassandraSession {
     /// Execute a prepared statement and decode each row into a `Decodable` type.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
-    @preconcurrency
-    public func execute<T: Decodable & Sendable>(
+    public func execute<T: Decodable>(
         prepared: CassandraClient.PreparedStatement,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -305,13 +305,14 @@ extension CassandraSession {
     /// Query small data-sets that fit into memory. Only use this when it is safe to buffer the entire data-set into memory.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    @preconcurrency
     public func query<T>(
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none,
-        transform: @escaping (CassandraClient.Row) -> T?
+        transform: @escaping @Sendable (CassandraClient.Row) -> T?
     ) -> EventLoopFuture<[T]> {
         self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger).map {
             rows in
@@ -322,7 +323,8 @@ extension CassandraSession {
     /// Query small data-sets that fit into memory. Only use this when it's safe to buffer the entire data-set into memory.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
-    public func query<T: Decodable>(
+    @preconcurrency
+    public func query<T: Decodable & Sendable>(
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
@@ -446,7 +448,8 @@ extension CassandraSession {
     /// Execute a prepared statement and decode each row into a `Decodable` type.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
-    public func execute<T: Decodable>(
+    @preconcurrency
+    public func execute<T: Decodable & Sendable>(
         prepared: CassandraClient.PreparedStatement,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -311,7 +311,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none,
-        transform: @escaping (CassandraClient.Row) -> T?
+        transform: @escaping @Sendable (CassandraClient.Row) -> T?
     ) -> EventLoopFuture<[T]> {
         self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger).map {
             rows in
@@ -322,7 +322,7 @@ extension CassandraSession {
     /// Query small data-sets that fit into memory. Only use this when it's safe to buffer the entire data-set into memory.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
-    public func query<T: Decodable>(
+    public func query<T: Decodable & Sendable>(
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
@@ -446,7 +446,7 @@ extension CassandraSession {
     /// Execute a prepared statement and decode each row into a `Decodable` type.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
-    public func execute<T: Decodable>(
+    public func execute<T: Decodable & Sendable>(
         prepared: CassandraClient.PreparedStatement,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
@@ -459,17 +459,18 @@ extension CassandraSession {
                 effectiveOptions.encryptionTable = prepared.encryptionTable
             }
         }
+        let finalOptions = effectiveOptions
         return self.execute(
             prepared: prepared,
             parameters: parameters,
-            options: effectiveOptions,
+            options: finalOptions,
             on: eventLoop,
             logger: logger
         ).flatMapThrowing { rows in
             let result = try rows.map { row in
-                try T(from: self.makeDecoder(row: row, options: effectiveOptions))
+                try T(from: self.makeDecoder(row: row, options: finalOptions))
             }
-            self.logDecryptedRows(count: result.count, options: effectiveOptions, logger: logger)
+            self.logDecryptedRows(count: result.count, options: finalOptions, logger: logger)
             return result
         }
     }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -322,6 +322,7 @@ extension CassandraSession {
     /// Query small data-sets that fit into memory. Only use this when it's safe to buffer the entire data-set into memory.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    @preconcurrency
     public func query<T: Decodable & Sendable>(
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
@@ -446,6 +447,7 @@ extension CassandraSession {
     /// Execute a prepared statement and decode each row into a `Decodable` type.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    @preconcurrency
     public func execute<T: Decodable & Sendable>(
         prepared: CassandraClient.PreparedStatement,
         parameters: [CassandraClient.Statement.Value] = [],
@@ -1150,8 +1152,8 @@ extension CassandraClient {
         }
 
         fileprivate struct ConnectionTask: Sendable {
-            // `_task` only ever holds a Sendable `Task`, erased to `Any` for availability — safe to treat as Sendable.
-            nonisolated(unsafe) private let _task: Any
+            // `_task` only ever holds a `Task<Void, Error>`, erased to `any Sendable` for availability.
+            private let _task: any Sendable
 
             @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
             var task: Task<Void, Swift.Error> {

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -483,25 +483,25 @@ extension CassandraClient {
             }
         }
 
-        public struct Options: CustomStringConvertible {
+        public struct Options: Sendable, CustomStringConvertible {
             /// Sets the statement's consistency level. Default is `.localOne`.
             public var consistency: CassandraClient.Consistency?
             /// Sets the statement's request timeout in milliseconds. Default is `CASS_UINT64_MAX`
             public var requestTimeout: UInt64?
 
             /// Type-erased backing store for ``encryptionContextBuilder``.
-            private var _encryptionContextBuilder: Any?
+            private var _encryptionContextBuilder: (any Sendable)?
 
             /// Closure that extracts encryption context from each row during Codable decoding.
             @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
             public var encryptionContextBuilder:
                 (
-                    (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
+                    @Sendable (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
                 )?
             {
                 get {
                     self._encryptionContextBuilder
-                        as? (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
+                        as? @Sendable (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
                 }
                 set { self._encryptionContextBuilder = newValue }
             }


### PR DESCRIPTION
  ## Summary
  Part of the Swift 6 strict-concurrency effort (Phase 1, annotation-only). Adds `Sendable`-related annotations so these types/closures can cross concurrency boundaries; no runtime behavior change.

  ## Changes
  - query<T>/execute<T>(prepared:) (EventLoopFuture variants): constrain the decoded generic to Sendable (T: Decodable & Sendable) and mark @preconcurrency; propagate the same through CassandraClient's forwarding execute<T>. Async variants left unconstrained.
  - query(transform:): mark the transform closure @Sendable (function @preconcurrency).
  - Statement.Options: conform to Sendable; constrain encryptionContextBuilder's backing store to (any Sendable) and its closure type to @Sendable.
  - ConnectionTask: conform to Sendable, storing _task as any Sendable (was Any) — compiler-verified, unblocks Session: Sendable under v6.
  - Snapshot effectiveOptions into a let before it's captured in the result closure (avoids capturing a mutated var).

  ## Source-breaking
  - Options.encryptionContextBuilder's setter now requires a @Sendable closure (availability-gated) — the one hard break.
  - The query/execute T: Sendable constraints and transform: @Sendable are softened by @preconcurrency: non-migrated callers are unaffected; strict-concurrency callers get a warning, not an error.

  ## Verification
  - Builds clean in Swift 5 language mode (current default).
  - With the language mode flipped to v6, the targeted diagnostics are cleared; remaining errors are pre-existing items addressed in later changes.
  - Full unit + integration suite passes (89 tests).
