### PR TITLE
Add uuidArray support for list<uuid> columns

### DIFF
--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -707,6 +707,11 @@ extension CassandraClient.Column {
         self.toArray(type: String.self)
     }
 
+    /// Get column value as `[UUID]`.
+    public var uuidArray: [Foundation.UUID]? {
+        self.toArray(type: Foundation.UUID.self)
+    }
+
     private func toArray<T>(type: T.Type) -> [T]? {
         guard cass_value_is_null(self.rawPointer) == cass_false else {
             return nil
@@ -749,6 +754,10 @@ extension CassandraClient.Column {
                 value = error == CASS_OK ? v as? T : nil
             case is String.Type:
                 value = valuePointer.flatMap { toString(cassValue: $0) as? T }
+            case is Foundation.UUID.Type:
+                var v = CassUuid()
+                let error = cass_value_get_uuid(valuePointer, &v)
+                value = error == CASS_OK ? v.uuid() as? T : nil
             default:
                 value = nil
             }
@@ -831,6 +840,16 @@ extension CassandraClient.Row {
     /// Get column value as `[String]`.
     public func column(_ index: Int) -> [String]? {
         self.column(index)?.stringArray
+    }
+
+    /// Get column value as `[UUID]`.
+    public func column(_ name: String) -> [Foundation.UUID]? {
+        self.column(name)?.uuidArray
+    }
+
+    /// Get column value as `[UUID]`.
+    public func column(_ index: Int) -> [Foundation.UUID]? {
+        self.column(index)?.uuidArray
     }
 }
 

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -310,6 +310,13 @@ extension CassandraClient {
                     )
                 }
                 return value as! T
+            } else if type == [Foundation.UUID].self {
+                guard let value: [Foundation.UUID] = row.column(key.stringValue) else {
+                    throw DecodingError.typeMismatch(
+                        "value for \(key.stringValue) not found or of incorrect data type."
+                    )
+                }
+                return value as! T
             } else {
                 throw DecodingError.notSupported("Decoding of \(type) is not supported.")
             }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -214,6 +214,8 @@ extension CassandraClient {
                     result = try self.bindArray(array, at: index)
                 case .stringArray(let array):
                     result = try self.bindArray(array, at: index)
+                case .uuidArray(let array):
+                    result = try self.bindArray(array, at: index)
                 default:
                     result = try self.bindMapCases(parameter, index)
                 }
@@ -279,6 +281,9 @@ extension CassandraClient {
                     appendResult = cass_collection_append_double(collection, value)
                 case let value as String:
                     appendResult = cass_collection_append_string(collection, value)
+                case let value as Foundation.UUID:
+                    let cassUuid = CassUuid(value.uuid)
+                    appendResult = cass_collection_append_uuid(collection, cassUuid)
                 default:
                     throw CassandraClient.Error.badParams("Array of \(T.self) is not supported")
                 }
@@ -353,6 +358,7 @@ extension CassandraClient {
             case float32Array([Float32])
             case doubleArray([Double])
             case stringArray([String])
+            case uuidArray([Foundation.UUID])
 
             case int8Int8Map([Int8: Int8])
             case int8Int16Map([Int8: Int16])

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -878,6 +878,7 @@ final class Tests: XCTestCase {
             let col18: [Float32]
             let col19: [Double]
             let col20: [String]
+            let col21: [UUID]
             let doesNotExist: Bool?
         }
 
@@ -907,6 +908,7 @@ final class Tests: XCTestCase {
                     Double.random(in: Double(Int64.min)...Double(Int64.max))
                 },
                 col20: (0...Int.random(in: 1...3)).map { _ in UUID().uuidString },
+                col21: (0...Int.random(in: 1...3)).map { _ in UUID() },
                 doesNotExist: nil
             )
         }
@@ -937,7 +939,8 @@ final class Tests: XCTestCase {
                 col17 list<bigint>,
                 col18 list<float>,
                 col19 list<double>,
-                col20 list<text>
+                col20 list<text>,
+                col21 list<uuid>
                 );
                 """
             ).wait()
@@ -966,14 +969,15 @@ final class Tests: XCTestCase {
                 .float32Array(model.col18),
                 .doubleArray(model.col19),
                 .stringArray(model.col20),
+                .uuidArray(model.col21),
             ]
             futures.append(
                 self.cassandraClient.run(
                     """
                     insert into \(tableName)
-                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20)
+                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21)
                     values
-                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     parameters: parameters
                 )
@@ -1013,6 +1017,7 @@ final class Tests: XCTestCase {
             XCTAssertEqual(item.col18, data[index].col18, "results should match")
             XCTAssertEqual(item.col19, data[index].col19, "results should match")
             XCTAssertEqual(item.col20, data[index].col20, "results should match")
+            XCTAssertEqual(item.col21, data[index].col21, "results should match")
         }
     }
 
@@ -1071,6 +1076,7 @@ final class Tests: XCTestCase {
                 col21 list<float>,
                 col22 list<double>,
                 col23 list<text>,
+                col24 list<uuid>,
                 )
                 """
             ).wait()
@@ -1107,6 +1113,7 @@ final class Tests: XCTestCase {
                 Double.random(in: Double(Int64.min)...Double(Int64.max))
             }
             let textList = (0...Int.random(in: 1...3)).map { _ in UUID().uuidString }
+            let uuidList = (0...Int.random(in: 1...3)).map { _ in UUID() }
 
             let parameters: [CassandraClient.Statement.Value] = [
                 .int8(index),  // tinyint
@@ -1132,15 +1139,16 @@ final class Tests: XCTestCase {
                 .float32Array(float32List),  // list<float>
                 .doubleArray(doubleList),  // list<double>
                 .stringArray(textList),  // list<text>
+                .uuidArray(uuidList),  // list<uuid>
             ]
 
             XCTAssertNoThrow(
                 try self.cassandraClient.run(
                     """
                     insert into \(tableName)
-                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21, col22, col23)
+                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21, col22, col23, col24)
                     values
-                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     parameters: parameters
                 ).wait()
@@ -1182,6 +1190,7 @@ final class Tests: XCTestCase {
             XCTAssertEqual(row.column("col21"), float32List, "expected value to match")
             XCTAssertEqual(row.column("col22"), doubleList, "expected value to match")
             XCTAssertEqual(row.column("col23"), textList, "expected value to match")
+            XCTAssertEqual(row.column("col24"), uuidList, "expected value to match")
         }
     }
 


### PR DESCRIPTION
_Add uuidArray support for reading and writing list<uuid> columns_

### Motivation:

CassandraClient.Column.toArray handled Int8, Int16, Int32, Int64, Float32, Double, and String element types but UUID was missing. As a result, list<uuid> and set<uuid> columns always returned nil, making them inaccessible through the Swift API.

### Modifications:

- Add Foundation.UUID case to toArray using cass_value_get_uuid to decode each element, converting the resulting CassUuid to Foundation.UUID via the existing CassUuid.uuid() helper
- Add Column.uuidArray: [Foundation.UUID]? computed property
- Add Row.column(_ name: String) -> [Foundation.UUID]? and Row.column(_ index: Int) -> [Foundation.UUID]? convenience overloads
- Add Statement.Value.uuidArray([Foundation.UUID]) enum case and wire bindArray to append UUID elements via cass_collection_append_uuid
- Extend testListTypes with a list<uuid> column covering insert and read round-trip

### Result:

list<uuid> and set<uuid> columns can be read from and written to Cassandra through the Swift API. Column.uuidArray returns the decoded [UUID] values and Statement.Value.uuidArray binds a [UUID] parameter for inserts.
