### PR TITLE
Fix Column.string returning raw bytes for non-text column types

### DIFF
--- a/Sources/CassandraClient/Data+Maps.swift
+++ b/Sources/CassandraClient/Data+Maps.swift
@@ -331,16 +331,7 @@ extension CassandraClient.Column {
             let error = cass_value_get_bool(pointer, &value)
             return error == CASS_OK ? (value == cass_true) as? T : nil
         case is String.Type:
-            var stringPtr: UnsafePointer<CChar>?
-            var stringSize = 0
-            let error = cass_value_get_string(pointer, &stringPtr, &stringSize)
-            guard let ptr = stringPtr, error == CASS_OK else {
-                return nil
-            }
-            let buffer = UnsafeBufferPointer(start: ptr, count: stringSize)
-            return buffer.withMemoryRebound(to: UInt8.self) {
-                String(decoding: $0, as: UTF8.self) as? T
-            }
+            return toString(cassValue: pointer) as? T
         case is Foundation.UUID.Type:
             var value = CassUuid()
             let error = cass_value_get_uuid(pointer, &value)

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -237,7 +237,15 @@ extension CassandraClient {
 
 // MARK: - Utils
 
-private func toString(cassValue: OpaquePointer) -> String? {
+func toString(cassValue: OpaquePointer) -> String? {
+    let valueType = cass_value_type(cassValue)
+    guard
+        valueType == CASS_VALUE_TYPE_ASCII
+            || valueType == CASS_VALUE_TYPE_TEXT
+            || valueType == CASS_VALUE_TYPE_VARCHAR
+    else {
+        return nil
+    }
     var value: UnsafePointer<CChar>?
     var valueSize = 0
     let error = cass_value_get_string(cassValue, &value, &valueSize)
@@ -246,7 +254,7 @@ private func toString(cassValue: OpaquePointer) -> String? {
     }
     let stringBuffer = UnsafeBufferPointer(start: definiteValue, count: valueSize)
     return stringBuffer.withMemoryRebound(to: UInt8.self) {
-        String(decoding: $0, as: UTF8.self)
+        String(bytes: $0, encoding: .utf8)
     }
 }
 

--- a/Tests/CassandraClientTests/DataTests.swift
+++ b/Tests/CassandraClientTests/DataTests.swift
@@ -1,0 +1,143 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+/// Verifies that Column.string only returns a value for text-typed columns (ASCII, TEXT, VARCHAR)
+/// and returns nil for all other types (int, blob, uuid, boolean, etc.).
+///
+/// The DataStax C driver's cass_value_get_string has no type checking - it returns CASS_OK and
+/// raw bytes for any non-null column. Without an explicit type guard, Column.string incorrectly
+/// succeeds for non-string columns, causing callers to receive binary garbage for blobs, ints,
+/// UDTs, and frozen collections.
+final class DataTests: XCTestCase {
+    var cassandraClient: CassandraClient!
+
+    override func setUp() {
+        super.setUp()
+        let env = ProcessInfo.processInfo.environment
+        let keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        var configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        configuration.username = env["CASSANDRA_USER"]
+        configuration.password = env["CASSANDRA_PASSWORD"]
+        configuration.keyspace = keyspace
+        self.cassandraClient = CassandraClient(configuration: configuration)
+        XCTAssertNoThrow(
+            try self.cassandraClient.withSession(keyspace: .none) { session in
+                try session.run(
+                    "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+                ).wait()
+            }
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        XCTAssertNoThrow(try self.cassandraClient.shutdown())
+        self.cassandraClient = nil
+    }
+
+    func testStringReturnsValueForTextColumns() {
+        let tableName = "test_col_string_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run(
+                "create table \(tableName) (id int primary key, a ascii, b text, c varchar);"
+            ).wait()
+        )
+        XCTAssertNoThrow(
+            try self.cassandraClient.run(
+                "insert into \(tableName) (id, a, b, c) values (1, 'ascii', 'text', 'varchar');"
+            ).wait()
+        )
+
+        let rows = try! self.cassandraClient.query("select a, b, c from \(tableName);").wait()
+        let row = rows.first!
+
+        XCTAssertEqual(row.column("a")?.string, "ascii")
+        XCTAssertEqual(row.column("b")?.string, "text")
+        XCTAssertEqual(row.column("c")?.string, "varchar")
+    }
+
+    func testStringReturnsNilForNonTextColumns() {
+        let tableName = "test_col_string_nil_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run(
+                """
+                create table \(tableName) (
+                    id int primary key,
+                    col_int int,
+                    col_bigint bigint,
+                    col_blob blob,
+                    col_utf8_blob blob,
+                    col_uuid uuid,
+                    col_bool boolean,
+                    col_float float,
+                    col_double double
+                );
+                """
+            ).wait()
+        )
+        let uuid = UUID()
+        XCTAssertNoThrow(
+            try self.cassandraClient.run(
+                "insert into \(tableName) (id, col_int, col_bigint, col_blob, col_utf8_blob, col_uuid, col_bool, col_float, col_double) values (?, ?, ?, ?, ?, ?, ?, ?, ?);",
+                parameters: [
+                    .int32(1),
+                    .int32(42),
+                    .int64(9_999_999_999),
+                    .bytes([0xDE, 0xAD, 0xBE, 0xEF]),
+                    .bytes(Array("hello".utf8)),
+                    .uuid(uuid),
+                    .bool(true),
+                    .float32(3.14),
+                    .double(2.718),
+                ]
+            ).wait()
+        )
+
+        let rows = try! self.cassandraClient.query(
+            "select col_int, col_bigint, col_blob, col_utf8_blob, col_uuid, col_bool, col_float, col_double from \(tableName);"
+        ).wait()
+        let row = rows.first!
+
+        XCTAssertNil(row.column("col_int")?.string, "int column must not decode as string")
+        XCTAssertNil(row.column("col_bigint")?.string, "bigint column must not decode as string")
+        XCTAssertNil(row.column("col_blob")?.string, "blob column must not decode as string")
+        XCTAssertNil(
+            row.column("col_utf8_blob")?.string,
+            "blob with valid UTF-8 bytes must be nil from the type guard, not the UTF-8 decode"
+        )
+        XCTAssertNil(row.column("col_uuid")?.string, "uuid column must not decode as string")
+        XCTAssertNil(row.column("col_bool")?.string, "boolean column must not decode as string")
+        XCTAssertNil(row.column("col_float")?.string, "float column must not decode as string")
+        XCTAssertNil(row.column("col_double")?.string, "double column must not decode as string")
+
+        XCTAssertEqual(row.column("col_int")?.int32, 42)
+        XCTAssertEqual(row.column("col_bigint")?.int64, 9_999_999_999)
+        XCTAssertEqual(row.column("col_blob")?.bytes, [0xDE, 0xAD, 0xBE, 0xEF])
+        XCTAssertEqual(row.column("col_utf8_blob")?.bytes, Array("hello".utf8))
+        XCTAssertEqual(row.column("col_uuid")?.uuid, uuid)
+        XCTAssertEqual(row.column("col_bool")?.bool, true)
+    }
+}

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -664,7 +664,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -964,7 +964,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1006,7 +1006,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, name text)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, name text)").get()
         }
 
         // Schema has no encrypted columns — only PK
@@ -1059,7 +1059,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1113,9 +1113,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run(
+            try await session.run(
                 "create table \(tableName) (partition_id text, cluster_id int, secret blob, PRIMARY KEY (partition_id, cluster_id))"
-            ).wait()
+            ).get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1173,9 +1173,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run(
+            try await session.run(
                 "create table \(tableName) (user_id text primary key, secret_name blob, secret_age blob)"
-            ).wait()
+            ).get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1231,9 +1231,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run(
+            try await session.run(
                 "create table \(tableName) (user_id text primary key, secret_name blob, secret_age blob)"
-            ).wait()
+            ).get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1294,9 +1294,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run(
+            try await session.run(
                 "create table \(tableName) (part_id text, clust_id int, secret blob, PRIMARY KEY (part_id, clust_id))"
-            ).wait()
+            ).get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1343,7 +1343,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1386,7 +1386,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1451,7 +1451,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let insertStmt = try await self.cassandraClient.prepare(
@@ -1483,7 +1483,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)").get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1547,9 +1547,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run(
+            try await session.run(
                 "create table \(tableName) (partition_id text, cluster_id int, secret blob, PRIMARY KEY (partition_id, cluster_id))"
-            ).wait()
+            ).get()
         }
 
         let schema = try CassandraClient.EncryptionSchema(
@@ -1634,7 +1634,7 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(tableName) (id text primary key, value text)").wait()
+            try await session.run("create table \(tableName) (id text primary key, value text)").get()
         }
 
         let insertStmt = try await self.cassandraClient.prepare(
@@ -1670,9 +1670,9 @@ final class EncryptionIntegrationTests: XCTestCase {
         do {
             let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
-            try session.run("create table \(encTable1) (user_id text primary key, secret blob)").wait()
-            try session.run("create table \(encTable2) (item_id text primary key, data blob)").wait()
-            try session.run("create table \(plainTable) (id text primary key, value text)").wait()
+            try await session.run("create table \(encTable1) (user_id text primary key, secret blob)").get()
+            try await session.run("create table \(encTable2) (item_id text primary key, data blob)").get()
+            try await session.run("create table \(plainTable) (id text primary key, value text)").get()
         }
 
         let schema1 = try CassandraClient.EncryptionSchema(


### PR DESCRIPTION
_Fix Column.string returning raw bytes for non-text column types_

### Motivation:

The DataStax C driver's `cass_value_get_string` has no type checking - it calls `as_string_ref()` and returns `CASS_OK` for any non-null value, regardless of the column's actual CQL type. 

The Swift `toString()` helper called this unconditionally, meaning `Column.string` appeared to succeed for `int`, `bigint`, `blob`, `uuid`, `boolean`, `float`, `double`, `UDT` and frozen collection columns, returning their raw binary serialization decoded as lossy UTF-8.

This caused callers that try `Column.string` before falling back to typed accessors to silently receive binary garbage instead of nil, breaking display layers for frozen UDTs and complex types.

### Modifications:

- In `toString()`, `call cass_value_type` first and return nil early for any type that is not `ASCII`, TEXT, or `VARCHAR`.
- Replace `String(decoding:as:UTF8.self)` (non-failable, silently replaces invalid UTF-8 with U+FFFD) with `String(bytes:encoding:)` (failable, returns nil for invalid UTF-8).
- Add `DataTests.swift` with integration tests verifying `Column.string` returns a value for text-typed columns and nil for all other types.

### Result:

`Column.string` now returns nil for non-text columns, matching the documented semantics. Typed accessors on those columns continue to work correctly. Callers that use `Column.string` as a fallback for unknown types will correctly fall through to bytes or other representations.