### PR TITLE
Expose wasRequestUnexecuted on CassandraClient.Error

### DIFF
--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 internal import CDataStaxDriver
+import Foundation
 
 extension CassandraClient {
     /// Possible ``CassandraClient`` errors.
@@ -795,6 +796,30 @@ extension CassandraClient {
             .init(code: .other(code: code, description: description))
         }
     }
+}
+
+extension CassandraClient.Error {
+    /// The coordinator rejected the request before execution began, so the statement had no
+    /// effect and is always safe to retry on another coordinator — even when the statement is
+    /// not idempotent.
+    ///
+    /// This is true for a bootstrapping node (which never processes the request), for
+    /// `UNAVAILABLE` (the coordinator found too few replicas before contacting any of them), and
+    /// for the `OVERLOADED` response a node sends while shutting down (server message
+    /// "Server is shutting down"). A genuinely overloaded server is not covered here, since the
+    /// request may have been applied before the overload response.
+    public var wasRequestUnexecuted: Bool {
+        switch self.code {
+        case .serverBootstrapping, .serverUnavailable:
+            return true
+        case .serverOverloaded(let message):
+            return message.contains(Self.serverShuttingDownMessage)
+        default:
+            return false
+        }
+    }
+
+    private static let serverShuttingDownMessage = "Server is shutting down"
 }
 
 extension CassandraClient {

--- a/Tests/CassandraClientTests/ErrorTests.swift
+++ b/Tests/CassandraClientTests/ErrorTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+@testable import CassandraClient
+
+final class ErrorTests: XCTestCase {
+    func testWasRequestUnexecuted() {
+        XCTAssertTrue(
+            CassandraClient.Error.serverOverloaded(
+                "Queried host was overloaded: Server is shutting down"
+            ).wasRequestUnexecuted
+        )
+        XCTAssertTrue(CassandraClient.Error.serverBootstrapping("").wasRequestUnexecuted)
+        XCTAssertTrue(CassandraClient.Error.serverUnavailable("").wasRequestUnexecuted)
+
+        XCTAssertFalse(CassandraClient.Error.serverOverloaded("Too many requests").wasRequestUnexecuted)
+        XCTAssertFalse(CassandraClient.Error.noHostsAvailable("").wasRequestUnexecuted)
+        XCTAssertFalse(CassandraClient.Error.requestTimedOut("").wasRequestUnexecuted)
+        XCTAssertFalse(CassandraClient.Error.syntaxError("").wasRequestUnexecuted)
+        XCTAssertFalse(CassandraClient.Error.unauthorized("").wasRequestUnexecuted)
+    }
+}


### PR DESCRIPTION
#### Motivation:

When a coordinator is bootstrapping, or is shutting down (it returns an OVERLOADED error whose server message is "Server is shutting down"), it rejects the request before any execution begins. In those cases the statement had no effect and is always safe to retry on another coordinator, even when the statement is not idempotent.

CassandraClient.Error keeps its underlying code private and bridges to a generic NSError, so a caller building a retry policy has no supported way to tell these "never executed" responses apart from errors where the statement may already have been applied. The only workaround is to match on localizedDescription, which is brittle.

#### Modifications:

- Add a public computed property wasRequestUnexecuted on CassandraClient.Error.
  - It returns true for a bootstrapping node and for an overloaded response carrying the "Server is shutting down" message, and false otherwise. 

- Add a unit test covering both true cases and a range of unrelated errors.

#### Result:

Callers can drive retry decisions from a stable, documented API instead of string-matching error descriptions: treat wasRequestUnexecuted as always safe to retry regardless of statement idempotency. No behavior change for existing code.