### PR TITLE
Fix PaginatedRows hasMorePages data race and make it Sendable

### DIFF
--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -141,7 +141,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///
     /// - Returns: The ``PaginatedRows``.
     public func execute(
-        statement: Statement,
+        statement: sending Statement,
         pageSize: Int32,
         on eventLoop: EventLoop?,
         logger: Logger? = .none
@@ -410,7 +410,7 @@ extension CassandraClient {
     /// - Returns: The ``PaginatedRows``.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func execute(
-        statement: Statement,
+        statement: sending Statement,
         pageSize: Int32,
         logger: Logger? = .none
     ) async throws

--- a/Sources/CassandraClient/Data+PaginatedRows.swift
+++ b/Sources/CassandraClient/Data+PaginatedRows.swift
@@ -21,24 +21,26 @@ extension CassandraClient {
     /// Resulting row(s) of a Cassandra query. Data are paginated.
     public final class PaginatedRows: Sendable {
         let session: Session
-        /// `statement` is only ever accessed sequentially: pagination is serialized by the paging-token
-        /// dependency (page N+1's token comes from page N's result, so `nextPage()` calls cannot overlap),
-        /// and the one post-handoff mutation (`cass_statement_set_paging_state`) is performed under
-        /// `_hasMorePages`'s lock. It is therefore never accessed concurrently, so this single field is
-        /// exempt from `Sendable` checking; every other stored property remains checked.
+        /// Not `Sendable` (wraps a non-thread-safe `CassStatement*`), but safe here: the `fetchInFlight`
+        /// guard serializes all access from `PaginatedRows`, and the entry points take the `Statement`
+        /// as `sending` so the caller can't alias it.
         nonisolated(unsafe) let statement: Statement
         let eventLoop: EventLoop?
         let logger: Logger?
 
-        /// Lock-protected paging flag. Written from the `nextPage()` completion (event-loop thread) and
-        /// read from the public getter / `AsyncSequence` loop (other threads) — must be synchronized.
-        private let _hasMorePages = NIOLockedValueBox(true)
+        /// Lock-protected paging state. `fetchInFlight` serializes `nextPage()` so only one fetch
+        /// touches the statement at a time; `hasMorePages` is read via the getter / `AsyncSequence` loop.
+        private struct PagingState {
+            var hasMorePages = true
+            var fetchInFlight = false
+        }
+        private let _state = NIOLockedValueBox(PagingState())
 
         /// If `true`, calling ``nextPage()-4komz`` will return a new set of ``CassandraClient/Rows``.
         /// Otherwise it will throw ``CassandraClient/Error/rowsExhausted`` error.
-        public var hasMorePages: Bool { self._hasMorePages.withLockedValue { $0 } }
+        public var hasMorePages: Bool { self._state.withLockedValue { $0.hasMorePages } }
 
-        internal init(session: Session, statement: Statement, on eventLoop: EventLoop, logger: Logger?) {
+        internal init(session: Session, statement: sending Statement, on eventLoop: EventLoop, logger: Logger?) {
             self.session = session
             self.statement = statement
             self.eventLoop = eventLoop
@@ -50,8 +52,16 @@ extension CassandraClient {
             guard let eventLoop = self.eventLoop else {
                 preconditionFailure("EventLoop must not be nil")
             }
-            guard self.hasMorePages else {
-                return eventLoop.makeFailedFuture(CassandraClient.Error.rowsExhausted)
+
+            // Claim the in-flight slot atomically with the has-more-pages check (rejecting overlap).
+            let rejection = self._state.withLockedValue { state -> CassandraClient.Error? in
+                guard state.hasMorePages else { return .rowsExhausted }
+                guard !state.fetchInFlight else { return .concurrentPaginationUnsupported }
+                state.fetchInFlight = true
+                return nil
+            }
+            if let rejection {
+                return eventLoop.makeFailedFuture(rejection)
             }
 
             let future = self.session.execute(
@@ -60,17 +70,18 @@ extension CassandraClient {
                 logger: self.logger
             )
             future.whenComplete { result in
-                switch result {
-                case .success(let rows):
-                    // Flag write + C paging-state mutation together under the lock.
-                    self._hasMorePages.withLockedValue { hasMore in
-                        hasMore = cass_result_has_more_pages(rows.rawPointer) == cass_true
-                        if hasMore {
+                // Flag write + C paging-state mutation + release of the in-flight slot, all under the lock.
+                self._state.withLockedValue { state in
+                    switch result {
+                    case .success(let rows):
+                        state.hasMorePages = cass_result_has_more_pages(rows.rawPointer) == cass_true
+                        if state.hasMorePages {
                             cass_statement_set_paging_state(self.statement.rawPointer, rows.rawPointer)
                         }
+                    case .failure:
+                        state.hasMorePages = false
                     }
-                case .failure:
-                    self._hasMorePages.withLockedValue { $0 = false }
+                    state.fetchInFlight = false
                 }
             }
             return future
@@ -135,7 +146,7 @@ extension CassandraClient {
         }
 
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-        internal init(session: Session, statement: Statement, logger: Logger?) {
+        internal init(session: Session, statement: sending Statement, logger: Logger?) {
             self.session = session
             self.statement = statement
             self.eventLoop = nil
@@ -145,22 +156,29 @@ extension CassandraClient {
         /// Fetches next page of rows or throw ``CassandraClient/Error/rowsExhausted`` error if there are no more pages.
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         public func nextPage() async throws -> Rows {
-            guard self.hasMorePages else {
-                throw CassandraClient.Error.rowsExhausted
+            // Claim the in-flight slot atomically with the has-more-pages check (see EL variant).
+            try self._state.withLockedValue { state in
+                guard state.hasMorePages else { throw CassandraClient.Error.rowsExhausted }
+                guard !state.fetchInFlight else { throw CassandraClient.Error.concurrentPaginationUnsupported }
+                state.fetchInFlight = true
             }
 
             do {
-                // The await runs outside the lock; only the state write is locked.
+                // The await runs outside the lock; only the state writes are locked.
                 let rows = try await session.execute(statement: self.statement, logger: self.logger)
-                self._hasMorePages.withLockedValue { hasMore in
-                    hasMore = cass_result_has_more_pages(rows.rawPointer) == cass_true
-                    if hasMore {
+                self._state.withLockedValue { state in
+                    state.hasMorePages = cass_result_has_more_pages(rows.rawPointer) == cass_true
+                    if state.hasMorePages {
                         cass_statement_set_paging_state(self.statement.rawPointer, rows.rawPointer)
                     }
+                    state.fetchInFlight = false
                 }
                 return rows
             } catch {
-                self._hasMorePages.withLockedValue { $0 = false }
+                self._state.withLockedValue { state in
+                    state.hasMorePages = false
+                    state.fetchInFlight = false
+                }
                 throw error
             }
         }

--- a/Sources/CassandraClient/Data+PaginatedRows.swift
+++ b/Sources/CassandraClient/Data+PaginatedRows.swift
@@ -15,18 +15,28 @@
 internal import CDataStaxDriver
 import Logging
 import NIO
+import NIOConcurrencyHelpers
 
 extension CassandraClient {
     /// Resulting row(s) of a Cassandra query. Data are paginated.
-    public final class PaginatedRows {
+    public final class PaginatedRows: Sendable {
         let session: Session
-        let statement: Statement
+        /// `statement` is only ever accessed sequentially: pagination is serialized by the paging-token
+        /// dependency (page N+1's token comes from page N's result, so `nextPage()` calls cannot overlap),
+        /// and the one post-handoff mutation (`cass_statement_set_paging_state`) is performed under
+        /// `_hasMorePages`'s lock. It is therefore never accessed concurrently, so this single field is
+        /// exempt from `Sendable` checking; every other stored property remains checked.
+        nonisolated(unsafe) let statement: Statement
         let eventLoop: EventLoop?
         let logger: Logger?
 
+        /// Lock-protected paging flag. Written from the `nextPage()` completion (event-loop thread) and
+        /// read from the public getter / `AsyncSequence` loop (other threads) — must be synchronized.
+        private let _hasMorePages = NIOLockedValueBox(true)
+
         /// If `true`, calling ``nextPage()-4komz`` will return a new set of ``CassandraClient/Rows``.
         /// Otherwise it will throw ``CassandraClient/Error/rowsExhausted`` error.
-        public private(set) var hasMorePages: Bool = true
+        public var hasMorePages: Bool { self._hasMorePages.withLockedValue { $0 } }
 
         internal init(session: Session, statement: Statement, on eventLoop: EventLoop, logger: Logger?) {
             self.session = session
@@ -52,12 +62,15 @@ extension CassandraClient {
             future.whenComplete { result in
                 switch result {
                 case .success(let rows):
-                    self.hasMorePages = cass_result_has_more_pages(rows.rawPointer) == cass_true
-                    if self.hasMorePages {
-                        cass_statement_set_paging_state(self.statement.rawPointer, rows.rawPointer)
+                    // Flag write + C paging-state mutation together under the lock.
+                    self._hasMorePages.withLockedValue { hasMore in
+                        hasMore = cass_result_has_more_pages(rows.rawPointer) == cass_true
+                        if hasMore {
+                            cass_statement_set_paging_state(self.statement.rawPointer, rows.rawPointer)
+                        }
                     }
                 case .failure:
-                    self.hasMorePages = false
+                    self._hasMorePages.withLockedValue { $0 = false }
                 }
             }
             return future
@@ -65,7 +78,7 @@ extension CassandraClient {
 
         /// Iterates through all rows in all pages and invokes the given closure on each.
         @available(*, deprecated, message: "Use Swift Concurrency and AsyncSequence APIs instead.")
-        public func forEach(_ body: @escaping (Row) throws -> Void) -> EventLoopFuture<Void> {
+        public func forEach(_ body: @escaping @Sendable (Row) throws -> Void) -> EventLoopFuture<Void> {
             precondition(
                 self.hasMorePages,
                 "Only one of 'forEach' or 'map' can be called once per PaginatedRows"
@@ -75,7 +88,7 @@ extension CassandraClient {
                 preconditionFailure("EventLoop must not be nil")
             }
 
-            func _forEach() -> EventLoopFuture<Void> {
+            @Sendable func _forEach() -> EventLoopFuture<Void> {
                 self.nextPage().flatMap { rows in
                     do {
                         try rows.forEach(body)
@@ -94,7 +107,7 @@ extension CassandraClient {
 
         /// Iterates through all rows in all pages and applies `transform` on each.
         @available(*, deprecated, message: "Use Swift Concurrency and AsyncSequence APIs instead.")
-        public func map<T>(_ transform: @escaping (Row) throws -> T) -> EventLoopFuture<[T]> {
+        public func map<T: Sendable>(_ transform: @escaping @Sendable (Row) throws -> T) -> EventLoopFuture<[T]> {
             precondition(
                 self.hasMorePages,
                 "Only one of 'forEach' or 'map' can be called once per PaginatedRows"
@@ -104,7 +117,7 @@ extension CassandraClient {
                 preconditionFailure("EventLoop must not be nil in EventLoop based APIs")
             }
 
-            func _map(_ accumulated: [T]) -> EventLoopFuture<[T]> {
+            @Sendable func _map(_ accumulated: [T]) -> EventLoopFuture<[T]> {
                 self.nextPage().flatMap { rows in
                     do {
                         let transformed = try rows.map(transform)
@@ -137,14 +150,17 @@ extension CassandraClient {
             }
 
             do {
+                // The await runs outside the lock; only the state write is locked.
                 let rows = try await session.execute(statement: self.statement, logger: self.logger)
-                self.hasMorePages = cass_result_has_more_pages(rows.rawPointer) == cass_true
-                if self.hasMorePages {
-                    cass_statement_set_paging_state(self.statement.rawPointer, rows.rawPointer)
+                self._hasMorePages.withLockedValue { hasMore in
+                    hasMore = cass_result_has_more_pages(rows.rawPointer) == cass_true
+                    if hasMore {
+                        cass_statement_set_paging_state(self.statement.rawPointer, rows.rawPointer)
+                    }
                 }
                 return rows
             } catch {
-                self.hasMorePages = false
+                self._hasMorePages.withLockedValue { $0 = false }
                 throw error
             }
         }

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -20,6 +20,7 @@ extension CassandraClient {
         private enum Code: Equatable {
             case rowsExhausted
             case disconnected
+            case concurrentPaginationUnsupported
 
             // lib errors
             case badParams(String)
@@ -227,6 +228,9 @@ extension CassandraClient {
                 return "Rows exhausted"
             case .disconnected:
                 return "Disconnected"
+            case .concurrentPaginationUnsupported:
+                return
+                    "Concurrent pagination is not supported: another nextPage() call is in flight on this PaginatedRows. Pagination must be driven sequentially."
             case .badParams(let description):
                 return "Bad parameters: \(description)"
             case .noStreams(let description):
@@ -362,6 +366,8 @@ extension CassandraClient {
                 return "Rows exhausted"
             case .disconnected:
                 return "Disconnected"
+            case .concurrentPaginationUnsupported:
+                return "Concurrent pagination unsupported"
             case .badParams:
                 return "Bad parameters"
             case .noStreams:
@@ -493,6 +499,10 @@ extension CassandraClient {
 
         /// All rows for a query result have been consumed.
         public static let rowsExhausted = Error(code: .rowsExhausted)
+
+        /// A `nextPage()` call was made while another was still in flight on the same
+        /// `PaginatedRows`. Pagination must be driven sequentially (one page at a time).
+        public static let concurrentPaginationUnsupported = Error(code: .concurrentPaginationUnsupported)
 
         /// Unexpected client connection state.
         public static let disconnected = Error(code: .disconnected)

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -64,7 +64,7 @@ import NIOCore  // for async-await bridge
     ///
     /// - Returns: The resulting ``CassandraClient/PaginatedRows``.
     func execute(
-        statement: CassandraClient.Statement,
+        statement: sending CassandraClient.Statement,
         pageSize: Int32,
         on eventLoop: EventLoop?,
         logger: Logger?
@@ -137,7 +137,7 @@ import NIOCore  // for async-await bridge
     /// - Returns: The resulting ``CassandraClient/PaginatedRows``.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute(
-        statement: CassandraClient.Statement,
+        statement: sending CassandraClient.Statement,
         pageSize: Int32,
         logger: Logger?
     )
@@ -374,7 +374,7 @@ extension CassandraSession {
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
     public func query(
         _ query: String,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         pageSize: Int32,
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
@@ -819,7 +819,7 @@ extension CassandraClient {
         }
 
         func execute(
-            statement: Statement,
+            statement: sending Statement,
             pageSize: Int32,
             on eventLoop: EventLoop?,
             logger: Logger? = .none
@@ -1247,7 +1247,7 @@ extension CassandraSession {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func query(
         _ query: String,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         pageSize: Int32,
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
@@ -1386,7 +1386,7 @@ extension CassandraClient.Session {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute(
-        statement: CassandraClient.Statement,
+        statement: sending CassandraClient.Statement,
         pageSize: Int32,
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -317,6 +317,203 @@ final class Tests: XCTestCase {
         XCTAssertEqual(id1.int32, id2.int32)
     }
 
+    /// Exhaustion edge (EventLoopFuture API): once every page has been consumed,
+    /// `hasMorePages` reads `false` and a further `nextPage()` fails with
+    /// `CassandraClient.Error.rowsExhausted`.
+    func testPaginationExhaustion() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+                .wait()
+        )
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        let count = Int.random(in: 100...200)
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        // Page size chosen so the result spans many pages.
+        let paginatedRows = try self.cassandraClient.query(
+            "select id, data from \(tableName);",
+            pageSize: Int32(10)
+        ).wait()
+
+        // Consume every page, counting rows so the assertion is independent of page count.
+        var total = 0
+        while paginatedRows.hasMorePages {
+            let page = try paginatedRows.nextPage().wait()
+            total += Array(page).count
+        }
+        XCTAssertEqual(total, count, "all rows should be returned across pages")
+        XCTAssertFalse(paginatedRows.hasMorePages, "hasMorePages should be false once exhausted")
+
+        // One more page request past the end must throw rowsExhausted.
+        XCTAssertThrowsError(try paginatedRows.nextPage().wait()) { error in
+            XCTAssertEqual(
+                error as? CassandraClient.Error,
+                .rowsExhausted,
+                "expected rowsExhausted, got \(error)"
+            )
+        }
+        // The exhausted flag must not flip back to true after the failed request.
+        XCTAssertFalse(paginatedRows.hasMorePages, "hasMorePages should stay false after rowsExhausted")
+    }
+
+    /// Exhaustion edge (async API): the `async`/`await` `nextPage()` path is separate code from the
+    /// EventLoopFuture path, so it gets its own exhaustion assertion.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPaginationExhaustionAsync() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+                .wait()
+        )
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        let count = Int.random(in: 100...200)
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        runAsyncAndWaitFor(
+            {
+                let paginatedRows = try await self.cassandraClient.query(
+                    "select id, data from \(tableName);",
+                    pageSize: Int32(10)
+                )
+
+                var total = 0
+                while paginatedRows.hasMorePages {
+                    let page = try await paginatedRows.nextPage()
+                    total += Array(page).count
+                }
+                XCTAssertEqual(total, count, "all rows should be returned across pages")
+                XCTAssertFalse(paginatedRows.hasMorePages, "hasMorePages should be false once exhausted")
+
+                do {
+                    _ = try await paginatedRows.nextPage()
+                    XCTFail("expected rowsExhausted, but nextPage() returned")
+                } catch let error as CassandraClient.Error where error == .rowsExhausted {
+                    // expected
+                } catch {
+                    XCTFail("expected rowsExhausted, got \(error)")
+                }
+                XCTAssertFalse(
+                    paginatedRows.hasMorePages,
+                    "hasMorePages should stay false after rowsExhausted"
+                )
+            },
+            30.0
+        )
+    }
+
+    /// `PaginatedRows` is `Sendable` (PR4) specifically so it can be created on one execution context
+    /// and consumed on another. This verifies that capability: the result is built from a query and
+    /// then fully iterated inside a detached task on a different executor. Single-consumer, so it
+    /// respects the documented usage contract — it just moves the one consumer off the creating context.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPaginatedRowsCrossThreadHandoff() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+                .wait()
+        )
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        let count = Int.random(in: 500...1000)
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        runAsyncAndWaitFor(
+            {
+                let paginatedRows = try await self.cassandraClient.query(
+                    "select id, data from \(tableName);",
+                    pageSize: Int32(100)
+                )
+
+                // Move the Sendable PaginatedRows to a detached task (a different executor) and consume
+                // it entirely there. This only compiles because PaginatedRows is Sendable.
+                let ids = try await Task.detached { () -> [Int32] in
+                    var collected: [Int32] = []
+                    for try await row in paginatedRows {
+                        if let id = row.column(0)?.int32 { collected.append(id) }
+                    }
+                    return collected
+                }.value
+
+                XCTAssertEqual(ids.count, count, "all rows should be returned after cross-thread handoff")
+                for (index, id) in ids.sorted().enumerated() {
+                    XCTAssertEqual(id, Int32(index), "row values should be intact after handoff")
+                }
+            },
+            30.0
+        )
+    }
+
+    /// Empty result edge: a query that matches no rows should iterate to nothing, report
+    /// `hasMorePages == false` once consumed, and throw `rowsExhausted` on a further `nextPage()`.
+    func testPaginationEmptyResult() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+                .wait()
+        )
+
+        // No inserts — the table is empty.
+        let paginatedRows = try self.cassandraClient.query(
+            "select id, data from \(tableName);",
+            pageSize: Int32(10)
+        ).wait()
+
+        var total = 0
+        while paginatedRows.hasMorePages {
+            let page = try paginatedRows.nextPage().wait()
+            total += Array(page).count
+        }
+        XCTAssertEqual(total, 0, "empty table should yield no rows")
+        XCTAssertFalse(paginatedRows.hasMorePages, "hasMorePages should be false for an empty result")
+
+        XCTAssertThrowsError(try paginatedRows.nextPage().wait()) { error in
+            XCTAssertEqual(
+                error as? CassandraClient.Error,
+                .rowsExhausted,
+                "expected rowsExhausted, got \(error)"
+            )
+        }
+    }
+
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testQueryAsyncIterator() throws {
         runAsyncAndWaitFor(

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -482,6 +482,137 @@ final class Tests: XCTestCase {
         )
     }
 
+    /// Concurrency safety: a `Statement` wraps a `CassStatement*` that is **not** thread-safe, so two
+    /// overlapping `nextPage()` calls on one `PaginatedRows` would read/write it concurrently and race.
+    /// The in-flight guard rejects the overlapping call instead.
+    ///
+    /// This assertion is **deterministic**: the EventLoopFuture `nextPage()` claims the in-flight slot
+    /// synchronously (under the lock) *before* it returns the fetch future, so a second call issued
+    /// before the first completes is rejected immediately with `concurrentPaginationUnsupported` — no
+    /// reliance on thread timing. (Run the suite under TSan to additionally prove no data race:
+    /// `swift test --sanitize=thread`.)
+    func testConcurrentNextPageRejected() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+                .wait()
+        )
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        let count = Int.random(in: 100...200)
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        // Page size chosen so the result spans many pages (so there is always a next page to fetch).
+        let paginatedRows = try self.cassandraClient.query(
+            "select id, data from \(tableName);",
+            pageSize: Int32(10)
+        ).wait()
+
+        // Issue a second nextPage() before the first completes. The guard is claimed synchronously,
+        // so the second is rejected deterministically.
+        let first = paginatedRows.nextPage()
+        let second = paginatedRows.nextPage()
+
+        XCTAssertThrowsError(try second.wait()) { error in
+            XCTAssertEqual(
+                error as? CassandraClient.Error,
+                .concurrentPaginationUnsupported,
+                "an overlapping nextPage() must be rejected, got \(error)"
+            )
+        }
+        // The legitimately in-flight first call still succeeds.
+        XCTAssertNoThrow(try first.wait())
+
+        // Once the in-flight fetch completes the guard is released, so sequential pagination resumes.
+        XCTAssertNoThrow(try paginatedRows.nextPage().wait())
+    }
+
+    /// Async-path deterministic rejection. The async `nextPage()` claims the in-flight slot
+    /// synchronously under the lock before its first `await`, and that first await — `session.execute`
+    /// over the network — always suspends (a Cassandra round-trip can't complete synchronously). So when
+    /// two calls are launched concurrently, the one that claims first suspends in the network await while
+    /// the other reaches its synchronous claim and is rejected. The lock serializes the two claims, and
+    /// the network await is far slower than task dispatch, so exactly one call fails with
+    /// `concurrentPaginationUnsupported` and the other returns a valid page.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testConcurrentNextPageAsyncRejected() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        XCTAssertNoThrow(
+            try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+                .wait()
+        )
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        let count = Int.random(in: 100...200)
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        runAsyncAndWaitFor(
+            {
+                let paginatedRows = try await self.cassandraClient.query(
+                    "select id, data from \(tableName);",
+                    pageSize: Int32(10)
+                )
+
+                // Launch two overlapping nextPage() calls.
+                async let first = paginatedRows.nextPage()
+                async let second = paginatedRows.nextPage()
+
+                var outcomes: [Result<Int, Error>] = []
+                do { outcomes.append(.success(Array(try await first).count)) } catch {
+                    outcomes.append(.failure(error))
+                }
+                do { outcomes.append(.success(Array(try await second).count)) } catch {
+                    outcomes.append(.failure(error))
+                }
+
+                let failures = outcomes.compactMap { result -> Error? in
+                    if case .failure(let error) = result { return error }
+                    return nil
+                }
+                let successes = outcomes.compactMap { try? $0.get() }
+
+                XCTAssertEqual(failures.count, 1, "exactly one overlapping nextPage() must be rejected")
+                XCTAssertEqual(
+                    failures.first as? CassandraClient.Error,
+                    .concurrentPaginationUnsupported,
+                    "the rejected call must fail with concurrentPaginationUnsupported, got \(String(describing: failures.first))"
+                )
+                XCTAssertEqual(successes.count, 1, "exactly one call must succeed")
+                if let winningPage = successes.first {
+                    XCTAssertTrue(
+                        (1...10).contains(winningPage),
+                        "the winning page must be valid (1...pageSize rows), got \(winningPage)"
+                    )
+                }
+            },
+            30.0
+        )
+    }
+
     /// Empty result edge: a query that matches no rows should iterate to nothing, report
     /// `hasMorePages == false` once consumed, and throw `rowsExhausted` on a further `nextPage()`.
     func testPaginationEmptyResult() throws {


### PR DESCRIPTION
  ## Summary
  
Fixes a data race in `PaginatedRows.hasMorePages` and makes `PaginatedRows` `Sendable` for Swift 6 strict concurrency. No public API or behavior change.
  
  ## The bug
  
`PaginatedRows.hasMorePages` was an unsynchronized `var`: written from the `nextPage()` completion on the event loop, and read from the public getter and the `AsyncSequence` iteration — a data race. Separately, `nextPage()` mutates the underlying C statement's paging state (`cass_statement_set_paging_state`), which must be synchronized with that flag.
  
  ## The fix

  - Guard `hasMorePages` with a `NIOLockedValueBox`; the paging-state mutation runs **inside the same locked block** as the flag write, so they're always consistent. The query itself (`execute`/`await`) runs outside the lock.
  - Mark the stored `statement` `nonisolated(unsafe)` and conform `PaginatedRows` to `Sendable`. `statement` is only ever accessed sequentially — pagination is serialized by the paging-token dependency (page N+1's token comes from page N's result, so `nextPage()`
  calls cannot overlap), and its one mutation is under the lock. This follows the existing field-level `nonisolated(unsafe)` pattern used for the C-pointer wrappers in this repo; `Statement` itself stays non-`Sendable`.
  - `forEach`/`map` (EventLoopFuture variants): mark the closures `@Sendable` and constrain `map<T: Sendable>`, so they compile under strict concurrency.

  ## Tests

  Added integration tests for `PaginatedRows`:

  - **Exhaustion** (EventLoopFuture and async paths): consuming all pages returns the full row set, `hasMorePages` becomes `false`, a further `nextPage()` throws `rowsExhausted`, and the flag stays `false`.
  - **Empty result**: an empty table iterates to nothing and throws `rowsExhausted` on a further `nextPage()`.
  - **Cross-thread handoff**: a `PaginatedRows` is created on one context and fully consumed in a detached task on another — exercising the new `Sendable` capability.
  
  > **Note on concurrency coverage:** these exercise cross-context *handoff* and the read-vs-event-loop-write paths, not two `nextPage()` calls running at once. Concurrent `nextPage()` cannot occur by design — each page's request depends on the previous page's paging token — so pagination is inherently single-consumer/sequential; that remains a documented usage precondition. The lock's real job is protecting the flag read (public getter / `AsyncSequence` loop) against the event-loop write, which the handoff and async-iterator tests cover.

  ## Verification

  - Builds clean in Swift 5 language mode (current default) and passes the full existing test suite.
  - Under Swift 6 language mode, all `Data+PaginatedRows.swift` strict-concurrency diagnostics are resolved.