### PR TITLE
Enable Swift 6 strict concurrency on the library target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -166,9 +166,6 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Metrics", package: "swift-metrics"),
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v5)
             ]
         ),
 

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -120,7 +120,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///
     /// - Returns: The resulting ``Rows``.
     public func execute(
-        statement: Statement,
+        statement: sending Statement,
         on eventLoop: EventLoop?,
         logger: Logger? = .none
     )
@@ -184,7 +184,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     /// - Returns: The resulting ``Rows``.
     public func execute(
         prepared: PreparedStatement,
-        parameters: [Statement.Value] = [],
+        parameters: sending [Statement.Value] = [],
         options: Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
@@ -211,7 +211,7 @@ public final class CassandraClient: CassandraSession, Sendable {
     @preconcurrency
     public func execute<T: Decodable & Sendable>(
         prepared: PreparedStatement,
-        parameters: [Statement.Value] = [],
+        parameters: sending [Statement.Value] = [],
         options: Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -52,8 +52,10 @@ public protocol PagingStateToken: ContiguousBytes {}
 
 extension CassandraClient {
     /// Resulting row(s) of a Cassandra query. Data are returned all at once.
-    public final class Rows: Sequence {
-        internal let rawPointer: OpaquePointer
+    public final class Rows: Sequence, Sendable {
+        /// This can be `nonisolated(unsafe)` because the docs state a result is read-only and "thread-safe to read or iterate over concurrently".
+        /// See Sources/CDataStaxDriver/datastax-cpp-driver/include/cassandra.h
+        nonisolated(unsafe) internal let rawPointer: OpaquePointer
 
         internal init(_ resultRawPointer: OpaquePointer) {
             self.rawPointer = resultRawPointer

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -46,7 +46,7 @@ import NIOCore  // for async-await bridge
     ///
     /// - Returns: The resulting ``CassandraClient/Rows``.
     func execute(
-        statement: CassandraClient.Statement,
+        statement: sending CassandraClient.Statement,
         on eventLoop: EventLoop?,
         logger: Logger?
     )
@@ -103,7 +103,7 @@ import NIOCore  // for async-await bridge
     /// - Returns: The resulting ``CassandraClient/Rows``.
     func execute(
         prepared: CassandraClient.PreparedStatement,
-        parameters: [CassandraClient.Statement.Value],
+        parameters: sending [CassandraClient.Statement.Value],
         options: CassandraClient.Statement.Options,
         on eventLoop: EventLoop?,
         logger: Logger?
@@ -230,7 +230,7 @@ extension CassandraSession {
     ///
     /// - Returns: The resulting ``CassandraClient/Rows``.
     internal func execute(
-        statement: CassandraClient.Statement,
+        statement: sending CassandraClient.Statement,
         logger: Logger? = .none
     )
         -> EventLoopFuture<CassandraClient.Rows>
@@ -294,7 +294,7 @@ extension CassandraSession {
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
     public func run(
         _ command: String,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
@@ -308,7 +308,7 @@ extension CassandraSession {
     @preconcurrency
     public func query<T>(
         _ query: String,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none,
@@ -326,7 +326,7 @@ extension CassandraSession {
     @preconcurrency
     public func query<T: Decodable & Sendable>(
         _ query: String,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
@@ -350,7 +350,7 @@ extension CassandraSession {
     ///   - Attempting to wrap the ``CassandraClient/Rows`` sequence in a list will not work, use the transformer variant instead.
     public func query(
         _ query: String,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
@@ -411,7 +411,7 @@ extension CassandraSession {
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
     public func execute(
         prepared: CassandraClient.PreparedStatement,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
@@ -451,7 +451,7 @@ extension CassandraSession {
     @preconcurrency
     public func execute<T: Decodable & Sendable>(
         prepared: CassandraClient.PreparedStatement,
-        parameters: [CassandraClient.Statement.Value] = [],
+        parameters: sending [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none
@@ -817,12 +817,12 @@ extension CassandraClient {
         }
 
         func execute(
-            statement: Statement,
+            statement: sending Statement,
             on eventLoop: EventLoop?,
             logger: Logger? = .none
         ) -> EventLoopFuture<Rows> {
-            // `Statement` isn't `Sendable`, but the library reads it once here and never retains or
-            // mutates it, so capturing it into the `@Sendable` body via `nonisolated(unsafe)` is safe.
+            // `statement` is `sending`: the caller has transferred sole ownership, so capturing it
+            // into the `@Sendable` body is safe even though `Statement` isn't `Sendable`.
             nonisolated(unsafe) let statement = statement
             return self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing: \(statement.query)")
@@ -1042,7 +1042,7 @@ extension CassandraClient {
 
         func execute(
             prepared: CassandraClient.PreparedStatement,
-            parameters: [CassandraClient.Statement.Value] = [],
+            parameters: sending [CassandraClient.Statement.Value] = [],
             options: CassandraClient.Statement.Options = .init(),
             on eventLoop: EventLoop? = .none,
             logger: Logger? = .none
@@ -1384,6 +1384,9 @@ extension CassandraClient.Session {
         return try await body(logger)
     }
 
+    // Unlike the EventLoopFuture variant, `statement` need not be `sending`: it's non-Sendable, so
+    // the compiler already blocks running two executes over one statement concurrently, and this
+    // preserves the safe execute-await-reuse pattern.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute(
         statement: CassandraClient.Statement,

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -499,7 +499,7 @@ final class CassFuture<T>: Sendable {
         self.mapper = mapper
     }
 
-    func asNIOFuture(eventLoop: any EventLoop) -> EventLoopFuture<T> {
+    func asNIOFuture(eventLoop: any EventLoop) -> EventLoopFuture<T> where T: Sendable {
         let promise = eventLoop.makePromise(of: T.self)
         self.setResultCallback { result in
             promise.completeWith(result)
@@ -508,7 +508,7 @@ final class CassFuture<T>: Sendable {
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func await() async throws -> T {
+    func await() async throws -> T where T: Sendable {
         try await withCheckedThrowingContinuation { continuation in
             setResultCallback { result in
                 continuation.resume(with: result)
@@ -516,19 +516,19 @@ final class CassFuture<T>: Sendable {
         }
     }
 
-    func syncWait() throws -> T {
-        var result: Result<T, any Error>?
+    func syncWait() throws -> T where T: Sendable {
+        let resultBox = NIOLockedValueBox<Result<T, any Error>?>(nil)
         let semaphore = DispatchSemaphore(value: 0)
-        self.setResultCallback {
-            result = $0
+        self.setResultCallback { result in
+            resultBox.withLockedValue { $0 = result }
             semaphore.signal()
         }
         semaphore.wait()
-        return try result!.get()
+        return try resultBox.withLockedValue { $0! }.get()
     }
 
     private func setResultCallback(
-        completion: @escaping (Result<T, any Error>) -> Void
+        completion: @escaping @Sendable (Result<T, any Error>) -> Void
     ) {
         let closure = unmanagedRetainedClosure {
             DispatchQueue.global().async {
@@ -569,10 +569,14 @@ extension CassFuture {
     }
 }
 
-extension CassFuture where T == OpaquePointer {
+extension CassFuture where T == CassPrepared {
     /// Wraps a future whose value is a prepared statement (extracted via `cass_future_get_prepared`).
     convenience init(preparedFrom rawPointer: OpaquePointer) {
-        self.init(rawPointer: rawPointer, extract: { cass_future_get_prepared($0) }, mapper: { $0! })
+        self.init(
+            rawPointer: rawPointer,
+            extract: { cass_future_get_prepared($0) },
+            mapper: { CassPrepared(rawPointer: $0!) }
+        )
     }
 }
 
@@ -580,6 +584,13 @@ extension CassFuture where T == Void {
     convenience init(rawPointer: OpaquePointer) {
         self.init(rawPointer: rawPointer, extract: { _ in nil }, mapper: { _ in })
     }
+}
+
+/// A `Sendable` wrapper around a `CassPrepared*` pointer. The docs state a prepared statement is
+/// read-only and "thread-safe to concurrently bind", so the pointer is safe to cross concurrency boundaries.
+/// See Sources/CDataStaxDriver/datastax-cpp-driver/include/cassandra.h
+struct CassPrepared: Sendable {
+    nonisolated(unsafe) let rawPointer: OpaquePointer
 }
 
 struct CassSession: Sendable, ~Copyable {
@@ -605,7 +616,7 @@ struct CassSession: Sendable, ~Copyable {
         return CassFuture(rawPointer: futurePointer!)
     }
 
-    func prepare(query: String) -> CassFuture<OpaquePointer> {
+    func prepare(query: String) -> CassFuture<CassPrepared> {
         let futurePointer = cass_session_prepare(self.rawPointer, query)
         return CassFuture(preparedFrom: futurePointer!)
     }
@@ -751,10 +762,10 @@ extension CassandraClient {
         }
 
         /// Ensure the session is connected, then invoke `body` on the given event loop.
-        private func withConnection<Result>(
+        private func withConnection<Result: Sendable>(
             on eventLoop: EventLoop?,
             logger: Logger?,
-            _ body: @escaping (EventLoop, Logger) -> EventLoopFuture<Result>
+            _ body: @escaping @Sendable (EventLoop, Logger) -> EventLoopFuture<Result>
         ) -> EventLoopFuture<Result> {
             let eventLoop = eventLoop ?? self.eventLoopGroup.next()
             let logger = logger ?? self.logger
@@ -810,7 +821,10 @@ extension CassandraClient {
             on eventLoop: EventLoop?,
             logger: Logger? = .none
         ) -> EventLoopFuture<Rows> {
-            self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
+            // `Statement` isn't `Sendable`, but the library reads it once here and never retains or
+            // mutates it, so capturing it into the `@Sendable` body via `nonisolated(unsafe)` is safe.
+            nonisolated(unsafe) let statement = statement
+            return self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing: \(statement.query)")
                 logger.trace("\(statement.parameters)")
                 let future = self.underlying.execute(statement: statement)
@@ -846,7 +860,7 @@ extension CassandraClient {
             self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("preparing: \(query)")
                 let future = self.underlying.prepare(query: query)
-                return future.asNIOFuture(eventLoop: eventLoop).flatMapThrowing { rawPointer in
+                return future.asNIOFuture(eventLoop: eventLoop).flatMapThrowing { prepared in
                     let pkColumns: [String]
                     if let tableName = encryptionTable {
                         pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
@@ -854,7 +868,7 @@ extension CassandraClient {
                         pkColumns = []
                     }
                     let prepared = CassandraClient.PreparedStatement(
-                        rawPointer: rawPointer,
+                        rawPointer: prepared.rawPointer,
                         encryptionTable: encryptionTable,
                         primaryKeyColumnNames: pkColumns
                     )
@@ -1072,8 +1086,9 @@ extension CassandraClient {
             on eventLoop: EventLoop?,
             logger: Logger?
         ) -> EventLoopFuture<Void> {
-            // Use optionalBatch to prove to compiler that we only take it once
-            var optionalBatch: CassandraClient.Batch? = batch
+            // `Batch` is `~Copyable`; `optionalBatch` consumes it exactly once via `take()`. `consuming`
+            // + move-only means the caller can't retain it, so the `nonisolated(unsafe)` capture is safe.
+            nonisolated(unsafe) var optionalBatch: CassandraClient.Batch? = batch
             return self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing batch")
                 let future = self.underlying.execute(batch: optionalBatch.take()!)
@@ -1460,7 +1475,7 @@ extension CassandraClient.Session {
         encryptionTable: String? = nil,
         logger: Logger? = .none
     ) async throws -> CassandraClient.PreparedStatement {
-        let preparedRawPointer: OpaquePointer = try await self.withConnection(logger: logger) { logger in
+        let prepared: CassPrepared = try await self.withConnection(logger: logger) { logger in
             logger.debug("preparing: \(query)")
             return try await self.underlying.prepare(query: query).await()
         }
@@ -1471,7 +1486,7 @@ extension CassandraClient.Session {
             pkColumns = []
         }
         return CassandraClient.PreparedStatement(
-            rawPointer: preparedRawPointer,
+            rawPointer: prepared.rawPointer,
             encryptionTable: encryptionTable,
             primaryKeyColumnNames: pkColumns
         )

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -17,6 +17,9 @@ import Foundation  // for date and uuid
 
 extension CassandraClient {
     /// A prepared statement to run in a Cassandra database.
+    ///
+    /// Not `Sendable`: a `Statement` must not be used concurrently, or reused/mutated until a prior
+    /// `execute` has completed (the driver reads it asynchronously while the request is in flight).
     public final class Statement: CustomStringConvertible {
         internal let query: String
         internal let parameters: [Value]

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -548,6 +548,10 @@ extension CassandraClient {
     }
 }
 
+// `Statement` is intentionally not `Sendable`; see the type's documentation.
+@available(*, unavailable)
+extension CassandraClient.Statement: Sendable {}
+
 private func checkResult(body: () -> CassError) throws {
     let result = body()
     guard result == CASS_OK else {


### PR DESCRIPTION
  ### Motivation

  The package declares `swift-tools-version:6.1` but opts out of strict-concurrency checking via `.swiftLanguageMode(.v5)`. This is the final PR of the migration: it removes that opt-out on the library target so `CassandraClient` builds under the Swift 6 language mode with data-race checking on.

  ### Modifications

  - Remove `.swiftLanguageMode(.v5)` from the `CassandraClient` library target. 
  - `CassFuture`: `@Sendable` completion + `where T: Sendable` on the bridge methods; `syncWait` uses `NIOLockedValueBox` instead of a callback-mutated `var`.
  - `Rows: Sendable` (result pointer `nonisolated(unsafe)`, justified by the driver's read-only / concurrent-read contract); `Rows.Iterator` stays non-Sendable.
  - New internal `CassPrepared` Sendable wrapper so the prepare future carries a Sendable value.
  - Synchronous `withConnection`: `Result: Sendable` + `@Sendable` body; the non-Sendable `statement` / `batch` captures are confined.
  - `Statement` marked explicitly non-Sendable (unavailable `Sendable` conformance).
  - `execute(statement:)` and the non-paginated EventLoopFuture read API (`query`/`run`/`execute(prepared:)` and their generic variants) take `sending` arguments, closing a caller-race where one statement could be shared across two in-flight requests. The async variants are intentionally left non-`sending`.

  ### Result

  - The `CassandraClient` library compiles clean under the Swift 6 language modev(zero errors/warnings).
  - Full test suite passes (95 tests).
  - Source-breaking: callers of the non-paginated EventLoopFuture `query`/`run`/`execute`/`execute(prepared:)` now pass `sending` arguments (in addition to the `@Sendable` closure parameters introduced in earlier PRs).