### PR TITLE
Bump minimum deployment target to macOS 15 / iOS 18 / visionOS 2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,6 +96,11 @@ do {
 
 let package = Package(
     name: "swift-cassandra-client",
+    platforms: [
+        .macOS(.v15),
+        .iOS(.v18),
+        .visionOS(.v2),
+    ],
     products: [
         .library(name: "CassandraClient", targets: ["CassandraClient"])
     ],

--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -92,7 +92,6 @@ extension CassandraClient {
 
         /// Add a prepared statement with parameters to this batch.
         /// Handles encryption context resolution automatically when encryption is configured.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public mutating func add(
             prepared: PreparedStatement,
             parameters: [Statement.Value],

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -26,12 +26,10 @@ public final class CassandraClient: CassandraSession, Sendable {
         self.eventLoopGroupContainer.value
     }
 
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public var encryptor: CassandraClient.Encryptor? {
         self.configuration.encryptor
     }
 
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public var encryptionSchemas: [String: CassandraClient.EncryptionSchema] {
         self.configuration.encryptionSchemas
     }

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -50,25 +50,12 @@ extension CassandraClient {
         public var compact: Bool?
 
         /// Encryptor for transparent column encryption.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-        public var encryptor: Encryptor? {
-            get { self._encryptor as? Encryptor }
-            set { self._encryptor = newValue }
-        }
-
-        private var _encryptor: (any Sendable)?
+        public var encryptor: Encryptor?
 
         /// Registered encryption schemas.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-        public var encryptionSchemas: [String: EncryptionSchema] {
-            get { self._encryptionSchemas as! [String: EncryptionSchema] }
-            set { self._encryptionSchemas = newValue }
-        }
-
-        private var _encryptionSchemas: any Sendable = [String: EncryptionSchema]()
+        public var encryptionSchemas: [String: EncryptionSchema] = [:]
 
         /// Register an encryption schema for automatic context building during decoding.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public mutating func registerEncryptionSchema(_ schema: EncryptionSchema) {
             var schemas = self.encryptionSchemas
             schemas[schema.registryKey] = schema

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -623,7 +623,6 @@ extension CassandraClient.Column {
         return error == CASS_OK ? Array(UnsafeBufferPointer(start: value, count: size)) : nil
     }
 
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func decryptedData(
         encryptor: CassandraClient.Encryptor,
         context: CassandraClient.EncryptionContext
@@ -830,7 +829,6 @@ extension CassandraClient.Row {
 
 // MARK: - Encrypted
 
-@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Column {
     /// Decrypt column and return as `String`.
     public func decryptedString(
@@ -930,7 +928,6 @@ extension CassandraClient.Column {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Row {
     /// Decrypt column by name and return as `String`.
     public func decryptedString(

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -27,7 +27,6 @@ extension CassandraClient {
         }
 
         /// Create a decoder with encryption support for decoding `Encrypted<T>` fields.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         init(row: Row, encryptor: Encryptor, rowContext: EncryptionContext.Base) {
             self.row = row
             self.userInfo[.cassandraEncryptor] = encryptor

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -341,9 +341,6 @@ extension CassandraClient {
 
         /// Decrypt column data using encryptor and context from userInfo.
         private func decryptColumnData(key: Key) throws -> Data {
-            guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
-                throw DecodingError.notSupported("Encryption requires macOS 15.0+")
-            }
             guard let encryptor = userInfo[.cassandraEncryptor] as? CassandraClient.Encryptor else {
                 throw DecodingError.notSupported(
                     "Encryptor not provided in decoder userInfo. Use RowDecoder(row:encryptor:rowContext:)"

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -177,7 +177,6 @@ extension CassandraClient.Encrypted: Sendable where T: Sendable {}
 extension CassandraClient {
     /// Internal cache for derived column keys and storage for root key material.
     /// Not thread-safe on its own — the `Encryptor` that owns it must hold a lock.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     struct KeysHolder {
         private var rootKeys: [String: Data]
         let salt: Data
@@ -247,7 +246,6 @@ extension CassandraClient {
 
 extension CassandraClient {
     /// Handles column-level encryption and decryption using AES-GCM with HKDF-derived keys.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public final class Encryptor {
         static let envelopeVersion: UInt8 = 0x02
         /// AES-GCM with a per-row DEK derived deterministically via HKDF from the column KEK and primary key.
@@ -656,7 +654,6 @@ extension CassandraClient {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Encryptor: Sendable {}
 
 // MARK: - KeyColumnType

--- a/Sources/CassandraClient/Session+Encryption.swift
+++ b/Sources/CassandraClient/Session+Encryption.swift
@@ -18,7 +18,6 @@ import Foundation
 
 extension CassandraSession {
     /// Resolve "table" or "keyspace.table" into the registry lookup key and schema.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     internal func resolveSchema(
         tableName: String
     ) throws -> CassandraClient.EncryptionSchema {
@@ -54,7 +53,6 @@ extension CassandraSession {
     /// Plaintext values bound to encrypted columns go undetected.
     /// When executing prepared statements, ``validateEncryptionBindings(prepared:parameters:options:)``
     /// checks both directions using parameter metadata.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func validateEncryptionBindings(
         parameters: [CassandraClient.Statement.Value],
         options: CassandraClient.Statement.Options
@@ -77,7 +75,6 @@ extension CassandraSession {
     ///
     /// This validation requires prepared statement metadata to map parameter indices to column names,
     /// so it only runs for prepared statement execution.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func validateEncryptionBindings(
         prepared: CassandraClient.PreparedStatement,
         parameters: [CassandraClient.Statement.Value],
@@ -107,7 +104,6 @@ extension CassandraSession {
 
     /// Build an EncryptionContext.Base from a row using the registered schema.
     /// Reads PK and CK columns as-is from the row, then constructs the full primaryKey.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     internal func buildEncryptionContext(
         row: CassandraClient.Row,
         tableName: String,
@@ -131,7 +127,6 @@ extension CassandraSession {
     }
 
     /// Read a cleartext column value from a row and return it as a KeyComponent.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     private static func readKeyComponent(
         from row: CassandraClient.Row,
         name: String,

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1188,12 +1188,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
-        let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-        } else {
-            statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-        }
+        let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
         return try await self.execute(statement: statement, logger: logger)
     }
 
@@ -1206,12 +1201,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
-        let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-        } else {
-            statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-        }
+        let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
         return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
     }
 
@@ -1245,10 +1235,8 @@ extension CassandraSession {
         logger: Logger? = .none
     ) async throws -> [T] {
         var effectiveOptions = options
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            if effectiveOptions.encryptionTable == nil {
-                effectiveOptions.encryptionTable = prepared.encryptionTable
-            }
+        if effectiveOptions.encryptionTable == nil {
+            effectiveOptions.encryptionTable = prepared.encryptionTable
         }
         let rows = try await self.execute(
             prepared: prepared,

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -25,11 +25,9 @@ import NIOCore  // for async-await bridge
     var eventLoopGroup: EventLoopGroup { get }
 
     /// Encryptor for transparent column encryption.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     var encryptor: CassandraClient.Encryptor? { get }
 
     /// Registered encrypted column schemas for automatic context building.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     var encryptionSchemas: [String: CassandraClient.EncryptionSchema] { get }
 
     /// The default keyspace for this session, used to resolve unqualified table names.
@@ -244,8 +242,7 @@ extension CassandraSession {
         row: CassandraClient.Row,
         options: CassandraClient.Statement.Options
     ) throws -> CassandraClient.RowDecoder {
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
-            let builder = options.encryptionContextBuilder,
+        if let builder = options.encryptionContextBuilder,
             let encryptor = self.encryptor
         {
             let ctx = try builder(row)
@@ -255,8 +252,7 @@ extension CassandraSession {
                 rowContext: ctx
             )
         }
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
-            let tableName = options.encryptionTable,
+        if let tableName = options.encryptionTable,
             let encryptor = self.encryptor
         {
             let ctx = try self.buildEncryptionContext(
@@ -274,7 +270,6 @@ extension CassandraSession {
     }
 
     /// Creates a Statement with the session's encryptor injected from Configuration.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     private func makeStatement(
         query: String,
         parameters: [CassandraClient.Statement.Value],
@@ -285,7 +280,7 @@ extension CassandraSession {
             query: query,
             parameters: parameters,
             options: options,
-            _encryptor: self.encryptor
+            encryptor: self.encryptor
         )
     }
 
@@ -356,12 +351,7 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
-            let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-            } else {
-                statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-            }
+            let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -381,12 +371,7 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.PaginatedRows> {
         do {
-            let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-            } else {
-                statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-            }
+            let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             return self.execute(statement: statement, pageSize: pageSize, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -417,27 +402,17 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
-            let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                try self.validateEncryptionBindings(
-                    prepared: prepared,
-                    parameters: parameters,
-                    options: options
-                )
-                statement = try CassandraClient.Statement(
-                    preparedRawPointer: prepared.bind(),
-                    parameters: parameters,
-                    options: options,
-                    _encryptor: self.encryptor
-                )
-            } else {
-                statement = try CassandraClient.Statement(
-                    preparedRawPointer: prepared.bind(),
-                    parameters: parameters,
-                    options: options,
-                    _encryptor: nil
-                )
-            }
+            try self.validateEncryptionBindings(
+                prepared: prepared,
+                parameters: parameters,
+                options: options
+            )
+            let statement = try CassandraClient.Statement(
+                preparedRawPointer: prepared.bind(),
+                parameters: parameters,
+                options: options,
+                encryptor: self.encryptor
+            )
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -457,10 +432,8 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<[T]> {
         var effectiveOptions = options
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            if effectiveOptions.encryptionTable == nil {
-                effectiveOptions.encryptionTable = prepared.encryptionTable
-            }
+        if effectiveOptions.encryptionTable == nil {
+            effectiveOptions.encryptionTable = prepared.encryptionTable
         }
         let finalOptions = effectiveOptions
         return self.execute(
@@ -644,12 +617,10 @@ extension CassandraClient {
             self.eventLoopGroupContainer.value
         }
 
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: CassandraClient.Encryptor? {
             self.configuration.encryptor
         }
 
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptionSchemas: [String: CassandraClient.EncryptionSchema] {
             self.configuration.encryptionSchemas
         }
@@ -929,7 +900,6 @@ extension CassandraClient {
 
         /// Resolve encryption contexts for parameters that have `context: nil` using driver schema metadata.
         /// Discovers PK columns from Cassandra's metadata cache rather than requiring EncryptionSchema registration.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         private func resolveEncryptionContexts(
             prepared: CassandraClient.PreparedStatement,
             parameters: [CassandraClient.Statement.Value],
@@ -1007,7 +977,6 @@ extension CassandraClient {
         }
 
         /// Extract a KeyComponent from a Statement.Value by inspecting its type.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         private static func extractKeyComponent(
             from value: CassandraClient.Statement.Value,
             columnName: String
@@ -1034,32 +1003,22 @@ extension CassandraClient {
             logger: Logger? = .none
         ) -> EventLoopFuture<CassandraClient.Rows> {
             do {
-                let statement: CassandraClient.Statement
-                if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                    let resolvedParameters = try self.resolveEncryptionContexts(
-                        prepared: prepared,
-                        parameters: parameters,
-                        options: options
-                    )
-                    try self.validateEncryptionBindings(
-                        prepared: prepared,
-                        parameters: resolvedParameters,
-                        options: options
-                    )
-                    statement = try CassandraClient.Statement(
-                        preparedRawPointer: prepared.bind(),
-                        parameters: resolvedParameters,
-                        options: options,
-                        _encryptor: self.encryptor
-                    )
-                } else {
-                    statement = try CassandraClient.Statement(
-                        preparedRawPointer: prepared.bind(),
-                        parameters: parameters,
-                        options: options,
-                        _encryptor: nil
-                    )
-                }
+                let resolvedParameters = try self.resolveEncryptionContexts(
+                    prepared: prepared,
+                    parameters: parameters,
+                    options: options
+                )
+                try self.validateEncryptionBindings(
+                    prepared: prepared,
+                    parameters: resolvedParameters,
+                    options: options
+                )
+                let statement = try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    parameters: resolvedParameters,
+                    options: options,
+                    encryptor: self.encryptor
+                )
                 return self.execute(statement: statement, on: eventLoop, logger: logger)
             } catch {
                 let eventLoop = eventLoop ?? self.eventLoopGroup.next()
@@ -1101,9 +1060,7 @@ extension CassandraClient {
                             CassandraClient.PreparedStatement, [CassandraClient.Statement.Value],
                             CassandraClient.Statement.Options
                         ) throws -> CassandraClient.Statement
-                    )?
-                if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                    resolver = { [self] prepared, parameters, options in
+                    )? = { [self] prepared, parameters, options in
                         let resolvedParameters = try self.resolveEncryptionContexts(
                             prepared: prepared,
                             parameters: parameters,
@@ -1118,12 +1075,9 @@ extension CassandraClient {
                             preparedRawPointer: prepared.bind(),
                             parameters: resolvedParameters,
                             options: options,
-                            _encryptor: self.encryptor
+                            encryptor: self.encryptor
                         )
                     }
-                } else {
-                    resolver = nil
-                }
                 var batch = try Batch(configuration: configuration, resolver: resolver)
                 try build(&batch)
                 return self.execute(batch: batch, on: eventLoop, logger: logger)
@@ -1426,9 +1380,7 @@ extension CassandraClient.Session {
                     CassandraClient.PreparedStatement, [CassandraClient.Statement.Value],
                     CassandraClient.Statement.Options
                 ) throws -> CassandraClient.Statement
-            )?
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            resolver = { [self] prepared, parameters, options in
+            )? = { [self] prepared, parameters, options in
                 let resolvedParameters = try self.resolveEncryptionContexts(
                     prepared: prepared,
                     parameters: parameters,
@@ -1443,12 +1395,9 @@ extension CassandraClient.Session {
                     preparedRawPointer: prepared.bind(),
                     parameters: resolvedParameters,
                     options: options,
-                    _encryptor: self.encryptor
+                    encryptor: self.encryptor
                 )
             }
-        } else {
-            resolver = nil
-        }
         var batch = try CassandraClient.Batch(configuration: configuration, resolver: resolver)
         try await build(&batch)
         try await self.execute(batch: batch, logger: logger)
@@ -1484,32 +1433,22 @@ extension CassandraClient.Session {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
-        let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            let resolvedParameters = try self.resolveEncryptionContexts(
-                prepared: prepared,
-                parameters: parameters,
-                options: options
-            )
-            try self.validateEncryptionBindings(
-                prepared: prepared,
-                parameters: resolvedParameters,
-                options: options
-            )
-            statement = try CassandraClient.Statement(
-                preparedRawPointer: prepared.bind(),
-                parameters: resolvedParameters,
-                options: options,
-                _encryptor: self.encryptor
-            )
-        } else {
-            statement = try CassandraClient.Statement(
-                preparedRawPointer: prepared.bind(),
-                parameters: parameters,
-                options: options,
-                _encryptor: nil
-            )
-        }
+        let resolvedParameters = try self.resolveEncryptionContexts(
+            prepared: prepared,
+            parameters: parameters,
+            options: options
+        )
+        try self.validateEncryptionBindings(
+            prepared: prepared,
+            parameters: resolvedParameters,
+            options: options
+        )
+        let statement = try CassandraClient.Statement(
+            preparedRawPointer: prepared.bind(),
+            parameters: resolvedParameters,
+            options: options,
+            encryptor: self.encryptor
+        )
         return try await self.execute(statement: statement, logger: logger)
     }
 

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -22,22 +22,19 @@ extension CassandraClient {
         internal let parameters: [Value]
         internal let options: Options
         internal let rawPointer: OpaquePointer
-        private let _encryptor: AnyObject?
-
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-        private var encryptor: Encryptor? { self._encryptor as? Encryptor }
+        private let encryptor: Encryptor?
 
         /// Create a new `Statement`.
         public convenience init(query: String, parameters: [Value] = [], options: Options = .init()) throws {
-            try self.init(query: query, parameters: parameters, options: options, _encryptor: nil)
+            try self.init(query: query, parameters: parameters, options: options, encryptor: nil)
         }
 
         /// Internal init that accepts an encryptor injected by Session from Configuration.
-        internal init(query: String, parameters: [Value], options: Options, _encryptor: AnyObject?) throws {
+        internal init(query: String, parameters: [Value], options: Options, encryptor: Encryptor?) throws {
             self.query = query
             self.parameters = parameters
             self.options = options
-            self._encryptor = _encryptor
+            self.encryptor = encryptor
             self.rawPointer = cass_statement_new(query, parameters.count)
 
             try self.bindParameters()
@@ -48,12 +45,12 @@ extension CassandraClient {
             preparedRawPointer: OpaquePointer,
             parameters: [Value],
             options: Options,
-            _encryptor: AnyObject?
+            encryptor: Encryptor?
         ) throws {
             self.query = "(prepared)"
             self.parameters = parameters
             self.options = options
-            self._encryptor = _encryptor
+            self.encryptor = encryptor
             self.rawPointer = preparedRawPointer
 
             try self.bindParameters()
@@ -489,25 +486,11 @@ extension CassandraClient {
             /// Sets the statement's request timeout in milliseconds. Default is `CASS_UINT64_MAX`
             public var requestTimeout: UInt64?
 
-            /// Type-erased backing store for ``encryptionContextBuilder``.
-            private var _encryptionContextBuilder: (any Sendable)?
-
             /// Closure that extracts encryption context from each row during Codable decoding.
-            @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
             public var encryptionContextBuilder:
                 (
                     @Sendable (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
                 )?
-            {
-                get {
-                    self._encryptionContextBuilder
-                        as? @Sendable (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
-                }
-                set { self._encryptionContextBuilder = newValue }
-            }
-
-            /// Backing store for ``encryptionTable``.
-            private var _encryptionTable: String?
 
             /// Table name for column-registration-based automatic decryption.
             /// Use `"table"` (combined with the session keyspace) or `"keyspace.table"` for cross-keyspace queries.
@@ -517,15 +500,11 @@ extension CassandraClient {
             /// - Important: The query must SELECT all primary key columns registered in the schema.
             ///   The decoder reads these columns from each result row to build the ``PrimaryKey`` for key derivation.
             ///   Omitting a key column will cause decryption to fail at runtime.
-            @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-            public var encryptionTable: String? {
-                get { self._encryptionTable }
-                set { self._encryptionTable = newValue }
-            }
+            public var encryptionTable: String?
 
             /// Whether any encryption options are set (context builder or table name).
             internal var hasEncryptionOptions: Bool {
-                self._encryptionContextBuilder != nil || self._encryptionTable != nil
+                self.encryptionContextBuilder != nil || self.encryptionTable != nil
             }
 
             public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -233,9 +233,6 @@ extension CassandraClient {
             context: EncryptionContext,
             at index: Int
         ) throws -> CassError {
-            guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
-                throw CassandraClient.Error.encryptionError("Encryption requires macOS 15.0+")
-            }
             guard let encryptor = self.encryptor else {
                 throw CassandraClient.Error.encryptionConfigError(
                     "Encryptor required but not set in Configuration"


### PR DESCRIPTION
## Summary
- Bumps the package's platform floor to macOS 15 / iOS 18 / visionOS 2, the versions the column-encryption feature's CryptoKit APIs (HKDF, AES-GCM) actually require.
- Removes the `@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)` annotations and the type-erased `(any Sendable)?` / `AnyObject?` backing stores they forced on `Configuration.encryptor`/`.encryptionSchemas`, `Statement.Options.encryptionContextBuilder`/`.encryptionTable`, and `Statement`'s internal encryptor, along with the paired `if #available { ... } else { ... }` runtime branches in `Session.swift` that could never actually take the "unavailable" branch once the deployment target guarantees the API.
- The separate `@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)` gate used for async/await APIs is unrelated to CryptoKit and is left in place, since tvOS/watchOS floors aren't being touched here.

Resolves #89.

## Test plan
- [ ] CI (`swift build` / `swift test` across the Linux/macOS matrix) — no Swift toolchain was available in the environment this was authored in to verify locally.
- [ ] Confirm the encryption test suite still passes unconditionally now that the availability guards are gone.