### PR TITLE
Add withModelType: overloads for explicit decoded-type query calls

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,6 +96,11 @@ do {
 
 let package = Package(
     name: "swift-cassandra-client",
+    platforms: [
+        .macOS(.v15),
+        .iOS(.v18),
+        .visionOS(.v2),
+    ],
     products: [
         .library(name: "CassandraClient", targets: ["CassandraClient"])
     ],

--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -92,7 +92,6 @@ extension CassandraClient {
 
         /// Add a prepared statement with parameters to this batch.
         /// Handles encryption context resolution automatically when encryption is configured.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public mutating func add(
             prepared: PreparedStatement,
             parameters: [Statement.Value],

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -26,12 +26,10 @@ public final class CassandraClient: CassandraSession, Sendable {
         self.eventLoopGroupContainer.value
     }
 
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public var encryptor: CassandraClient.Encryptor? {
         self.configuration.encryptor
     }
 
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public var encryptionSchemas: [String: CassandraClient.EncryptionSchema] {
         self.configuration.encryptionSchemas
     }

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -50,25 +50,12 @@ extension CassandraClient {
         public var compact: Bool?
 
         /// Encryptor for transparent column encryption.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-        public var encryptor: Encryptor? {
-            get { self._encryptor as? Encryptor }
-            set { self._encryptor = newValue }
-        }
-
-        private var _encryptor: (any Sendable)?
+        public var encryptor: Encryptor?
 
         /// Registered encryption schemas.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-        public var encryptionSchemas: [String: EncryptionSchema] {
-            get { self._encryptionSchemas as! [String: EncryptionSchema] }
-            set { self._encryptionSchemas = newValue }
-        }
-
-        private var _encryptionSchemas: any Sendable = [String: EncryptionSchema]()
+        public var encryptionSchemas: [String: EncryptionSchema] = [:]
 
         /// Register an encryption schema for automatic context building during decoding.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public mutating func registerEncryptionSchema(_ schema: EncryptionSchema) {
             var schemas = self.encryptionSchemas
             schemas[schema.registryKey] = schema

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -623,7 +623,6 @@ extension CassandraClient.Column {
         return error == CASS_OK ? Array(UnsafeBufferPointer(start: value, count: size)) : nil
     }
 
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func decryptedData(
         encryptor: CassandraClient.Encryptor,
         context: CassandraClient.EncryptionContext
@@ -830,7 +829,6 @@ extension CassandraClient.Row {
 
 // MARK: - Encrypted
 
-@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Column {
     /// Decrypt column and return as `String`.
     public func decryptedString(
@@ -930,7 +928,6 @@ extension CassandraClient.Column {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Row {
     /// Decrypt column by name and return as `String`.
     public func decryptedString(

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -27,7 +27,6 @@ extension CassandraClient {
         }
 
         /// Create a decoder with encryption support for decoding `Encrypted<T>` fields.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         init(row: Row, encryptor: Encryptor, rowContext: EncryptionContext.Base) {
             self.row = row
             self.userInfo[.cassandraEncryptor] = encryptor

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -341,9 +341,6 @@ extension CassandraClient {
 
         /// Decrypt column data using encryptor and context from userInfo.
         private func decryptColumnData(key: Key) throws -> Data {
-            guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
-                throw DecodingError.notSupported("Encryption requires macOS 15.0+")
-            }
             guard let encryptor = userInfo[.cassandraEncryptor] as? CassandraClient.Encryptor else {
                 throw DecodingError.notSupported(
                     "Encryptor not provided in decoder userInfo. Use RowDecoder(row:encryptor:rowContext:)"

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -177,7 +177,6 @@ extension CassandraClient.Encrypted: Sendable where T: Sendable {}
 extension CassandraClient {
     /// Internal cache for derived column keys and storage for root key material.
     /// Not thread-safe on its own — the `Encryptor` that owns it must hold a lock.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     struct KeysHolder {
         private var rootKeys: [String: Data]
         let salt: Data
@@ -247,7 +246,6 @@ extension CassandraClient {
 
 extension CassandraClient {
     /// Handles column-level encryption and decryption using AES-GCM with HKDF-derived keys.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     public final class Encryptor {
         static let envelopeVersion: UInt8 = 0x02
         /// AES-GCM with a per-row DEK derived deterministically via HKDF from the column KEK and primary key.
@@ -656,7 +654,6 @@ extension CassandraClient {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Encryptor: Sendable {}
 
 // MARK: - KeyColumnType

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -94,8 +94,31 @@ extension CassandraClient {
 
         private var code: Code
 
+        /// The CQL query text that caused this error, if it was captured at the call site.
+        public var query: String?
+
+        /// The source file of the call site that triggered this error, if captured.
+        public var file: String?
+
+        /// The source line of the call site that triggered this error, if captured.
+        public var line: UInt?
+
         private init(code: Code) {
             self.code = code
+        }
+
+        public static func == (lhs: Error, rhs: Error) -> Bool {
+            lhs.code == rhs.code
+        }
+
+        /// Returns a copy of this error annotated with the CQL query text and call-site location.
+        /// Existing annotations are preserved rather than overwritten, so the innermost call site wins.
+        func annotated(query: String, file: String, line: UInt) -> Error {
+            var copy = self
+            copy.query = copy.query ?? query
+            copy.file = copy.file ?? file
+            copy.line = copy.line ?? line
+            return copy
         }
 
         init(_ error: CassError, message: String? = .none) {
@@ -223,6 +246,17 @@ extension CassandraClient {
         }
 
         public var description: String {
+            var result = self.message
+            if let query = self.query {
+                result += " [query: \(query)]"
+            }
+            if let file = self.file, let line = self.line {
+                result += " [\(file):\(line)]"
+            }
+            return result
+        }
+
+        private var message: String {
             switch self.code {
             case .rowsExhausted:
                 return "Rows exhausted"

--- a/Sources/CassandraClient/Session+Encryption.swift
+++ b/Sources/CassandraClient/Session+Encryption.swift
@@ -18,7 +18,6 @@ import Foundation
 
 extension CassandraSession {
     /// Resolve "table" or "keyspace.table" into the registry lookup key and schema.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     internal func resolveSchema(
         tableName: String
     ) throws -> CassandraClient.EncryptionSchema {
@@ -54,7 +53,6 @@ extension CassandraSession {
     /// Plaintext values bound to encrypted columns go undetected.
     /// When executing prepared statements, ``validateEncryptionBindings(prepared:parameters:options:)``
     /// checks both directions using parameter metadata.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func validateEncryptionBindings(
         parameters: [CassandraClient.Statement.Value],
         options: CassandraClient.Statement.Options
@@ -77,7 +75,6 @@ extension CassandraSession {
     ///
     /// This validation requires prepared statement metadata to map parameter indices to column names,
     /// so it only runs for prepared statement execution.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     func validateEncryptionBindings(
         prepared: CassandraClient.PreparedStatement,
         parameters: [CassandraClient.Statement.Value],
@@ -107,7 +104,6 @@ extension CassandraSession {
 
     /// Build an EncryptionContext.Base from a row using the registered schema.
     /// Reads PK and CK columns as-is from the row, then constructs the full primaryKey.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     internal func buildEncryptionContext(
         row: CassandraClient.Row,
         tableName: String,
@@ -131,7 +127,6 @@ extension CassandraSession {
     }
 
     /// Read a cleartext column value from a row and return it as a KeyComponent.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     private static func readKeyComponent(
         from row: CassandraClient.Row,
         name: String,

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -206,6 +206,21 @@ import NIOCore  // for async-await bridge
 
 private let encryptionLogger = Logger(label: "cassandra.encryption")
 
+/// Attaches the CQL query text and call-site location to a `CassandraClient.Error`, leaving other error
+/// types untouched. This is what lets failures like "Invalid amount of bind variables" be traced back
+/// to the query and call site that caused them.
+private func annotateCassandraError(
+    _ error: any Swift.Error,
+    query: String,
+    file: String,
+    line: UInt
+) -> any Swift.Error {
+    guard let cassandraError = error as? CassandraClient.Error else {
+        return error
+    }
+    return cassandraError.annotated(query: query, file: file, line: line)
+}
+
 extension CassandraSession {
     private func logDecryptedRows(count: Int, options: CassandraClient.Statement.Options, logger: Logger?) {
         if count > 0, options.hasEncryptionOptions {
@@ -292,9 +307,19 @@ extension CassandraSession {
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) -> EventLoopFuture<Void> {
-        self.query(command, parameters: parameters, options: options, on: eventLoop, logger: logger).map { _ in () }
+        self.query(
+            command,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger,
+            file: file,
+            line: line
+        ).map { _ in () }
     }
 
     /// Query small data-sets that fit into memory. Only use this when it is safe to buffer the entire data-set into memory.
@@ -307,10 +332,19 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
         logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line,
         transform: @escaping @Sendable (CassandraClient.Row) -> T?
     ) -> EventLoopFuture<[T]> {
-        self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger).map {
-            rows in
+        self.query(
+            query,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger,
+            file: file,
+            line: line
+        ).map { rows in
             rows.compactMap(transform)
         }
     }
@@ -324,10 +358,20 @@ extension CassandraSession {
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) -> EventLoopFuture<[T]> {
-        self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger)
-            .flatMapThrowing { rows in
+        self.query(
+            query,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger,
+            file: file,
+            line: line
+        )
+        .flatMapThrowing { rows in
                 let result = try rows.map { row in
                     try T(from: self.makeDecoder(row: row, options: options))
                 }
@@ -348,14 +392,19 @@ extension CassandraSession {
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) -> EventLoopFuture<CassandraClient.Rows> {
+        let fallbackLoop = eventLoop ?? self.eventLoopGroup.next()
         do {
             let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             return self.execute(statement: statement, on: eventLoop, logger: logger)
+                .flatMapError { error in
+                    fallbackLoop.makeFailedFuture(annotateCassandraError(error, query: query, file: file, line: line))
+                }
         } catch {
-            let eventLoop = eventLoop ?? eventLoopGroup.next()
-            return eventLoop.makeFailedFuture(error)
+            return fallbackLoop.makeFailedFuture(annotateCassandraError(error, query: query, file: file, line: line))
         }
     }
 
@@ -368,14 +417,19 @@ extension CassandraSession {
         pageSize: Int32,
         options: CassandraClient.Statement.Options = .init(),
         on eventLoop: EventLoop? = .none,
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) -> EventLoopFuture<CassandraClient.PaginatedRows> {
+        let fallbackLoop = eventLoop ?? self.eventLoopGroup.next()
         do {
             let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             return self.execute(statement: statement, pageSize: pageSize, on: eventLoop, logger: logger)
+                .flatMapError { error in
+                    fallbackLoop.makeFailedFuture(annotateCassandraError(error, query: query, file: file, line: line))
+                }
         } catch {
-            let eventLoop = eventLoop ?? eventLoopGroup.next()
-            return eventLoop.makeFailedFuture(error)
+            return fallbackLoop.makeFailedFuture(annotateCassandraError(error, query: query, file: file, line: line))
         }
     }
 
@@ -1132,9 +1186,18 @@ extension CassandraSession {
         _ command: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) async throws {
-        _ = try await self.query(command, parameters: parameters, options: options, logger: logger)
+        _ = try await self.query(
+            command,
+            parameters: parameters,
+            options: options,
+            logger: logger,
+            file: file,
+            line: line
+        )
     }
 
     /// Query small data-sets that fit into memory. Only use this when it's safe to buffer the entire data-set into memory.
@@ -1144,13 +1207,17 @@ extension CassandraSession {
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line,
         transform: @escaping (CassandraClient.Row) -> T?
     ) async throws -> [T] {
         let rows = try await self.query(
             query,
             parameters: parameters,
             options: options,
-            logger: logger
+            logger: logger,
+            file: file,
+            line: line
         )
         return rows.compactMap(transform)
     }
@@ -1161,13 +1228,17 @@ extension CassandraSession {
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) async throws -> [T] {
         let rows = try await self.query(
             query,
             parameters: parameters,
             options: options,
-            logger: logger
+            logger: logger,
+            file: file,
+            line: line
         )
         let result = try rows.map { row in
             try T(from: self.makeDecoder(row: row, options: options))
@@ -1186,10 +1257,16 @@ extension CassandraSession {
         _ query: String,
         parameters: [CassandraClient.Statement.Value] = [],
         options: CassandraClient.Statement.Options = .init(),
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) async throws -> CassandraClient.Rows {
-        let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-        return try await self.execute(statement: statement, logger: logger)
+        do {
+            let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
+            return try await self.execute(statement: statement, logger: logger)
+        } catch {
+            throw annotateCassandraError(error, query: query, file: file, line: line)
+        }
     }
 
     /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`.
@@ -1199,10 +1276,16 @@ extension CassandraSession {
         parameters: sending [CassandraClient.Statement.Value] = [],
         pageSize: Int32,
         options: CassandraClient.Statement.Options = .init(),
-        logger: Logger? = .none
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
     ) async throws -> CassandraClient.PaginatedRows {
-        let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-        return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
+        do {
+            let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
+            return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
+        } catch {
+            throw annotateCassandraError(error, query: query, file: file, line: line)
+        }
     }
 
     /// Prepare a CQL query for repeated execution.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1188,12 +1188,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
-        let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-        } else {
-            statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-        }
+        let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
         return try await self.execute(statement: statement, logger: logger)
     }
 
@@ -1206,12 +1201,7 @@ extension CassandraSession {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
-        let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-        } else {
-            statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-        }
+        let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
         return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
     }
 
@@ -1245,10 +1235,8 @@ extension CassandraSession {
         logger: Logger? = .none
     ) async throws -> [T] {
         var effectiveOptions = options
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            if effectiveOptions.encryptionTable == nil {
-                effectiveOptions.encryptionTable = prepared.encryptionTable
-            }
+        if effectiveOptions.encryptionTable == nil {
+            effectiveOptions.encryptionTable = prepared.encryptionTable
         }
         let rows = try await self.execute(
             prepared: prepared,

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -25,11 +25,9 @@ import NIOCore  // for async-await bridge
     var eventLoopGroup: EventLoopGroup { get }
 
     /// Encryptor for transparent column encryption.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     var encryptor: CassandraClient.Encryptor? { get }
 
     /// Registered encrypted column schemas for automatic context building.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     var encryptionSchemas: [String: CassandraClient.EncryptionSchema] { get }
 
     /// The default keyspace for this session, used to resolve unqualified table names.
@@ -244,8 +242,7 @@ extension CassandraSession {
         row: CassandraClient.Row,
         options: CassandraClient.Statement.Options
     ) throws -> CassandraClient.RowDecoder {
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
-            let builder = options.encryptionContextBuilder,
+        if let builder = options.encryptionContextBuilder,
             let encryptor = self.encryptor
         {
             let ctx = try builder(row)
@@ -255,8 +252,7 @@ extension CassandraSession {
                 rowContext: ctx
             )
         }
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *),
-            let tableName = options.encryptionTable,
+        if let tableName = options.encryptionTable,
             let encryptor = self.encryptor
         {
             let ctx = try self.buildEncryptionContext(
@@ -274,7 +270,6 @@ extension CassandraSession {
     }
 
     /// Creates a Statement with the session's encryptor injected from Configuration.
-    @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
     private func makeStatement(
         query: String,
         parameters: [CassandraClient.Statement.Value],
@@ -285,7 +280,7 @@ extension CassandraSession {
             query: query,
             parameters: parameters,
             options: options,
-            _encryptor: self.encryptor
+            encryptor: self.encryptor
         )
     }
 
@@ -356,12 +351,7 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
-            let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-            } else {
-                statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-            }
+            let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -381,12 +371,7 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.PaginatedRows> {
         do {
-            let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                statement = try self.makeStatement(query: query, parameters: parameters, options: options)
-            } else {
-                statement = try CassandraClient.Statement(query: query, parameters: parameters, options: options)
-            }
+            let statement = try self.makeStatement(query: query, parameters: parameters, options: options)
             return self.execute(statement: statement, pageSize: pageSize, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -417,27 +402,17 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<CassandraClient.Rows> {
         do {
-            let statement: CassandraClient.Statement
-            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                try self.validateEncryptionBindings(
-                    prepared: prepared,
-                    parameters: parameters,
-                    options: options
-                )
-                statement = try CassandraClient.Statement(
-                    preparedRawPointer: prepared.bind(),
-                    parameters: parameters,
-                    options: options,
-                    _encryptor: self.encryptor
-                )
-            } else {
-                statement = try CassandraClient.Statement(
-                    preparedRawPointer: prepared.bind(),
-                    parameters: parameters,
-                    options: options,
-                    _encryptor: nil
-                )
-            }
+            try self.validateEncryptionBindings(
+                prepared: prepared,
+                parameters: parameters,
+                options: options
+            )
+            let statement = try CassandraClient.Statement(
+                preparedRawPointer: prepared.bind(),
+                parameters: parameters,
+                options: options,
+                encryptor: self.encryptor
+            )
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -457,10 +432,8 @@ extension CassandraSession {
         logger: Logger? = .none
     ) -> EventLoopFuture<[T]> {
         var effectiveOptions = options
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            if effectiveOptions.encryptionTable == nil {
-                effectiveOptions.encryptionTable = prepared.encryptionTable
-            }
+        if effectiveOptions.encryptionTable == nil {
+            effectiveOptions.encryptionTable = prepared.encryptionTable
         }
         let finalOptions = effectiveOptions
         return self.execute(
@@ -644,12 +617,10 @@ extension CassandraClient {
             self.eventLoopGroupContainer.value
         }
 
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: CassandraClient.Encryptor? {
             self.configuration.encryptor
         }
 
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptionSchemas: [String: CassandraClient.EncryptionSchema] {
             self.configuration.encryptionSchemas
         }
@@ -929,7 +900,6 @@ extension CassandraClient {
 
         /// Resolve encryption contexts for parameters that have `context: nil` using driver schema metadata.
         /// Discovers PK columns from Cassandra's metadata cache rather than requiring EncryptionSchema registration.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         private func resolveEncryptionContexts(
             prepared: CassandraClient.PreparedStatement,
             parameters: [CassandraClient.Statement.Value],
@@ -1007,7 +977,6 @@ extension CassandraClient {
         }
 
         /// Extract a KeyComponent from a Statement.Value by inspecting its type.
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         private static func extractKeyComponent(
             from value: CassandraClient.Statement.Value,
             columnName: String
@@ -1034,32 +1003,22 @@ extension CassandraClient {
             logger: Logger? = .none
         ) -> EventLoopFuture<CassandraClient.Rows> {
             do {
-                let statement: CassandraClient.Statement
-                if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                    let resolvedParameters = try self.resolveEncryptionContexts(
-                        prepared: prepared,
-                        parameters: parameters,
-                        options: options
-                    )
-                    try self.validateEncryptionBindings(
-                        prepared: prepared,
-                        parameters: resolvedParameters,
-                        options: options
-                    )
-                    statement = try CassandraClient.Statement(
-                        preparedRawPointer: prepared.bind(),
-                        parameters: resolvedParameters,
-                        options: options,
-                        _encryptor: self.encryptor
-                    )
-                } else {
-                    statement = try CassandraClient.Statement(
-                        preparedRawPointer: prepared.bind(),
-                        parameters: parameters,
-                        options: options,
-                        _encryptor: nil
-                    )
-                }
+                let resolvedParameters = try self.resolveEncryptionContexts(
+                    prepared: prepared,
+                    parameters: parameters,
+                    options: options
+                )
+                try self.validateEncryptionBindings(
+                    prepared: prepared,
+                    parameters: resolvedParameters,
+                    options: options
+                )
+                let statement = try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    parameters: resolvedParameters,
+                    options: options,
+                    encryptor: self.encryptor
+                )
                 return self.execute(statement: statement, on: eventLoop, logger: logger)
             } catch {
                 let eventLoop = eventLoop ?? self.eventLoopGroup.next()
@@ -1101,9 +1060,7 @@ extension CassandraClient {
                             CassandraClient.PreparedStatement, [CassandraClient.Statement.Value],
                             CassandraClient.Statement.Options
                         ) throws -> CassandraClient.Statement
-                    )?
-                if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-                    resolver = { [self] prepared, parameters, options in
+                    )? = { [self] prepared, parameters, options in
                         let resolvedParameters = try self.resolveEncryptionContexts(
                             prepared: prepared,
                             parameters: parameters,
@@ -1118,12 +1075,9 @@ extension CassandraClient {
                             preparedRawPointer: prepared.bind(),
                             parameters: resolvedParameters,
                             options: options,
-                            _encryptor: self.encryptor
+                            encryptor: self.encryptor
                         )
                     }
-                } else {
-                    resolver = nil
-                }
                 var batch = try Batch(configuration: configuration, resolver: resolver)
                 try build(&batch)
                 return self.execute(batch: batch, on: eventLoop, logger: logger)
@@ -1426,9 +1380,7 @@ extension CassandraClient.Session {
                     CassandraClient.PreparedStatement, [CassandraClient.Statement.Value],
                     CassandraClient.Statement.Options
                 ) throws -> CassandraClient.Statement
-            )?
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            resolver = { [self] prepared, parameters, options in
+            )? = { [self] prepared, parameters, options in
                 let resolvedParameters = try self.resolveEncryptionContexts(
                     prepared: prepared,
                     parameters: parameters,
@@ -1443,12 +1395,9 @@ extension CassandraClient.Session {
                     preparedRawPointer: prepared.bind(),
                     parameters: resolvedParameters,
                     options: options,
-                    _encryptor: self.encryptor
+                    encryptor: self.encryptor
                 )
             }
-        } else {
-            resolver = nil
-        }
         var batch = try CassandraClient.Batch(configuration: configuration, resolver: resolver)
         try await build(&batch)
         try await self.execute(batch: batch, logger: logger)
@@ -1484,32 +1433,22 @@ extension CassandraClient.Session {
         options: CassandraClient.Statement.Options = .init(),
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
-        let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            let resolvedParameters = try self.resolveEncryptionContexts(
-                prepared: prepared,
-                parameters: parameters,
-                options: options
-            )
-            try self.validateEncryptionBindings(
-                prepared: prepared,
-                parameters: resolvedParameters,
-                options: options
-            )
-            statement = try CassandraClient.Statement(
-                preparedRawPointer: prepared.bind(),
-                parameters: resolvedParameters,
-                options: options,
-                _encryptor: self.encryptor
-            )
-        } else {
-            statement = try CassandraClient.Statement(
-                preparedRawPointer: prepared.bind(),
-                parameters: parameters,
-                options: options,
-                _encryptor: nil
-            )
-        }
+        let resolvedParameters = try self.resolveEncryptionContexts(
+            prepared: prepared,
+            parameters: parameters,
+            options: options
+        )
+        try self.validateEncryptionBindings(
+            prepared: prepared,
+            parameters: resolvedParameters,
+            options: options
+        )
+        let statement = try CassandraClient.Statement(
+            preparedRawPointer: prepared.bind(),
+            parameters: resolvedParameters,
+            options: options,
+            encryptor: self.encryptor
+        )
         return try await self.execute(statement: statement, logger: logger)
     }
 

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -372,12 +372,41 @@ extension CassandraSession {
             line: line
         )
         .flatMapThrowing { rows in
-                let result = try rows.map { row in
-                    try T(from: self.makeDecoder(row: row, options: options))
-                }
-                self.logDecryptedRows(count: result.count, options: options, logger: logger)
-                return result
+            let result = try rows.map { row in
+                try T(from: self.makeDecoder(row: row, options: options))
             }
+            self.logDecryptedRows(count: result.count, options: options, logger: logger)
+            return result
+        }
+    }
+
+    /// Query small data-sets that fit into memory, decoding each row into `model`.
+    ///
+    /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `session.query("select ...", withModelType: Model.self)`.
+    ///
+    /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    @preconcurrency
+    public func query<T: Decodable & Sendable>(
+        _ query: String,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none,
+        withModelType model: T.Type,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> EventLoopFuture<[T]> {
+        self.query(
+            query,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger,
+            file: file,
+            line: line
+        )
     }
 
     /// Query large data-sets where using an interator helps control memory usage.
@@ -1247,6 +1276,24 @@ extension CassandraSession {
         return result
     }
 
+    /// Query small data-sets that fit into memory, decoding each row into `model`.
+    ///
+    /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `try await session.query("select ...", withModelType: Model.self)`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func query<T: Decodable>(
+        _ query: String,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        withModelType model: T.Type,
+        file: String = #fileID,
+        line: UInt = #line
+    ) async throws -> [T] {
+        try await self.query(query, parameters: parameters, options: options, logger: logger, file: file, line: line)
+    }
+
     /// Query large data-sets where using an interator helps control memory usage.
     ///
     /// - Important:
@@ -1316,6 +1363,34 @@ extension CassandraSession {
         return paginatedRows.map { row in
             try T(from: self.makeDecoder(row: row, options: options))
         }
+    }
+
+    /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`,
+    /// decoding each row into `model` as pages are fetched.
+    ///
+    /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `try await session.query("select ...", pageSize: 100, withModelType: Model.self)`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func query<T: Decodable>(
+        _ query: String,
+        parameters: sending [CassandraClient.Statement.Value] = [],
+        pageSize: Int32,
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        withModelType model: T.Type,
+        file: String = #fileID,
+        line: UInt = #line
+    ) async throws -> AsyncThrowingMapSequence<CassandraClient.PaginatedRows, T> {
+        try await self.query(
+            query,
+            parameters: parameters,
+            pageSize: pageSize,
+            options: options,
+            logger: logger,
+            file: file,
+            line: line
+        )
     }
 
     /// Prepare a CQL query for repeated execution.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1288,6 +1288,36 @@ extension CassandraSession {
         }
     }
 
+    /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`,
+    /// decoding each row into `T` as pages are fetched rather than buffering the whole result set in memory.
+    ///
+    /// - Important:
+    ///   - Advancing the returned sequence invalidates values retrieved by the previous iteration,
+    ///     same as ``query(_:parameters:pageSize:options:logger:)``.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func query<T: Decodable>(
+        _ query: String,
+        parameters: sending [CassandraClient.Statement.Value] = [],
+        pageSize: Int32,
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
+    ) async throws -> AsyncThrowingMapSequence<CassandraClient.PaginatedRows, T> {
+        let paginatedRows = try await self.query(
+            query,
+            parameters: parameters,
+            pageSize: pageSize,
+            options: options,
+            logger: logger,
+            file: file,
+            line: line
+        )
+        return paginatedRows.map { row in
+            try T(from: self.makeDecoder(row: row, options: options))
+        }
+    }
+
     /// Prepare a CQL query for repeated execution.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func prepare(

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -22,22 +22,19 @@ extension CassandraClient {
         internal let parameters: [Value]
         internal let options: Options
         internal let rawPointer: OpaquePointer
-        private let _encryptor: AnyObject?
-
-        @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-        private var encryptor: Encryptor? { self._encryptor as? Encryptor }
+        private let encryptor: Encryptor?
 
         /// Create a new `Statement`.
         public convenience init(query: String, parameters: [Value] = [], options: Options = .init()) throws {
-            try self.init(query: query, parameters: parameters, options: options, _encryptor: nil)
+            try self.init(query: query, parameters: parameters, options: options, encryptor: nil)
         }
 
         /// Internal init that accepts an encryptor injected by Session from Configuration.
-        internal init(query: String, parameters: [Value], options: Options, _encryptor: AnyObject?) throws {
+        internal init(query: String, parameters: [Value], options: Options, encryptor: Encryptor?) throws {
             self.query = query
             self.parameters = parameters
             self.options = options
-            self._encryptor = _encryptor
+            self.encryptor = encryptor
             self.rawPointer = cass_statement_new(query, parameters.count)
 
             try self.bindParameters()
@@ -48,12 +45,12 @@ extension CassandraClient {
             preparedRawPointer: OpaquePointer,
             parameters: [Value],
             options: Options,
-            _encryptor: AnyObject?
+            encryptor: Encryptor?
         ) throws {
             self.query = "(prepared)"
             self.parameters = parameters
             self.options = options
-            self._encryptor = _encryptor
+            self.encryptor = encryptor
             self.rawPointer = preparedRawPointer
 
             try self.bindParameters()
@@ -489,25 +486,11 @@ extension CassandraClient {
             /// Sets the statement's request timeout in milliseconds. Default is `CASS_UINT64_MAX`
             public var requestTimeout: UInt64?
 
-            /// Type-erased backing store for ``encryptionContextBuilder``.
-            private var _encryptionContextBuilder: (any Sendable)?
-
             /// Closure that extracts encryption context from each row during Codable decoding.
-            @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
             public var encryptionContextBuilder:
                 (
                     @Sendable (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
                 )?
-            {
-                get {
-                    self._encryptionContextBuilder
-                        as? @Sendable (CassandraClient.Row) throws -> CassandraClient.EncryptionContext.Base
-                }
-                set { self._encryptionContextBuilder = newValue }
-            }
-
-            /// Backing store for ``encryptionTable``.
-            private var _encryptionTable: String?
 
             /// Table name for column-registration-based automatic decryption.
             /// Use `"table"` (combined with the session keyspace) or `"keyspace.table"` for cross-keyspace queries.
@@ -517,15 +500,11 @@ extension CassandraClient {
             /// - Important: The query must SELECT all primary key columns registered in the schema.
             ///   The decoder reads these columns from each result row to build the ``PrimaryKey`` for key derivation.
             ///   Omitting a key column will cause decryption to fail at runtime.
-            @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
-            public var encryptionTable: String? {
-                get { self._encryptionTable }
-                set { self._encryptionTable = newValue }
-            }
+            public var encryptionTable: String?
 
             /// Whether any encryption options are set (context builder or table name).
             internal var hasEncryptionOptions: Bool {
-                self._encryptionContextBuilder != nil || self._encryptionTable != nil
+                self.encryptionContextBuilder != nil || self.encryptionTable != nil
             }
 
             public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -233,9 +233,6 @@ extension CassandraClient {
             context: EncryptionContext,
             at index: Int
         ) throws -> CassError {
-            guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
-                throw CassandraClient.Error.encryptionError("Encryption requires macOS 15.0+")
-            }
             guard let encryptor = self.encryptor else {
                 throw CassandraClient.Error.encryptionConfigError(
                     "Encryptor required but not set in Configuration"


### PR DESCRIPTION
## Summary
> **Depends on #110, #111, and #112** (branched on top of #112). Files-changed will show all four PRs' diffs until those merge; the "Commits" tab isolates the one new commit here (`Add withModelType: overloads for explicit decoded-type query calls`).

- The existing `query<T: Decodable & Sendable>(...)` overloads infer `T` purely from the call site's return-type context (a variable's type annotation, or an `as [Model]` cast), which works but isn't very discoverable -- nothing at the call site itself says what type is being decoded into. #20 suggested following patterns like `JSONDecoder.decode(_:from:)` and accepting the model type as an explicit parameter instead.
- Adds sibling overloads of the non-paginated (sync and async) and the paginated-decoding `query(...)` methods that take a `withModelType model: T.Type` parameter, e.g.:
  ```swift
  session.query("select ...", withModelType: Model.self)
  ```
- These are purely additive: they're distinguished from the existing implicit-inference overloads by the presence of the `withModelType:` argument label, so nothing about the current inferred-type call pattern changes.

Resolves #20.

## Test plan
- [ ] CI -- no Swift toolchain was available in the environment this was authored in to verify locally.
- [ ] Confirm the existing implicit-inference `query<T: Decodable>(...)` call sites still resolve to the original overloads unchanged.
- [ ] Add/confirm a test calling the new `withModelType:` overloads directly.