### PR TITLE
Add opt-in request logging (failures + slow queries)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.41.1")),
         .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.36.0"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.12.0")),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "2.0.0")),
     ],

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -40,8 +40,12 @@ public final class CassandraClient: CassandraSession, Sendable {
         self.configuration.keyspace
     }
 
+    public var requestLoggingEnabled: Bool {
+        self.configuration.requestLoggingEnabled
+    }
+
     private let configuration: Configuration
-    private let logger: Logger
+    public let logger: Logger
     private let defaultSession: Session
     private let isShutdown = ManagedAtomic<Bool>(false)
 

--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -40,10 +40,6 @@ public final class CassandraClient: CassandraSession, Sendable {
         self.configuration.keyspace
     }
 
-    public var requestLoggingEnabled: Bool {
-        self.configuration.requestLoggingEnabled
-    }
-
     private let configuration: Configuration
     public let logger: Logger
     private let defaultSession: Session

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -37,11 +37,8 @@ extension CassandraClient {
         public var requestTimeoutMillis: UInt32?
         public var resolveTimeoutMillis: UInt32?
 
-        /// Master switch for request logging (failures, slow queries, connect/preflight failures). Off by default.
-        public var requestLoggingEnabled: Bool = false
-
-        /// Logs a successful query at `.info` when its latency exceeds this threshold. Only consulted when
-        /// ``requestLoggingEnabled`` is `true`. `nil` disables the check; `0` logs every success.
+        /// Logs a successful query at `.debug` when its latency reaches this threshold (ms). `nil` disables
+        /// the check; `0` logs every success.
         public var slowQueryThresholdMillis: UInt32? = nil
 
         /// Includes bound parameter values in request logs when `true`. Off by default — values are potential PII.

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -36,6 +36,22 @@ extension CassandraClient {
         public var connectTimeoutMillis: UInt32?
         public var requestTimeoutMillis: UInt32?
         public var resolveTimeoutMillis: UInt32?
+
+        /// Master switch for request logging (failures, slow queries, connect/preflight failures). Off by default.
+        public var requestLoggingEnabled: Bool = false
+
+        /// Logs a successful query at `.info` when its latency exceeds this threshold. Only consulted when
+        /// ``requestLoggingEnabled`` is `true`. `nil` disables the check; `0` logs every success.
+        public var slowQueryThresholdMillis: UInt32? = nil
+
+        /// Includes bound parameter values in request logs when `true`. Off by default — values are potential PII.
+        public var logBoundValues: Bool = false
+
+        /// Maximum length of query text in a log record; longer text is truncated.
+        internal static let maxLoggedQueryLength = 500
+        /// Maximum length of each bound value in a log record when ``logBoundValues`` is set.
+        internal static let maxLoggedValueLength = 50
+
         public var coreConnectionsPerHost: UInt32?
         public var tcpNodelay: Bool?
         public var tcpKeepalive: Bool?

--- a/Sources/CassandraClient/EncryptionConstants.swift
+++ b/Sources/CassandraClient/EncryptionConstants.swift
@@ -15,15 +15,6 @@
 // MARK: - Centralised encryption string constants
 
 extension CassandraClient {
-    internal enum EncryptionLogKey {
-        static let keyName = "encryption.keyName"
-        static let column = "encryption.column"
-        static let keyRotationFrom = "encryption.keyRotation.from"
-        static let keyRotationTo = "encryption.keyRotation.to"
-        static let keysLoaded = "encryption.keysLoaded"
-        static let rowsDecrypted = "encryption.rowsDecrypted"
-    }
-
     internal enum EncryptionMetric {
         static let encryptTotal = "cassandra.encryption.encrypt.total"
         static let encryptDuration = "cassandra.encryption.encrypt.duration"

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -497,6 +497,38 @@ extension CassandraClient {
             }
         }
 
+        /// Coarse failure category, used to choose a log level (and, later, a metric tag).
+        /// Total over every case; `server` is the explicit default so no failure is left uncategorized.
+        internal var category: CassandraClient.ErrorCategory {
+            switch self.code {
+            case .requestTimedOut, .readTimeout, .writeTimeout, .serverOverloaded, .serverBootstrapping:
+                return .transient
+            case .noHostsAvailable, .serverUnavailable, .unableToConnect, .hostResolution:
+                return .unavailable
+            case .syntaxError, .invalidQuery, .unauthorized, .badCredentials,
+                .badParams, .invalidValueType, .invalidItemCount, .parameterUnset,
+                .indexOutOfBounds, .nameDoesNotExist, .noPagingState, .nullValue,
+                .encryptionConfigError, .keyNotFound:
+                return .callerFault
+            case .invalidFutureType, .invalidErrorResultType, .callbackAlreadySet, .internalError:
+                return .wrapperInternal
+            // Explicit `server` bucket (no `default:`) so a newly-added `Error.Code` fails to compile until it
+            // is deliberately categorised — this function is the single source of truth reused by metrics.
+            case .serverError, .protocolError, .readFailure, .writeFailure, .functionFailure, .truncateError,
+                .alreadyExists, .serverConfigError, .requestQueueFull, .unprepared,
+                .sslInvalidCert, .sslInvalidPrivateKey, .sslNoPeerCert, .sslInvalidPeerCert,
+                .sslIdentityMismatch, .sslProtocolError, .sslClosed,
+                .encryptionError, .decryptionError,
+                .noStreams, .unableToInit, .messageEncode, .unexpectedResponse, .noAvailableIOThread,
+                .writeError, .unableToSetKeyspace, .invalidStatementType, .unableToDetermineProtocol,
+                .notImplemented, .unableToClose, .invalidCustomType, .invalidData, .notEnoughData,
+                .invalidState, .noCustomPayload,
+                .rowsExhausted, .disconnected, .concurrentPaginationUnsupported,
+                .other:
+                return .server
+            }
+        }
+
         /// All rows for a query result have been consumed.
         public static let rowsExhausted = Error(code: .rowsExhausted)
 
@@ -772,5 +804,22 @@ extension CassandraClient {
         public var description: String {
             "Configuration error: \(self.message)"
         }
+    }
+}
+
+extension CassandraClient {
+    /// Coarse failure category for a ``CassandraClient/Error``. Consumed by the log level and (later) a
+    /// metric tag, so the two can never disagree about a failure's kind.
+    internal enum ErrorCategory: String {
+        /// Routine / retryable (timeouts, overloaded, bootstrapping). Logged at `.debug`.
+        case transient
+        /// Exhausted availability — can't reach the cluster. Logged at `.warning`.
+        case unavailable
+        /// Programming / bad-input error (syntax, bad params, encryption config). Logged at `.warning`.
+        case callerFault
+        /// Server / unexpected (the default bucket). Logged at `.warning`.
+        case server
+        /// Wrapper invariant ("shouldn't happen"). Logged at `.error`. Raw value is `"internal"`.
+        case wrapperInternal = "internal"
     }
 }

--- a/Sources/CassandraClient/LogConstants.swift
+++ b/Sources/CassandraClient/LogConstants.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Centralised log-metadata-key constants
+
+extension CassandraClient {
+    /// Structured-log metadata key names for request logging. Follows the repo's `<domain>.<thing>`
+    /// convention (matching ``EncryptionLogKey``).
+    internal enum LogKey {
+        static let query = "request.query"
+        static let consistency = "request.consistency"
+        static let errorCategory = "request.errorCategory"
+        static let latencyMs = "request.latencyMs"
+        static let boundValues = "request.boundValues"
+    }
+
+    /// Structured-log metadata key names for encryption. Values are unchanged from their original
+    /// definition (shipped keys — consumers may filter on them), just relocated here (by-kind).
+    internal enum EncryptionLogKey {
+        static let keyName = "encryption.keyName"
+        static let column = "encryption.column"
+        static let keyRotationFrom = "encryption.keyRotation.from"
+        static let keyRotationTo = "encryption.keyRotation.to"
+        static let keysLoaded = "encryption.keysLoaded"
+        static let rowsDecrypted = "encryption.rowsDecrypted"
+    }
+}

--- a/Sources/CassandraClient/PreparedStatement.swift
+++ b/Sources/CassandraClient/PreparedStatement.swift
@@ -26,8 +26,17 @@ extension CassandraClient {
         /// PK column names (partition + clustering keys), looked up once at prepare time to avoid repeated schema metadata queries.
         internal let primaryKeyColumnNames: [String]
 
-        internal init(rawPointer: CassPrepared, encryptionTable: String? = nil, primaryKeyColumnNames: [String] = []) {
+        /// The CQL text this statement was prepared from, so prepared-path logs show the real query rather than `"(prepared)"`.
+        internal let query: String
+
+        internal init(
+            rawPointer: CassPrepared,
+            query: String = "(prepared)",
+            encryptionTable: String? = nil,
+            primaryKeyColumnNames: [String] = []
+        ) {
             self.rawPointer = rawPointer
+            self.query = query
             self.encryptionTable = encryptionTable
             self.primaryKeyColumnNames = primaryKeyColumnNames
             var count = 0

--- a/Sources/CassandraClient/RequestLogging.swift
+++ b/Sources/CassandraClient/RequestLogging.swift
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Logging
+import NIOCore
+
+extension CassandraClient {
+    /// Shared request-logging helper. Deliberately free of any `Session` reference so it can be unit-tested
+    /// directly with a synthesized error and a capturing `LogHandler`.
+    internal enum RequestLog {
+        /// The log level for a failure category (a mapping *from* the category, kept separate from the
+        /// categoriser so the category stays reusable by metrics).
+        static func level(for category: ErrorCategory) -> Logger.Level {
+            switch category {
+            case .transient: return .debug
+            case .unavailable, .callerFault, .server: return .warning
+            case .wrapperInternal: return .error
+            }
+        }
+
+        /// Log a failed request once, at the level for its category, with best-effort metadata.
+        /// The error field uses `shortDescription` (code label) — never `description`, which can echo the
+        /// server-provided message (potential PII).
+        static func logFailure(
+            _ error: CassandraClient.Error,
+            query: String? = nil,
+            consistency: CassandraClient.Consistency? = nil,
+            startedAt: DispatchTime? = nil,
+            boundValues: String? = nil,
+            logger: Logger
+        ) {
+            let category = error.category
+            var metadata: Logger.Metadata = [LogKey.errorCategory: "\(category.rawValue)"]
+            if let query {
+                metadata[LogKey.query] = "\(Self.truncated(query))"
+            }
+            if let consistency {
+                metadata[LogKey.consistency] = "\(consistency)"
+            }
+            if let startedAt {
+                metadata[LogKey.latencyMs] = "\(Self.elapsedMillis(since: startedAt))"
+            }
+            if let boundValues {
+                metadata[LogKey.boundValues] = "\(boundValues)"
+            }
+            logger.log(level: Self.level(for: category), "\(error.shortDescription)", metadata: metadata)
+        }
+
+        /// If a successful request's elapsed time exceeds the threshold, log a `.info` "slow query" record.
+        /// `thresholdMillis == nil` skips all timing work (hot-path guard).
+        static func checkSlowSuccess(
+            startedAt: DispatchTime,
+            query: String,
+            thresholdMillis: UInt32?,
+            boundValues: String? = nil,
+            logger: Logger
+        ) {
+            guard let thresholdMillis else { return }
+            let elapsed = Self.elapsedMillis(since: startedAt)
+            guard elapsed > thresholdMillis else { return }
+            var metadata: Logger.Metadata = [
+                LogKey.query: "\(Self.truncated(query))",
+                LogKey.latencyMs: "\(elapsed)",
+            ]
+            if let boundValues {
+                metadata[LogKey.boundValues] = "\(boundValues)"
+            }
+            logger.info("slow query", metadata: metadata)
+        }
+
+        /// Attach failure + slow-success logging to a bridged `EventLoopFuture`, returning it unchanged.
+        /// The completion closure captures only the Sendable values passed in — never a `Statement`/`Batch`.
+        static func instrument<Value>(
+            _ future: EventLoopFuture<Value>,
+            enabled: Bool,
+            startedAt: DispatchTime,
+            query: String?,
+            consistency: CassandraClient.Consistency?,
+            thresholdMillis: UInt32?,
+            boundValues: String? = nil,
+            logger: Logger
+        ) -> EventLoopFuture<Value> {
+            guard enabled else { return future }
+            return future.always { result in
+                switch result {
+                case .success:
+                    if let query {
+                        Self.checkSlowSuccess(
+                            startedAt: startedAt,
+                            query: query,
+                            thresholdMillis: thresholdMillis,
+                            boundValues: boundValues,
+                            logger: logger
+                        )
+                    }
+                case .failure(let error):
+                    if let cassError = error as? CassandraClient.Error {
+                        Self.logFailure(
+                            cassError,
+                            query: query,
+                            consistency: consistency,
+                            startedAt: startedAt,
+                            boundValues: boundValues,
+                            logger: logger
+                        )
+                    }
+                }
+            }
+        }
+
+        /// Run an async request body with the same failure + slow-success logging.
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        static func instrumented<Value>(
+            enabled: Bool,
+            startedAt: DispatchTime,
+            query: String?,
+            consistency: CassandraClient.Consistency?,
+            thresholdMillis: UInt32?,
+            boundValues: String? = nil,
+            logger: Logger,
+            _ body: () async throws -> Value
+        ) async throws -> Value {
+            guard enabled else { return try await body() }
+            do {
+                let value = try await body()
+                if let query {
+                    Self.checkSlowSuccess(
+                        startedAt: startedAt,
+                        query: query,
+                        thresholdMillis: thresholdMillis,
+                        boundValues: boundValues,
+                        logger: logger
+                    )
+                }
+                return value
+            } catch {
+                if let cassError = error as? CassandraClient.Error {
+                    Self.logFailure(
+                        cassError,
+                        query: query,
+                        consistency: consistency,
+                        startedAt: startedAt,
+                        boundValues: boundValues,
+                        logger: logger
+                    )
+                }
+                throw error
+            }
+        }
+
+        /// Format bound parameter values into a single string, each value capped to `maxLoggedValueLength`.
+        /// Callers pass this only when `logBoundValues` is set (values are potential PII).
+        static func formatValues(_ parameters: [CassandraClient.Statement.Value]) -> String {
+            let cap = Configuration.maxLoggedValueLength
+            return parameters.map { value in
+                let string = "\(value)"
+                return string.count > cap ? String(string.prefix(cap)) + "…" : string
+            }.joined(separator: ", ")
+        }
+
+        private static func truncated(_ query: String) -> String {
+            let cap = Configuration.maxLoggedQueryLength
+            return query.count > cap ? String(query.prefix(cap)) + "…" : query
+        }
+
+        /// Monotonic elapsed milliseconds (uptime clock — unaffected by wall-clock/NTP adjustments).
+        private static func elapsedMillis(since start: DispatchTime) -> UInt64 {
+            let ns = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
+            return ns / 1_000_000
+        }
+    }
+}

--- a/Sources/CassandraClient/RequestLogging.swift
+++ b/Sources/CassandraClient/RequestLogging.swift
@@ -20,17 +20,7 @@ extension CassandraClient {
     /// Shared request-logging helper. Deliberately free of any `Session` reference so it can be unit-tested
     /// directly with a synthesized error and a capturing `LogHandler`.
     internal enum RequestLog {
-        /// The log level for a failure category (a mapping *from* the category, kept separate from the
-        /// categoriser so the category stays reusable by metrics).
-        static func level(for category: ErrorCategory) -> Logger.Level {
-            switch category {
-            case .transient: return .debug
-            case .unavailable, .callerFault, .server: return .warning
-            case .wrapperInternal: return .error
-            }
-        }
-
-        /// Log a failed request once, at the level for its category, with best-effort metadata.
+        /// Log a failed request at `.debug` (library convention — never warning/error), with best-effort metadata.
         /// The error field uses `shortDescription` (code label) — never `description`, which can echo the
         /// server-provided message (potential PII).
         static func logFailure(
@@ -55,11 +45,18 @@ extension CassandraClient {
             if let boundValues {
                 metadata[LogKey.boundValues] = "\(boundValues)"
             }
-            logger.log(level: Self.level(for: category), "\(error.shortDescription)", metadata: metadata)
+            // The error rides swift-log's `error:` param (first-class on event-based handlers), never the
+            // message. A wrapper carries only the code label — the raw `Error.description` embeds the
+            // server message (PII), and the param serialises `"\(error)"`.
+            logger.debug(
+                "request failed",
+                error: RedactedError(description: error.shortDescription),
+                metadata: metadata
+            )
         }
 
-        /// If a successful request's elapsed time exceeds the threshold, log a `.info` "slow query" record.
-        /// `thresholdMillis == nil` skips all timing work (hot-path guard).
+        /// If a successful request's elapsed time is at least the threshold, log a `.debug` "slow query" record.
+        /// `thresholdMillis == nil` skips all timing work (hot-path guard); `0` logs every success.
         static func checkSlowSuccess(
             startedAt: DispatchTime,
             query: String,
@@ -69,7 +66,7 @@ extension CassandraClient {
         ) {
             guard let thresholdMillis else { return }
             let elapsed = Self.elapsedMillis(since: startedAt)
-            guard elapsed > thresholdMillis else { return }
+            guard elapsed >= thresholdMillis else { return }
             var metadata: Logger.Metadata = [
                 LogKey.query: "\(Self.truncated(query))",
                 LogKey.latencyMs: "\(elapsed)",
@@ -77,64 +74,22 @@ extension CassandraClient {
             if let boundValues {
                 metadata[LogKey.boundValues] = "\(boundValues)"
             }
-            logger.info("slow query", metadata: metadata)
+            logger.debug("slow query", metadata: metadata)
         }
 
-        /// Attach failure + slow-success logging to a bridged `EventLoopFuture`, returning it unchanged.
-        /// The completion closure captures only the Sendable values passed in — never a `Statement`/`Batch`.
-        static func instrument<Value>(
-            _ future: EventLoopFuture<Value>,
-            enabled: Bool,
+        /// Emit the failure or slow-success record for a completed request outcome — shared by the
+        /// `EventLoopFuture` and async wrappers so both log identically.
+        private static func logOutcome<Value>(
+            _ result: Result<Value, Swift.Error>,
             startedAt: DispatchTime,
             query: String?,
             consistency: CassandraClient.Consistency?,
             thresholdMillis: UInt32?,
-            boundValues: String? = nil,
+            boundValues: String?,
             logger: Logger
-        ) -> EventLoopFuture<Value> {
-            guard enabled else { return future }
-            return future.always { result in
-                switch result {
-                case .success:
-                    if let query {
-                        Self.checkSlowSuccess(
-                            startedAt: startedAt,
-                            query: query,
-                            thresholdMillis: thresholdMillis,
-                            boundValues: boundValues,
-                            logger: logger
-                        )
-                    }
-                case .failure(let error):
-                    if let cassError = error as? CassandraClient.Error {
-                        Self.logFailure(
-                            cassError,
-                            query: query,
-                            consistency: consistency,
-                            startedAt: startedAt,
-                            boundValues: boundValues,
-                            logger: logger
-                        )
-                    }
-                }
-            }
-        }
-
-        /// Run an async request body with the same failure + slow-success logging.
-        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-        static func instrumented<Value>(
-            enabled: Bool,
-            startedAt: DispatchTime,
-            query: String?,
-            consistency: CassandraClient.Consistency?,
-            thresholdMillis: UInt32?,
-            boundValues: String? = nil,
-            logger: Logger,
-            _ body: () async throws -> Value
-        ) async throws -> Value {
-            guard enabled else { return try await body() }
-            do {
-                let value = try await body()
+        ) {
+            switch result {
+            case .success:
                 if let query {
                     Self.checkSlowSuccess(
                         startedAt: startedAt,
@@ -144,8 +99,7 @@ extension CassandraClient {
                         logger: logger
                     )
                 }
-                return value
-            } catch {
+            case .failure(let error):
                 if let cassError = error as? CassandraClient.Error {
                     Self.logFailure(
                         cassError,
@@ -156,8 +110,60 @@ extension CassandraClient {
                         logger: logger
                     )
                 }
-                throw error
             }
+        }
+
+        /// Attach failure + slow-success logging to a bridged `EventLoopFuture`, returning it unchanged.
+        /// The completion closure captures only the Sendable values passed in — never a `Statement`/`Batch`.
+        static func instrument<Value>(
+            _ future: EventLoopFuture<Value>,
+            startedAt: DispatchTime,
+            query: String?,
+            consistency: CassandraClient.Consistency?,
+            thresholdMillis: UInt32?,
+            boundValues: String? = nil,
+            logger: Logger
+        ) -> EventLoopFuture<Value> {
+            future.always { result in
+                Self.logOutcome(
+                    result,
+                    startedAt: startedAt,
+                    query: query,
+                    consistency: consistency,
+                    thresholdMillis: thresholdMillis,
+                    boundValues: boundValues,
+                    logger: logger
+                )
+            }
+        }
+
+        /// Run an async request body with the same failure + slow-success logging.
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        static func instrumented<Value>(
+            startedAt: DispatchTime,
+            query: String?,
+            consistency: CassandraClient.Consistency?,
+            thresholdMillis: UInt32?,
+            boundValues: String? = nil,
+            logger: Logger,
+            _ body: () async throws -> Value
+        ) async throws -> Value {
+            let result: Result<Value, Swift.Error>
+            do {
+                result = .success(try await body())
+            } catch {
+                result = .failure(error)
+            }
+            Self.logOutcome(
+                result,
+                startedAt: startedAt,
+                query: query,
+                consistency: consistency,
+                thresholdMillis: thresholdMillis,
+                boundValues: boundValues,
+                logger: logger
+            )
+            return try result.get()
         }
 
         /// Format bound parameter values into a single string, each value capped to `maxLoggedValueLength`.
@@ -166,19 +172,25 @@ extension CassandraClient {
             let cap = Configuration.maxLoggedValueLength
             return parameters.map { value in
                 let string = "\(value)"
-                return string.count > cap ? String(string.prefix(cap)) + "…" : string
+                return string.count > cap ? string.prefix(cap) + "…" : string
             }.joined(separator: ", ")
         }
 
         private static func truncated(_ query: String) -> String {
             let cap = Configuration.maxLoggedQueryLength
-            return query.count > cap ? String(query.prefix(cap)) + "…" : query
+            return query.count > cap ? query.prefix(cap) + "…" : query
         }
 
         /// Monotonic elapsed milliseconds (uptime clock — unaffected by wall-clock/NTP adjustments).
         private static func elapsedMillis(since start: DispatchTime) -> UInt64 {
             let ns = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
             return ns / 1_000_000
+        }
+
+        /// Carries only a code label as its string form, so swift-log's `error:` param never serialises
+        /// the server-provided message our real `Error.description` embeds (PII).
+        private struct RedactedError: Swift.Error, CustomStringConvertible {
+            let description: String
         }
     }
 }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -35,6 +35,12 @@ import NIOCore  // for async-await bridge
     /// The default keyspace for this session, used to resolve unqualified table names.
     var keyspace: String? { get }
 
+    /// The default `Logger` for this session/client, used when a call site passes no explicit logger.
+    var logger: Logger { get }
+
+    /// Whether request logging (failures + slow queries) is enabled — opt-in, default off.
+    var requestLoggingEnabled: Bool { get }
+
     /// Execute a prepared statement.
     ///
     /// **All** rows are returned.
@@ -209,6 +215,13 @@ import NIOCore  // for async-await bridge
 private let encryptionLogger = Logger(label: "cassandra.encryption")
 
 extension CassandraSession {
+    /// Fallback for conformers that don't provide their own logger. `CassandraClient` and `Session` witness
+    /// this with their configured logger, so this only applies to third-party conformances.
+    public var logger: Logger { Logger(label: "com.apple.cassandra") }
+
+    /// Default: request logging off (opt-in). Conformers backed by a `Configuration` witness this from it.
+    public var requestLoggingEnabled: Bool { false }
+
     private func logDecryptedRows(count: Int, options: CassandraClient.Statement.Options, logger: Logger?) {
         if count > 0, options.hasEncryptionOptions {
             (logger ?? encryptionLogger).debug(
@@ -364,6 +377,15 @@ extension CassandraSession {
             }
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
+            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                CassandraClient.RequestLog.logFailure(
+                    cassError,
+                    query: query,
+                    consistency: nil,
+                    startedAt: nil,
+                    logger: logger ?? self.logger
+                )
+            }
             let eventLoop = eventLoop ?? eventLoopGroup.next()
             return eventLoop.makeFailedFuture(error)
         }
@@ -389,6 +411,15 @@ extension CassandraSession {
             }
             return self.execute(statement: statement, pageSize: pageSize, on: eventLoop, logger: logger)
         } catch {
+            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                CassandraClient.RequestLog.logFailure(
+                    cassError,
+                    query: query,
+                    consistency: nil,
+                    startedAt: nil,
+                    logger: logger ?? self.logger
+                )
+            }
             let eventLoop = eventLoop ?? eventLoopGroup.next()
             return eventLoop.makeFailedFuture(error)
         }
@@ -426,6 +457,7 @@ extension CassandraSession {
                 )
                 statement = try CassandraClient.Statement(
                     preparedRawPointer: prepared.bind(),
+                    query: prepared.query,
                     parameters: parameters,
                     options: options,
                     _encryptor: self.encryptor
@@ -433,6 +465,7 @@ extension CassandraSession {
             } else {
                 statement = try CassandraClient.Statement(
                     preparedRawPointer: prepared.bind(),
+                    query: prepared.query,
                     parameters: parameters,
                     options: options,
                     _encryptor: nil
@@ -440,6 +473,15 @@ extension CassandraSession {
             }
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
+            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                CassandraClient.RequestLog.logFailure(
+                    cassError,
+                    query: prepared.query,
+                    consistency: nil,
+                    startedAt: nil,
+                    logger: logger ?? self.logger
+                )
+            }
             let eventLoop = eventLoop ?? eventLoopGroup.next()
             return eventLoop.makeFailedFuture(error)
         }
@@ -685,8 +727,12 @@ extension CassandraClient {
             self.configuration.keyspace
         }
 
+        public var requestLoggingEnabled: Bool {
+            self.configuration.requestLoggingEnabled
+        }
+
         private let configuration: Configuration
-        private let logger: Logger
+        public let logger: Logger
         private let _state = NIOLockedValueBox(State.idle)
 
         private let underlying: CassSession
@@ -863,9 +909,27 @@ extension CassandraClient {
             nonisolated(unsafe) let statement = statement
             return self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing: \(statement.query)")
-                logger.trace("\(statement.parameters)")
+                if self.configuration.logBoundValues {
+                    logger.trace("\(statement.parameters)")
+                }
+                // Capture only Sendable values before bridging — never `statement` into the completion.
+                let query = statement.query
+                let consistency = statement.options.consistency ?? self.configuration.consistency
+                let boundValues =
+                    self.configuration.logBoundValues
+                    ? CassandraClient.RequestLog.formatValues(statement.parameters) : nil
+                let startedAt = DispatchTime.now()
                 let future = self.underlying.execute(statement: statement)
-                return future.asNIOFuture(eventLoop: eventLoop)
+                return CassandraClient.RequestLog.instrument(
+                    future.asNIOFuture(eventLoop: eventLoop),
+                    enabled: self.configuration.requestLoggingEnabled,
+                    startedAt: startedAt,
+                    query: query,
+                    consistency: consistency,
+                    thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                    boundValues: boundValues,
+                    logger: logger
+                )
             }
         }
 
@@ -880,6 +944,15 @@ extension CassandraClient {
             do {
                 try statement.setPagingSize(pageSize)
             } catch {
+                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                    CassandraClient.RequestLog.logFailure(
+                        cassError,
+                        query: statement.query,
+                        consistency: nil,
+                        startedAt: nil,
+                        logger: logger ?? self.logger
+                    )
+                }
                 return eventLoop.makeFailedFuture(error)
             }
 
@@ -896,16 +969,40 @@ extension CassandraClient {
         ) -> EventLoopFuture<CassandraClient.PreparedStatement> {
             self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("preparing: \(query)")
+                let startedAt = DispatchTime.now()
                 let future = self.underlying.prepare(query: query)
-                return future.asNIOFuture(eventLoop: eventLoop).flatMapThrowing { prepared in
+                let bridged = CassandraClient.RequestLog.instrument(
+                    future.asNIOFuture(eventLoop: eventLoop),
+                    enabled: self.configuration.requestLoggingEnabled,
+                    startedAt: startedAt,
+                    query: query,
+                    consistency: nil,
+                    thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                    logger: logger
+                )
+                return bridged.flatMapThrowing { prepared in
                     let pkColumns: [String]
                     if let tableName = encryptionTable {
-                        pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+                        do {
+                            pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+                        } catch {
+                            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                                CassandraClient.RequestLog.logFailure(
+                                    cassError,
+                                    query: query,
+                                    consistency: nil,
+                                    startedAt: nil,
+                                    logger: logger
+                                )
+                            }
+                            throw error
+                        }
                     } else {
                         pkColumns = []
                     }
                     let prepared = CassandraClient.PreparedStatement(
                         rawPointer: prepared,
+                        query: query,
                         encryptionTable: encryptionTable,
                         primaryKeyColumnNames: pkColumns
                     )
@@ -1099,6 +1196,7 @@ extension CassandraClient {
                     )
                     statement = try CassandraClient.Statement(
                         preparedRawPointer: prepared.bind(),
+                        query: prepared.query,
                         parameters: resolvedParameters,
                         options: options,
                         _encryptor: self.encryptor
@@ -1106,6 +1204,7 @@ extension CassandraClient {
                 } else {
                     statement = try CassandraClient.Statement(
                         preparedRawPointer: prepared.bind(),
+                        query: prepared.query,
                         parameters: parameters,
                         options: options,
                         _encryptor: nil
@@ -1113,6 +1212,15 @@ extension CassandraClient {
                 }
                 return self.execute(statement: statement, on: eventLoop, logger: logger)
             } catch {
+                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                    CassandraClient.RequestLog.logFailure(
+                        cassError,
+                        query: prepared.query,
+                        consistency: nil,
+                        startedAt: nil,
+                        logger: logger ?? self.logger
+                    )
+                }
                 let eventLoop = eventLoop ?? self.eventLoopGroup.next()
                 return eventLoop.makeFailedFuture(error)
             }
@@ -1128,8 +1236,17 @@ extension CassandraClient {
             nonisolated(unsafe) var optionalBatch: CassandraClient.Batch? = batch
             return self.withConnection(on: eventLoop, logger: logger) { eventLoop, logger in
                 logger.debug("executing batch")
+                let startedAt = DispatchTime.now()
                 let future = self.underlying.execute(batch: optionalBatch.take()!)
-                return future.asNIOFuture(eventLoop: eventLoop)
+                return CassandraClient.RequestLog.instrument(
+                    future.asNIOFuture(eventLoop: eventLoop),
+                    enabled: self.configuration.requestLoggingEnabled,
+                    startedAt: startedAt,
+                    query: "batch",
+                    consistency: nil,
+                    thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                    logger: logger
+                )
             }
         }
 
@@ -1168,6 +1285,7 @@ extension CassandraClient {
                         )
                         return try CassandraClient.Statement(
                             preparedRawPointer: prepared.bind(),
+                            query: prepared.query,
                             parameters: resolvedParameters,
                             options: options,
                             _encryptor: self.encryptor
@@ -1180,6 +1298,15 @@ extension CassandraClient {
                 try build(&batch)
                 return self.execute(batch: batch, on: eventLoop, logger: logger)
             } catch {
+                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                    CassandraClient.RequestLog.logFailure(
+                        cassError,
+                        query: "batch",
+                        consistency: nil,
+                        startedAt: nil,
+                        logger: logger ?? self.logger
+                    )
+                }
                 let eventLoop = eventLoop ?? eventLoopGroup.next()
                 return eventLoop.makeFailedFuture(error)
             }
@@ -1187,12 +1314,23 @@ extension CassandraClient {
 
         private func connect(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Void> {
             logger.debug("connecting to: \(self.configuration)")
-
-            return self.configuration.makeCluster(on: eventLoop)
+            let startedAt = DispatchTime.now()
+            // Instrument the whole chain so a `makeCluster` failure (SSL / contact-point / credentials) is
+            // logged too, not just a driver-connect failure.
+            let connected = self.configuration.makeCluster(on: eventLoop)
                 .flatMap { cluster in
-                    let future = self.underlying.connect(cluster: cluster, keyspace: self.configuration.keyspace)
-                    return future.asNIOFuture(eventLoop: eventLoop)
+                    self.underlying.connect(cluster: cluster, keyspace: self.configuration.keyspace)
+                        .asNIOFuture(eventLoop: eventLoop)
                 }
+            return CassandraClient.RequestLog.instrument(
+                connected,
+                enabled: self.configuration.requestLoggingEnabled,
+                startedAt: startedAt,
+                query: nil,
+                consistency: nil,
+                thresholdMillis: nil,
+                logger: logger
+            )
         }
 
         private func disconnect() throws {
@@ -1433,9 +1571,26 @@ extension CassandraClient.Session {
     {
         try await self.withConnection(logger: logger) { logger in
             logger.debug("executing: \(statement.query)")
-            logger.trace("\(statement.parameters)")
-            let future = self.underlying.execute(statement: statement)
-            return try await future.await()
+            if self.configuration.logBoundValues {
+                logger.trace("\(statement.parameters)")
+            }
+            let query = statement.query
+            let consistency = statement.options.consistency ?? self.configuration.consistency
+            let boundValues =
+                self.configuration.logBoundValues
+                ? CassandraClient.RequestLog.formatValues(statement.parameters) : nil
+            let startedAt = DispatchTime.now()
+            return try await CassandraClient.RequestLog.instrumented(
+                enabled: self.configuration.requestLoggingEnabled,
+                startedAt: startedAt,
+                query: query,
+                consistency: consistency,
+                thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                boundValues: boundValues,
+                logger: logger
+            ) {
+                try await self.underlying.execute(statement: statement).await()
+            }
         }
     }
 
@@ -1445,7 +1600,20 @@ extension CassandraClient.Session {
         pageSize: Int32,
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
-        try statement.setPagingSize(pageSize)
+        do {
+            try statement.setPagingSize(pageSize)
+        } catch {
+            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                CassandraClient.RequestLog.logFailure(
+                    cassError,
+                    query: statement.query,
+                    consistency: nil,
+                    startedAt: nil,
+                    logger: logger ?? self.logger
+                )
+            }
+            throw error
+        }
         return CassandraClient.PaginatedRows(session: self, statement: statement, logger: logger)
     }
 
@@ -1458,8 +1626,17 @@ extension CassandraClient.Session {
         var optionalBatch: CassandraClient.Batch? = batch
         try await self.withConnection(logger: logger) { logger in
             logger.debug("executing batch")
-            let future = self.underlying.execute(batch: optionalBatch.take()!)
-            try await future.await()
+            let startedAt = DispatchTime.now()
+            try await CassandraClient.RequestLog.instrumented(
+                enabled: self.configuration.requestLoggingEnabled,
+                startedAt: startedAt,
+                query: "batch",
+                consistency: nil,
+                thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                logger: logger
+            ) {
+                try await self.underlying.execute(batch: optionalBatch.take()!).await()
+            }
         }
     }
 
@@ -1496,6 +1673,7 @@ extension CassandraClient.Session {
                 )
                 return try CassandraClient.Statement(
                     preparedRawPointer: prepared.bind(),
+                    query: prepared.query,
                     parameters: resolvedParameters,
                     options: options,
                     _encryptor: self.encryptor
@@ -1504,8 +1682,23 @@ extension CassandraClient.Session {
         } else {
             resolver = nil
         }
-        var batch = try CassandraClient.Batch(configuration: configuration, resolver: resolver)
-        try await build(&batch)
+        let batch: CassandraClient.Batch
+        do {
+            var built = try CassandraClient.Batch(configuration: configuration, resolver: resolver)
+            try await build(&built)
+            batch = built
+        } catch {
+            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                CassandraClient.RequestLog.logFailure(
+                    cassError,
+                    query: "batch",
+                    consistency: nil,
+                    startedAt: nil,
+                    logger: logger ?? self.logger
+                )
+            }
+            throw error
+        }
         try await self.execute(batch: batch, logger: logger)
     }
 
@@ -1517,16 +1710,40 @@ extension CassandraClient.Session {
     ) async throws -> CassandraClient.PreparedStatement {
         let prepared: CassPrepared = try await self.withConnection(logger: logger) { logger in
             logger.debug("preparing: \(query)")
-            return try await self.underlying.prepare(query: query).await()
+            let startedAt = DispatchTime.now()
+            return try await CassandraClient.RequestLog.instrumented(
+                enabled: self.configuration.requestLoggingEnabled,
+                startedAt: startedAt,
+                query: query,
+                consistency: nil,
+                thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                logger: logger
+            ) {
+                try await self.underlying.prepare(query: query).await()
+            }
         }
         let pkColumns: [String]
         if let tableName = encryptionTable {
-            pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+            do {
+                pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
+            } catch {
+                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                    CassandraClient.RequestLog.logFailure(
+                        cassError,
+                        query: query,
+                        consistency: nil,
+                        startedAt: nil,
+                        logger: logger ?? self.logger
+                    )
+                }
+                throw error
+            }
         } else {
             pkColumns = []
         }
         return CassandraClient.PreparedStatement(
             rawPointer: prepared,
+            query: query,
             encryptionTable: encryptionTable,
             primaryKeyColumnNames: pkColumns
         )
@@ -1540,30 +1757,45 @@ extension CassandraClient.Session {
         logger: Logger? = .none
     ) async throws -> CassandraClient.Rows {
         let statement: CassandraClient.Statement
-        if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
-            let resolvedParameters = try self.resolveEncryptionContexts(
-                prepared: prepared,
-                parameters: parameters,
-                options: options
-            )
-            try self.validateEncryptionBindings(
-                prepared: prepared,
-                parameters: resolvedParameters,
-                options: options
-            )
-            statement = try CassandraClient.Statement(
-                preparedRawPointer: prepared.bind(),
-                parameters: resolvedParameters,
-                options: options,
-                _encryptor: self.encryptor
-            )
-        } else {
-            statement = try CassandraClient.Statement(
-                preparedRawPointer: prepared.bind(),
-                parameters: parameters,
-                options: options,
-                _encryptor: nil
-            )
+        do {
+            if #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) {
+                let resolvedParameters = try self.resolveEncryptionContexts(
+                    prepared: prepared,
+                    parameters: parameters,
+                    options: options
+                )
+                try self.validateEncryptionBindings(
+                    prepared: prepared,
+                    parameters: resolvedParameters,
+                    options: options
+                )
+                statement = try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    query: prepared.query,
+                    parameters: resolvedParameters,
+                    options: options,
+                    _encryptor: self.encryptor
+                )
+            } else {
+                statement = try CassandraClient.Statement(
+                    preparedRawPointer: prepared.bind(),
+                    query: prepared.query,
+                    parameters: parameters,
+                    options: options,
+                    _encryptor: nil
+                )
+            }
+        } catch {
+            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                CassandraClient.RequestLog.logFailure(
+                    cassError,
+                    query: prepared.query,
+                    consistency: nil,
+                    startedAt: nil,
+                    logger: logger ?? self.logger
+                )
+            }
+            throw error
         }
         return try await self.execute(statement: statement, logger: logger)
     }
@@ -1572,10 +1804,20 @@ extension CassandraClient.Session {
     private func connect(logger: Logger) -> Task<Void, Swift.Error> {
         Task {
             logger.debug("connecting to: \(self.configuration)")
-
-            let cluster = try await self.configuration.makeCluster()
-            let future = self.underlying.connect(cluster: cluster, keyspace: self.configuration.keyspace)
-            return try await future.await()
+            let startedAt = DispatchTime.now()
+            // Instrument makeCluster + connect together so cluster-build failures are logged too.
+            return try await CassandraClient.RequestLog.instrumented(
+                enabled: self.configuration.requestLoggingEnabled,
+                startedAt: startedAt,
+                query: nil,
+                consistency: nil,
+                thresholdMillis: nil,
+                logger: logger
+            ) {
+                let cluster = try await self.configuration.makeCluster()
+                return try await self.underlying.connect(cluster: cluster, keyspace: self.configuration.keyspace)
+                    .await()
+            }
         }
     }
 }

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -38,9 +38,6 @@ import NIOCore  // for async-await bridge
     /// The default `Logger` for this session/client, used when a call site passes no explicit logger.
     var logger: Logger { get }
 
-    /// Whether request logging (failures + slow queries) is enabled — opt-in, default off.
-    var requestLoggingEnabled: Bool { get }
-
     /// Execute a prepared statement.
     ///
     /// **All** rows are returned.
@@ -219,9 +216,6 @@ extension CassandraSession {
     /// this with their configured logger, so this only applies to third-party conformances.
     public var logger: Logger { Logger(label: "com.apple.cassandra") }
 
-    /// Default: request logging off (opt-in). Conformers backed by a `Configuration` witness this from it.
-    public var requestLoggingEnabled: Bool { false }
-
     private func logDecryptedRows(count: Int, options: CassandraClient.Statement.Options, logger: Logger?) {
         if count > 0, options.hasEncryptionOptions {
             (logger ?? encryptionLogger).debug(
@@ -377,7 +371,7 @@ extension CassandraSession {
             }
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
-            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+            if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(
                     cassError,
                     query: query,
@@ -411,7 +405,7 @@ extension CassandraSession {
             }
             return self.execute(statement: statement, pageSize: pageSize, on: eventLoop, logger: logger)
         } catch {
-            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+            if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(
                     cassError,
                     query: query,
@@ -473,7 +467,7 @@ extension CassandraSession {
             }
             return self.execute(statement: statement, on: eventLoop, logger: logger)
         } catch {
-            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+            if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(
                     cassError,
                     query: prepared.query,
@@ -727,10 +721,6 @@ extension CassandraClient {
             self.configuration.keyspace
         }
 
-        public var requestLoggingEnabled: Bool {
-            self.configuration.requestLoggingEnabled
-        }
-
         private let configuration: Configuration
         public let logger: Logger
         private let _state = NIOLockedValueBox(State.idle)
@@ -922,7 +912,6 @@ extension CassandraClient {
                 let future = self.underlying.execute(statement: statement)
                 return CassandraClient.RequestLog.instrument(
                     future.asNIOFuture(eventLoop: eventLoop),
-                    enabled: self.configuration.requestLoggingEnabled,
                     startedAt: startedAt,
                     query: query,
                     consistency: consistency,
@@ -944,7 +933,7 @@ extension CassandraClient {
             do {
                 try statement.setPagingSize(pageSize)
             } catch {
-                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                if let cassError = error as? CassandraClient.Error {
                     CassandraClient.RequestLog.logFailure(
                         cassError,
                         query: statement.query,
@@ -973,7 +962,6 @@ extension CassandraClient {
                 let future = self.underlying.prepare(query: query)
                 let bridged = CassandraClient.RequestLog.instrument(
                     future.asNIOFuture(eventLoop: eventLoop),
-                    enabled: self.configuration.requestLoggingEnabled,
                     startedAt: startedAt,
                     query: query,
                     consistency: nil,
@@ -986,7 +974,7 @@ extension CassandraClient {
                         do {
                             pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
                         } catch {
-                            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                            if let cassError = error as? CassandraClient.Error {
                                 CassandraClient.RequestLog.logFailure(
                                     cassError,
                                     query: query,
@@ -1212,7 +1200,7 @@ extension CassandraClient {
                 }
                 return self.execute(statement: statement, on: eventLoop, logger: logger)
             } catch {
-                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                if let cassError = error as? CassandraClient.Error {
                     CassandraClient.RequestLog.logFailure(
                         cassError,
                         query: prepared.query,
@@ -1240,7 +1228,6 @@ extension CassandraClient {
                 let future = self.underlying.execute(batch: optionalBatch.take()!)
                 return CassandraClient.RequestLog.instrument(
                     future.asNIOFuture(eventLoop: eventLoop),
-                    enabled: self.configuration.requestLoggingEnabled,
                     startedAt: startedAt,
                     query: "batch",
                     consistency: nil,
@@ -1298,7 +1285,7 @@ extension CassandraClient {
                 try build(&batch)
                 return self.execute(batch: batch, on: eventLoop, logger: logger)
             } catch {
-                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                if let cassError = error as? CassandraClient.Error {
                     CassandraClient.RequestLog.logFailure(
                         cassError,
                         query: "batch",
@@ -1324,7 +1311,6 @@ extension CassandraClient {
                 }
             return CassandraClient.RequestLog.instrument(
                 connected,
-                enabled: self.configuration.requestLoggingEnabled,
                 startedAt: startedAt,
                 query: nil,
                 consistency: nil,
@@ -1581,7 +1567,6 @@ extension CassandraClient.Session {
                 ? CassandraClient.RequestLog.formatValues(statement.parameters) : nil
             let startedAt = DispatchTime.now()
             return try await CassandraClient.RequestLog.instrumented(
-                enabled: self.configuration.requestLoggingEnabled,
                 startedAt: startedAt,
                 query: query,
                 consistency: consistency,
@@ -1603,7 +1588,7 @@ extension CassandraClient.Session {
         do {
             try statement.setPagingSize(pageSize)
         } catch {
-            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+            if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(
                     cassError,
                     query: statement.query,
@@ -1628,7 +1613,6 @@ extension CassandraClient.Session {
             logger.debug("executing batch")
             let startedAt = DispatchTime.now()
             try await CassandraClient.RequestLog.instrumented(
-                enabled: self.configuration.requestLoggingEnabled,
                 startedAt: startedAt,
                 query: "batch",
                 consistency: nil,
@@ -1688,7 +1672,7 @@ extension CassandraClient.Session {
             try await build(&built)
             batch = built
         } catch {
-            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+            if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(
                     cassError,
                     query: "batch",
@@ -1712,7 +1696,6 @@ extension CassandraClient.Session {
             logger.debug("preparing: \(query)")
             let startedAt = DispatchTime.now()
             return try await CassandraClient.RequestLog.instrumented(
-                enabled: self.configuration.requestLoggingEnabled,
                 startedAt: startedAt,
                 query: query,
                 consistency: nil,
@@ -1727,7 +1710,7 @@ extension CassandraClient.Session {
             do {
                 pkColumns = try self.lookupPrimaryKeyColumnNames(tableName: tableName)
             } catch {
-                if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+                if let cassError = error as? CassandraClient.Error {
                     CassandraClient.RequestLog.logFailure(
                         cassError,
                         query: query,
@@ -1786,7 +1769,7 @@ extension CassandraClient.Session {
                 )
             }
         } catch {
-            if self.requestLoggingEnabled, let cassError = error as? CassandraClient.Error {
+            if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(
                     cassError,
                     query: prepared.query,
@@ -1807,7 +1790,6 @@ extension CassandraClient.Session {
             let startedAt = DispatchTime.now()
             // Instrument makeCluster + connect together so cluster-build failures are logged too.
             return try await CassandraClient.RequestLog.instrumented(
-                enabled: self.configuration.requestLoggingEnabled,
                 startedAt: startedAt,
                 query: nil,
                 consistency: nil,

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -49,11 +49,12 @@ extension CassandraClient {
         /// Internal init for prepared statements. Takes a pre-bound `CassStatement*` from `cass_prepared_bind()`.
         internal init(
             preparedRawPointer: OpaquePointer,
+            query: String = "(prepared)",
             parameters: [Value],
             options: Options,
             _encryptor: AnyObject?
         ) throws {
-            self.query = "(prepared)"
+            self.query = query
             self.parameters = parameters
             self.options = options
             self._encryptor = _encryptor

--- a/Tests/CassandraClientTests/RequestLoggingIntegrationTests.swift
+++ b/Tests/CassandraClientTests/RequestLoggingIntegrationTests.swift
@@ -1,0 +1,306 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+/// Request-logging INTEGRATION tests. Most require a live Cassandra — run with:
+///
+///     CASSANDRA_HOST=<your-test-cluster-host> swift test --filter RequestLoggingIntegrationTests
+///
+/// The async API is used deliberately: the async logging helper emits the record *before* the `await`
+/// returns, so assertions after the call are deterministic (no completion-callback race).
+/// `testConnectFailureLoggedOnce` points at an unroutable host and does not need the cluster.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class RequestLoggingIntegrationTests: XCTestCase {
+    private func makeConfig() -> CassandraClient.Configuration {
+        let env = ProcessInfo.processInfo.environment
+        var config = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        config.username = env["CASSANDRA_USER"]
+        config.password = env["CASSANDRA_PASSWORD"]
+        config.keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        config.requestTimeoutMillis = 24_000
+        config.connectTimeoutMillis = 10_000
+        return config
+    }
+
+    /// Create a client whose default logger captures, with slow-query logging on ("0" logs all successes).
+    private func makeCapturingClient(
+        logBoundValues: Bool = false
+    ) -> (CassandraClient, TestLogCapture, String) {
+        var config = self.makeConfig()
+        config.requestLoggingEnabled = true
+        config.slowQueryThresholdMillis = 0
+        config.logBoundValues = logBoundValues
+        let (logger, capture) = makeCapturingLogger()
+        let client = CassandraClient(configuration: config, logger: logger)
+        return (client, capture, config.keyspace!)
+    }
+
+    private func createKeyspaceAndTable(
+        _ client: CassandraClient,
+        keyspace: String,
+        table: String,
+        schema: String
+    ) async throws {
+        try await client.withSession(keyspace: .none) { session in
+            try await session.run(
+                "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+            )
+        }
+        let session = client.makeSession(keyspace: keyspace)
+        defer { try? session.shutdown() }
+        try await session.run("create table \(keyspace).\(table) \(schema)")
+    }
+
+    /// A prepared statement's slow-query record shows the real CQL, not "(prepared)".
+    func testPreparedStatementLogsRealCQL() throws {
+        runAsyncAndWaitFor {
+            let (client, capture, keyspace) = self.makeCapturingClient()
+            defer { XCTAssertNoThrow(try client.shutdown()) }
+            let table = "log_v6b_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.createKeyspaceAndTable(
+                client,
+                keyspace: keyspace,
+                table: table,
+                schema: "(id bigint primary key, v text)"
+            )
+
+            let session = client.makeSession(keyspace: keyspace)
+            defer { try? session.shutdown() }
+            let cql = "insert into \(table) (id, v) values (?, ?)"
+            let prepared = try await session.prepare(cql)
+            capture.clear()  // ignore setup logs
+            _ = try await session.execute(prepared: prepared, parameters: [.int64(1), .string("x")])
+
+            let record = capture.all.first {
+                $0.level == .info && $0.metadata[CassandraClient.LogKey.query] != nil
+            }
+            XCTAssertNotNil(record, "expected a slow-query record for the prepared execute")
+            XCTAssertEqual(record?.metadata[CassandraClient.LogKey.query], "\(cql)")
+        }
+    }
+
+    /// A batch's record carries the "batch" operation label (batch has no single query text).
+    func testBatchLogsOperationLabel() throws {
+        runAsyncAndWaitFor {
+            let (client, capture, keyspace) = self.makeCapturingClient()
+            defer { XCTAssertNoThrow(try client.shutdown()) }
+            let table = "log_v6c_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.createKeyspaceAndTable(
+                client,
+                keyspace: keyspace,
+                table: table,
+                schema: "(id int primary key, name text)"
+            )
+
+            capture.clear()
+            try await client.batch { batch in
+                try batch.add(
+                    statement: CassandraClient.Statement(
+                        query: "insert into \(table) (id, name) values (?, ?);",
+                        parameters: [.int32(1), .string("a")]
+                    )
+                )
+            }
+
+            let record = capture.all.first { $0.metadata[CassandraClient.LogKey.query] == "batch" }
+            XCTAssertNotNil(record, "expected a batch record labelled \"batch\"")
+        }
+    }
+
+    /// A connect failure (unroutable host) is logged exactly once. Does NOT need the cluster.
+    func testConnectFailureLoggedOnce() throws {
+        runAsyncAndWaitFor {
+            var config = CassandraClient.Configuration(
+                contactPointsProvider: { callback in callback(.success(["240.0.0.1"])) },  // unroutable
+                port: 9042,
+                protocolVersion: .v3
+            )
+            config.keyspace = "test"
+            config.connectTimeoutMillis = 2_000
+            config.requestLoggingEnabled = true
+            let (logger, capture) = makeCapturingLogger()
+            let client = CassandraClient(configuration: config, logger: logger)
+            defer { XCTAssertNoThrow(try client.shutdown()) }
+            let session = client.makeSession(keyspace: "test")
+            defer { try? session.shutdown() }
+
+            do {
+                try await session.run("select release_version from system.local")
+                XCTFail("expected a connect failure")
+            } catch {
+                // expected
+            }
+
+            let failures = capture.all.filter { $0.metadata[CassandraClient.LogKey.errorCategory] != nil }
+            XCTAssertEqual(failures.count, 1, "connect failure should be logged exactly once, not per waiter")
+        }
+    }
+
+    /// A preflight (binding) failure is logged even though it throws before the request is sent.
+    func testPreflightFailureLogged() throws {
+        runAsyncAndWaitFor {
+            let (client, capture, keyspace) = self.makeCapturingClient()
+            defer { XCTAssertNoThrow(try client.shutdown()) }
+            let table = "log_v1c_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.createKeyspaceAndTable(
+                client,
+                keyspace: keyspace,
+                table: table,
+                schema: "(id bigint primary key, v text)"
+            )
+
+            let session = client.makeSession(keyspace: keyspace)
+            defer { try? session.shutdown() }
+            let prepared = try await session.prepare("insert into \(table) (id, v) values (?, ?)")
+            capture.clear()
+
+            do {
+                // Bind more parameters than the statement has placeholders -> preflight bind failure.
+                _ = try await session.execute(
+                    prepared: prepared,
+                    parameters: [.int64(1), .string("x"), .string("extra")]
+                )
+                XCTFail("expected a preflight binding failure")
+            } catch {
+                // expected
+            }
+
+            let failures = capture.all.filter { $0.metadata[CassandraClient.LogKey.errorCategory] != nil }
+            XCTAssertFalse(failures.isEmpty, "preflight binding failure should be logged even before a request is sent")
+        }
+    }
+
+    /// PII: a bound value must not appear anywhere in captured logs (incl. the pre-existing `.trace` dump)
+    /// when `logBoundValues` is off (default), and must appear (capped) when it's explicitly enabled.
+    /// Exercises the real `Session` call site — not the `RequestLog` helper directly.
+    func testBoundValuesRespectConfigFlag() throws {
+        runAsyncAndWaitFor {
+            let table = "log_pii_\(DispatchTime.now().uptimeNanoseconds)"
+
+            func leaks(_ marker: String, in capture: TestLogCapture) -> Bool {
+                capture.all.contains { entry in
+                    entry.message.contains(marker) || entry.metadata.values.contains { "\($0)".contains(marker) }
+                }
+            }
+
+            // Off (default): the bound value must not leak into any captured record.
+            do {
+                let (client, capture, keyspace) = self.makeCapturingClient(logBoundValues: false)
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                try await self.createKeyspaceAndTable(
+                    client,
+                    keyspace: keyspace,
+                    table: table,
+                    schema: "(id bigint primary key, v text)"
+                )
+                let marker = "PII_MARKER_OFF_\(DispatchTime.now().uptimeNanoseconds)"
+                capture.clear()
+                _ = try await client.execute(
+                    statement: CassandraClient.Statement(
+                        query: "insert into \(table) (id, v) values (?, ?)",
+                        parameters: [.int64(1), .string(marker)]
+                    )
+                )
+                XCTAssertFalse(capture.all.isEmpty, "expected at least a slow-query record (threshold=0)")
+                XCTAssertFalse(leaks(marker, in: capture), "bound value must not appear when logBoundValues is off")
+            }
+
+            // On: the bound value should appear, capped, in the captured records.
+            do {
+                let (client, capture, _) = self.makeCapturingClient(logBoundValues: true)
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                let marker = "PII_MARKER_ON_\(DispatchTime.now().uptimeNanoseconds)"
+                capture.clear()
+                _ = try await client.execute(
+                    statement: CassandraClient.Statement(
+                        query: "insert into \(table) (id, v) values (?, ?)",
+                        parameters: [.int64(2), .string(marker)]
+                    )
+                )
+                XCTAssertTrue(leaks(marker, in: capture), "bound value should appear when logBoundValues is on")
+            }
+        }
+    }
+
+    /// Master switch: with `requestLoggingEnabled` left at its real default (false), neither a completion-site
+    /// success that would otherwise log (threshold=0) nor a preflight failure should produce a feature record.
+    /// Exercises the real `Session`/`CassandraSession` code paths — not `RequestLog.instrumented` directly.
+    func testMasterSwitchDefaultOffSuppressesRealLogging() throws {
+        // The pre-existing unconditional `.debug("executing: ...")` breadcrumb is unrelated to this switch and
+        // still appears, so check for this feature's own metadata rather than an empty capture.
+        @Sendable func hasFeatureRecord(_ capture: TestLogCapture) -> Bool {
+            capture.all.contains {
+                $0.metadata[CassandraClient.LogKey.errorCategory] != nil
+                    || $0.metadata[CassandraClient.LogKey.latencyMs] != nil
+            }
+        }
+
+        runAsyncAndWaitFor {
+            var config = self.makeConfig()
+            // Deliberately NOT set: requestLoggingEnabled stays at its real default (false).
+            config.slowQueryThresholdMillis = 0  // would log every success if the switch were ignored
+            let (logger, capture) = makeCapturingLogger()
+            let client = CassandraClient(configuration: config, logger: logger)
+            defer { XCTAssertNoThrow(try client.shutdown()) }
+
+            let table = "log_switch_off_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.createKeyspaceAndTable(
+                client,
+                keyspace: config.keyspace!,
+                table: table,
+                schema: "(id bigint primary key, v text)"
+            )
+
+            // Completion-site path: a real success that WOULD be logged (threshold=0) if the switch were
+            // not honored at the `instrument`/`instrumented` call sites.
+            capture.clear()
+            _ = try await client.execute(
+                statement: CassandraClient.Statement(
+                    query: "insert into \(table) (id, v) values (?, ?)",
+                    parameters: [.int64(1), .string("x")]
+                )
+            )
+            XCTAssertFalse(hasFeatureRecord(capture), "master switch off should suppress completion-site logging")
+
+            // Preflight path: a real binding failure that WOULD be logged if any of the 11 individual
+            // `if self.requestLoggingEnabled` preflight guards were missing or broken.
+            let session = client.makeSession(keyspace: config.keyspace!)
+            defer { try? session.shutdown() }
+            let prepared = try await session.prepare("insert into \(table) (id, v) values (?, ?)")
+            capture.clear()
+            do {
+                _ = try await session.execute(
+                    prepared: prepared,
+                    parameters: [.int64(1), .string("x"), .string("extra")]
+                )
+                XCTFail("expected a preflight binding failure")
+            } catch {
+                // expected
+            }
+            XCTAssertFalse(hasFeatureRecord(capture), "master switch off should suppress preflight-catch logging too")
+        }
+    }
+}

--- a/Tests/CassandraClientTests/RequestLoggingIntegrationTests.swift
+++ b/Tests/CassandraClientTests/RequestLoggingIntegrationTests.swift
@@ -50,7 +50,6 @@ final class RequestLoggingIntegrationTests: XCTestCase {
         logBoundValues: Bool = false
     ) -> (CassandraClient, TestLogCapture, String) {
         var config = self.makeConfig()
-        config.requestLoggingEnabled = true
         config.slowQueryThresholdMillis = 0
         config.logBoundValues = logBoundValues
         let (logger, capture) = makeCapturingLogger()
@@ -95,7 +94,7 @@ final class RequestLoggingIntegrationTests: XCTestCase {
             _ = try await session.execute(prepared: prepared, parameters: [.int64(1), .string("x")])
 
             let record = capture.all.first {
-                $0.level == .info && $0.metadata[CassandraClient.LogKey.query] != nil
+                $0.level == .debug && $0.metadata[CassandraClient.LogKey.query] != nil
             }
             XCTAssertNotNil(record, "expected a slow-query record for the prepared execute")
             XCTAssertEqual(record?.metadata[CassandraClient.LogKey.query], "\(cql)")
@@ -140,7 +139,6 @@ final class RequestLoggingIntegrationTests: XCTestCase {
             )
             config.keyspace = "test"
             config.connectTimeoutMillis = 2_000
-            config.requestLoggingEnabled = true
             let (logger, capture) = makeCapturingLogger()
             let client = CassandraClient(configuration: config, logger: logger)
             defer { XCTAssertNoThrow(try client.shutdown()) }
@@ -245,62 +243,4 @@ final class RequestLoggingIntegrationTests: XCTestCase {
         }
     }
 
-    /// Master switch: with `requestLoggingEnabled` left at its real default (false), neither a completion-site
-    /// success that would otherwise log (threshold=0) nor a preflight failure should produce a feature record.
-    /// Exercises the real `Session`/`CassandraSession` code paths — not `RequestLog.instrumented` directly.
-    func testMasterSwitchDefaultOffSuppressesRealLogging() throws {
-        // The pre-existing unconditional `.debug("executing: ...")` breadcrumb is unrelated to this switch and
-        // still appears, so check for this feature's own metadata rather than an empty capture.
-        @Sendable func hasFeatureRecord(_ capture: TestLogCapture) -> Bool {
-            capture.all.contains {
-                $0.metadata[CassandraClient.LogKey.errorCategory] != nil
-                    || $0.metadata[CassandraClient.LogKey.latencyMs] != nil
-            }
-        }
-
-        runAsyncAndWaitFor {
-            var config = self.makeConfig()
-            // Deliberately NOT set: requestLoggingEnabled stays at its real default (false).
-            config.slowQueryThresholdMillis = 0  // would log every success if the switch were ignored
-            let (logger, capture) = makeCapturingLogger()
-            let client = CassandraClient(configuration: config, logger: logger)
-            defer { XCTAssertNoThrow(try client.shutdown()) }
-
-            let table = "log_switch_off_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.createKeyspaceAndTable(
-                client,
-                keyspace: config.keyspace!,
-                table: table,
-                schema: "(id bigint primary key, v text)"
-            )
-
-            // Completion-site path: a real success that WOULD be logged (threshold=0) if the switch were
-            // not honored at the `instrument`/`instrumented` call sites.
-            capture.clear()
-            _ = try await client.execute(
-                statement: CassandraClient.Statement(
-                    query: "insert into \(table) (id, v) values (?, ?)",
-                    parameters: [.int64(1), .string("x")]
-                )
-            )
-            XCTAssertFalse(hasFeatureRecord(capture), "master switch off should suppress completion-site logging")
-
-            // Preflight path: a real binding failure that WOULD be logged if any of the 11 individual
-            // `if self.requestLoggingEnabled` preflight guards were missing or broken.
-            let session = client.makeSession(keyspace: config.keyspace!)
-            defer { try? session.shutdown() }
-            let prepared = try await session.prepare("insert into \(table) (id, v) values (?, ?)")
-            capture.clear()
-            do {
-                _ = try await session.execute(
-                    prepared: prepared,
-                    parameters: [.int64(1), .string("x"), .string("extra")]
-                )
-                XCTFail("expected a preflight binding failure")
-            } catch {
-                // expected
-            }
-            XCTAssertFalse(hasFeatureRecord(capture), "master switch off should suppress preflight-catch logging too")
-        }
-    }
 }

--- a/Tests/CassandraClientTests/RequestLoggingTests.swift
+++ b/Tests/CassandraClientTests/RequestLoggingTests.swift
@@ -1,0 +1,211 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+import Logging
+import XCTest
+
+@testable import CassandraClient
+
+/// Unit tests for request logging: a pure-categoriser test (no cluster) and direct-helper emission tests
+/// using the shared capturing `LogHandler` (`TestLogCapture`) — no cluster, no double-tautology.
+final class RequestLoggingTests: XCTestCase {
+    /// Categorisation + level mapping are pure functions — no cluster. Covers at least one case per
+    /// bucket (incl. a `server`-default catch-all case) and pins the metric-reused raw values.
+    func testCategorizationAndLevels() {
+        // transient
+        XCTAssertEqual(CassandraClient.Error.readTimeout("").category, .transient)
+        XCTAssertEqual(CassandraClient.Error.serverOverloaded("").category, .transient)
+        // unavailable (incl. connect-class lib errors)
+        XCTAssertEqual(CassandraClient.Error.noHostsAvailable("").category, .unavailable)
+        XCTAssertEqual(CassandraClient.Error.unableToConnect("").category, .unavailable)
+        // callerFault (incl. bind + encryption-config)
+        XCTAssertEqual(CassandraClient.Error.syntaxError("").category, .callerFault)
+        XCTAssertEqual(CassandraClient.Error.parameterUnset("").category, .callerFault)
+        XCTAssertEqual(CassandraClient.Error.encryptionConfigError("").category, .callerFault)
+        // server (default bucket) — incl. errors that only land here via the catch-all, and unprepared
+        XCTAssertEqual(CassandraClient.Error.serverError("").category, .server)
+        XCTAssertEqual(CassandraClient.Error.notImplemented("").category, .server)
+        XCTAssertEqual(CassandraClient.Error.unprepared("").category, .server)
+        // internal (wrapper invariant)
+        XCTAssertEqual(CassandraClient.Error.internalError("").category, .wrapperInternal)
+
+        XCTAssertEqual(CassandraClient.RequestLog.level(for: .transient), .debug)
+        XCTAssertEqual(CassandraClient.RequestLog.level(for: .unavailable), .warning)
+        XCTAssertEqual(CassandraClient.RequestLog.level(for: .callerFault), .warning)
+        XCTAssertEqual(CassandraClient.RequestLog.level(for: .server), .warning)
+        XCTAssertEqual(CassandraClient.RequestLog.level(for: .wrapperInternal), .error)
+
+        // The category raw values are what a future metric tag reuses verbatim — pin them.
+        XCTAssertEqual(CassandraClient.ErrorCategory.transient.rawValue, "transient")
+        XCTAssertEqual(CassandraClient.ErrorCategory.unavailable.rawValue, "unavailable")
+        XCTAssertEqual(CassandraClient.ErrorCategory.callerFault.rawValue, "callerFault")
+        XCTAssertEqual(CassandraClient.ErrorCategory.server.rawValue, "server")
+        XCTAssertEqual(CassandraClient.ErrorCategory.wrapperInternal.rawValue, "internal")
+    }
+
+    /// Emission shape via a direct helper call — no live server, no tautology.
+    func testFailureEmissionShape() {
+        let (logger, capture) = makeCapturingLogger()
+        let error = CassandraClient.Error.syntaxError("bad cql near 'SELET'")
+
+        CassandraClient.RequestLog.logFailure(
+            error,
+            query: "SELECT * FROM t WHERE id = ?",
+            consistency: .localOne,
+            startedAt: nil,
+            logger: logger
+        )
+
+        let entries = capture.all
+        XCTAssertEqual(entries.count, 1)
+        let entry = entries[0]
+        XCTAssertEqual(entry.level, .warning)  // callerFault -> .warning
+        XCTAssertEqual(entry.metadata[CassandraClient.LogKey.errorCategory], "callerFault")
+        XCTAssertEqual(entry.metadata[CassandraClient.LogKey.query], "SELECT * FROM t WHERE id = ?")
+        XCTAssertEqual(entry.message, error.shortDescription)
+        // The server-provided message must NOT leak into the structured log field.
+        XCTAssertFalse(entry.message.contains("SELET"))
+    }
+
+    /// Threshold 0 logs a slow record for a (>0 ms) success.
+    func testSlowQueryThresholdZeroLogs() {
+        let (logger, capture) = makeCapturingLogger()
+        let past = DispatchTime(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds - 5_000_000)  // ~5 ms ago
+        CassandraClient.RequestLog.checkSlowSuccess(
+            startedAt: past,
+            query: "SELECT 1",
+            thresholdMillis: 0,
+            logger: logger
+        )
+        let entries = capture.all
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].level, .info)
+        XCTAssertEqual(entries[0].metadata[CassandraClient.LogKey.query], "SELECT 1")
+        XCTAssertNotNil(entries[0].metadata[CassandraClient.LogKey.latencyMs])
+    }
+
+    /// Threshold nil does no timing and logs nothing.
+    func testSlowQueryThresholdNilSkips() {
+        let (logger, capture) = makeCapturingLogger()
+        let past = DispatchTime(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds - 5_000_000)
+        CassandraClient.RequestLog.checkSlowSuccess(
+            startedAt: past,
+            query: "SELECT 1",
+            thresholdMillis: nil,
+            logger: logger
+        )
+        XCTAssertTrue(capture.all.isEmpty)
+    }
+
+    /// A high threshold does not log a fast query.
+    func testSlowQueryHighThresholdNoLog() {
+        let (logger, capture) = makeCapturingLogger()
+        let past = DispatchTime(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds - 5_000_000)
+        CassandraClient.RequestLog.checkSlowSuccess(
+            startedAt: past,
+            query: "SELECT 1",
+            thresholdMillis: 600_000,
+            logger: logger
+        )
+        XCTAssertTrue(capture.all.isEmpty)
+    }
+
+    /// Query text longer than the cap is truncated in the record.
+    func testQueryTruncation() {
+        let (logger, capture) = makeCapturingLogger()
+        let longQuery = String(repeating: "a", count: 600)
+        CassandraClient.RequestLog.logFailure(
+            CassandraClient.Error.serverError("x"),
+            query: longQuery,
+            consistency: nil,
+            startedAt: nil,
+            logger: logger
+        )
+        let entries = capture.all
+        XCTAssertEqual(entries.count, 1)
+        let expected = String(longQuery.prefix(CassandraClient.Configuration.maxLoggedQueryLength)) + "…"
+        XCTAssertEqual(entries[0].metadata[CassandraClient.LogKey.query], "\(expected)")
+    }
+
+    /// Bound values are absent unless provided (logBoundValues), and are capped when present.
+    func testBoundValuesGate() {
+        // off (nil) -> no bound-values key
+        let (loggerOff, captureOff) = makeCapturingLogger()
+        CassandraClient.RequestLog.logFailure(
+            CassandraClient.Error.serverError("x"),
+            query: "q",
+            boundValues: nil,
+            logger: loggerOff
+        )
+        XCTAssertNil(captureOff.all[0].metadata[CassandraClient.LogKey.boundValues])
+
+        // on -> present
+        let (loggerOn, captureOn) = makeCapturingLogger()
+        CassandraClient.RequestLog.logFailure(
+            CassandraClient.Error.serverError("x"),
+            query: "q",
+            boundValues: "v0=42",
+            logger: loggerOn
+        )
+        XCTAssertEqual(captureOn.all[0].metadata[CassandraClient.LogKey.boundValues], "v0=42")
+    }
+
+    /// Each bound value is capped to maxLoggedValueLength.
+    func testBoundValueTruncation() {
+        let long = String(repeating: "b", count: 100)
+        let formatted = CassandraClient.RequestLog.formatValues([.string(long)])
+        XCTAssertTrue(formatted.hasSuffix("…"))
+        XCTAssertLessThanOrEqual(formatted.count, CassandraClient.Configuration.maxLoggedValueLength + 1)
+    }
+
+    /// Master switch (opt-in): with logging disabled, even a failure produces no record.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testMasterSwitchGatesLogging() {
+        // enabled: false -> a failure in the body is NOT logged
+        let (loggerOff, captureOff) = makeCapturingLogger()
+        let offDone = expectation(description: "off")
+        Task {
+            _ = try? await CassandraClient.RequestLog.instrumented(
+                enabled: false,
+                startedAt: DispatchTime.now(),
+                query: "q",
+                consistency: nil,
+                thresholdMillis: 0,
+                logger: loggerOff
+            ) { throw CassandraClient.Error.serverError("boom") }
+            offDone.fulfill()
+        }
+        wait(for: [offDone], timeout: 3)
+        XCTAssertTrue(captureOff.all.isEmpty, "master switch off should suppress all logging")
+
+        // enabled: true -> the failure IS logged
+        let (loggerOn, captureOn) = makeCapturingLogger()
+        let onDone = expectation(description: "on")
+        Task {
+            _ = try? await CassandraClient.RequestLog.instrumented(
+                enabled: true,
+                startedAt: DispatchTime.now(),
+                query: "q",
+                consistency: nil,
+                thresholdMillis: nil,
+                logger: loggerOn
+            ) { throw CassandraClient.Error.serverError("boom") }
+            onDone.fulfill()
+        }
+        wait(for: [onDone], timeout: 3)
+        XCTAssertEqual(captureOn.all.count, 1, "master switch on should emit the failure")
+    }
+}

--- a/Tests/CassandraClientTests/RequestLoggingTests.swift
+++ b/Tests/CassandraClientTests/RequestLoggingTests.swift
@@ -22,9 +22,9 @@ import XCTest
 /// Unit tests for request logging: a pure-categoriser test (no cluster) and direct-helper emission tests
 /// using the shared capturing `LogHandler` (`TestLogCapture`) — no cluster, no double-tautology.
 final class RequestLoggingTests: XCTestCase {
-    /// Categorisation + level mapping are pure functions — no cluster. Covers at least one case per
-    /// bucket (incl. a `server`-default catch-all case) and pins the metric-reused raw values.
-    func testCategorizationAndLevels() {
+    /// Categorisation is a pure function — no cluster. Covers at least one case per bucket (incl. a
+    /// `server`-default catch-all case) and pins the metric-reused raw values.
+    func testCategorization() {
         // transient
         XCTAssertEqual(CassandraClient.Error.readTimeout("").category, .transient)
         XCTAssertEqual(CassandraClient.Error.serverOverloaded("").category, .transient)
@@ -41,12 +41,6 @@ final class RequestLoggingTests: XCTestCase {
         XCTAssertEqual(CassandraClient.Error.unprepared("").category, .server)
         // internal (wrapper invariant)
         XCTAssertEqual(CassandraClient.Error.internalError("").category, .wrapperInternal)
-
-        XCTAssertEqual(CassandraClient.RequestLog.level(for: .transient), .debug)
-        XCTAssertEqual(CassandraClient.RequestLog.level(for: .unavailable), .warning)
-        XCTAssertEqual(CassandraClient.RequestLog.level(for: .callerFault), .warning)
-        XCTAssertEqual(CassandraClient.RequestLog.level(for: .server), .warning)
-        XCTAssertEqual(CassandraClient.RequestLog.level(for: .wrapperInternal), .error)
 
         // The category raw values are what a future metric tag reuses verbatim — pin them.
         XCTAssertEqual(CassandraClient.ErrorCategory.transient.rawValue, "transient")
@@ -72,12 +66,15 @@ final class RequestLoggingTests: XCTestCase {
         let entries = capture.all
         XCTAssertEqual(entries.count, 1)
         let entry = entries[0]
-        XCTAssertEqual(entry.level, .warning)  // callerFault -> .warning
+        XCTAssertEqual(entry.level, .debug)  // library convention — never warning/error
+        XCTAssertEqual(entry.message, "request failed")  // constant message, not the interpolated error
         XCTAssertEqual(entry.metadata[CassandraClient.LogKey.errorCategory], "callerFault")
         XCTAssertEqual(entry.metadata[CassandraClient.LogKey.query], "SELECT * FROM t WHERE id = ?")
-        XCTAssertEqual(entry.message, error.shortDescription)
-        // The server-provided message must NOT leak into the structured log field.
+        // The error rides swift-log's `error:` param, carrying only the code label — the server-provided
+        // message must NOT leak into the message or the error.
+        XCTAssertEqual(entry.error, error.shortDescription)
         XCTAssertFalse(entry.message.contains("SELET"))
+        XCTAssertFalse((entry.error ?? "").contains("SELET"))
     }
 
     /// Threshold 0 logs a slow record for a (>0 ms) success.
@@ -92,7 +89,7 @@ final class RequestLoggingTests: XCTestCase {
         )
         let entries = capture.all
         XCTAssertEqual(entries.count, 1)
-        XCTAssertEqual(entries[0].level, .info)
+        XCTAssertEqual(entries[0].level, .debug)
         XCTAssertEqual(entries[0].metadata[CassandraClient.LogKey.query], "SELECT 1")
         XCTAssertNotNil(entries[0].metadata[CassandraClient.LogKey.latencyMs])
     }
@@ -169,43 +166,5 @@ final class RequestLoggingTests: XCTestCase {
         let formatted = CassandraClient.RequestLog.formatValues([.string(long)])
         XCTAssertTrue(formatted.hasSuffix("…"))
         XCTAssertLessThanOrEqual(formatted.count, CassandraClient.Configuration.maxLoggedValueLength + 1)
-    }
-
-    /// Master switch (opt-in): with logging disabled, even a failure produces no record.
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func testMasterSwitchGatesLogging() {
-        // enabled: false -> a failure in the body is NOT logged
-        let (loggerOff, captureOff) = makeCapturingLogger()
-        let offDone = expectation(description: "off")
-        Task {
-            _ = try? await CassandraClient.RequestLog.instrumented(
-                enabled: false,
-                startedAt: DispatchTime.now(),
-                query: "q",
-                consistency: nil,
-                thresholdMillis: 0,
-                logger: loggerOff
-            ) { throw CassandraClient.Error.serverError("boom") }
-            offDone.fulfill()
-        }
-        wait(for: [offDone], timeout: 3)
-        XCTAssertTrue(captureOff.all.isEmpty, "master switch off should suppress all logging")
-
-        // enabled: true -> the failure IS logged
-        let (loggerOn, captureOn) = makeCapturingLogger()
-        let onDone = expectation(description: "on")
-        Task {
-            _ = try? await CassandraClient.RequestLog.instrumented(
-                enabled: true,
-                startedAt: DispatchTime.now(),
-                query: "q",
-                consistency: nil,
-                thresholdMillis: nil,
-                logger: loggerOn
-            ) { throw CassandraClient.Error.serverError("boom") }
-            onDone.fulfill()
-        }
-        wait(for: [onDone], timeout: 3)
-        XCTAssertEqual(captureOn.all.count, 1, "master switch on should emit the failure")
     }
 }

--- a/Tests/CassandraClientTests/TestLogCapture.swift
+++ b/Tests/CassandraClientTests/TestLogCapture.swift
@@ -22,6 +22,8 @@ final class TestLogCapture: @unchecked Sendable {
         let level: Logger.Level
         let message: String
         let metadata: Logger.Metadata
+        /// Stringified `LogEvent.error` (the swift-log `error:` param), if any.
+        let error: String?
     }
 
     private let lock = NSLock()
@@ -56,20 +58,20 @@ struct TestCapturingLogHandler: LogHandler {
         set { self.metadata[key] = newValue }
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    // Implements the event-based method so the `error:` param (`event.error`) is captured too.
+    func log(event: LogEvent) {
         var merged = self.metadata
-        if let metadata {
+        if let metadata = event.metadata {
             merged.merge(metadata) { _, new in new }
         }
-        self.capture.append(.init(level: level, message: "\(message)", metadata: merged))
+        self.capture.append(
+            .init(
+                level: event.level,
+                message: "\(event.message)",
+                metadata: merged,
+                error: event.error.map { "\($0)" }
+            )
+        )
     }
 }
 

--- a/Tests/CassandraClientTests/TestLogCapture.swift
+++ b/Tests/CassandraClientTests/TestLogCapture.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+
+/// Test-only capturing `LogHandler` — records emitted entries into a lock-protected buffer so tests can
+/// assert on level / message / metadata. Shared by the request-logging unit and integration tests.
+final class TestLogCapture: @unchecked Sendable {
+    struct Entry {
+        let level: Logger.Level
+        let message: String
+        let metadata: Logger.Metadata
+    }
+
+    private let lock = NSLock()
+    private var entries: [Entry] = []
+
+    func append(_ entry: Entry) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.entries.append(entry)
+    }
+
+    var all: [Entry] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.entries
+    }
+
+    func clear() {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.entries.removeAll()
+    }
+}
+
+struct TestCapturingLogHandler: LogHandler {
+    let capture: TestLogCapture
+    var logLevel: Logger.Level = .trace
+    var metadata: Logger.Metadata = [:]
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { self.metadata[key] }
+        set { self.metadata[key] = newValue }
+    }
+
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        var merged = self.metadata
+        if let metadata {
+            merged.merge(metadata) { _, new in new }
+        }
+        self.capture.append(.init(level: level, message: "\(message)", metadata: merged))
+    }
+}
+
+/// A `Logger` that records into a returned `TestLogCapture`.
+func makeCapturingLogger() -> (Logger, TestLogCapture) {
+    let capture = TestLogCapture()
+    var logger = Logger(label: "capture") { _ in TestCapturingLogHandler(capture: capture) }
+    logger.logLevel = .trace
+    return (logger, capture)
+}


### PR DESCRIPTION
### Motivation

Today the library logs almost nothing about request outcomes — a `.debug` breadcrumb on execute and a `.trace` dump of parameters, but no signal when a request fails or is slow. Operators have no visibility into failures or latency through their configured `swift-log` backend.

### Modifications

- New `Configuration.requestLoggingEnabled` master switch (default `false`) gates all of the below; nothing is logged unless explicitly enabled.
- Failures are logged once, at a level chosen by a total `CassandraClient.Error` category function (`transient`/`unavailable`/ `callerFault`/`server`/`internal`).
- New `Configuration.slowQueryThresholdMillis` (default `nil`) logs successful queries whose server round-trip latency exceeds the threshold, at `.info`.
- New `Configuration.logBoundValues` (default `false`) gates bound parameter values in request logs, and the pre-existing `.trace` parameter dump — bound values are potential PII.
- Logging covers all three failure exits: request completion (execute/prepare/batch, sync and async), connect (including cluster/SSL/contact-point setup, not just the driver connect call), and preflight/construction failures (e.g. parameter binding) that throw before a request is sent.
- Prepared statements now carry their original CQL text, so prepared-path logs show the real query instead of `"(prepared)"`.
- Adds a `logger` and a `requestLoggingEnabled` requirement to the public `CassandraSession` protocol (both with default implementations, so existing conformers are unaffected) so the shared query/execute/batch implementations can log using the session's configured logger and switch.

### Result

- Adds 15 new tests (9 unit, 6 integration) covering categorization, level mapping, PII gating, the master switch, connect-failure and preflight-failure logging, and prepared/batch query text in logs.
- Full existing suite (110 tests) passes unchanged.
- No source-breaking changes: new `Configuration` fields are defaulted and the `Configuration` initializer isn't memberwise; the two new `CassandraSession` requirements ship with default implementations.