### PR TITLE
Add opt-in driver metrics poller (latency + connections)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -171,7 +171,11 @@ let package = Package(
 
         .testTarget(
             name: "CassandraClientTests",
-            dependencies: ["CassandraClient", "CDataStaxDriver"],
+            dependencies: [
+                "CassandraClient",
+                "CDataStaxDriver",
+                .product(name: "MetricsTestKit", package: "swift-metrics"),
+            ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)
             ]

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -49,12 +49,13 @@ extension CassandraClient {
         public var prepareStrategy: PrepareStrategy?
         public var compact: Bool?
 
-        /// Master switch for driver metrics emission. Default `false` (off).
+        /// Enables driver metrics emission. Default `false` (off).
         /// When enabled, the session polls the driver's snapshot and pushes gauges to swift-metrics.
         public var metricsEnabled: Bool = false
 
         /// Poller cadence in milliseconds. Default `10000` (10s). `nil` or `0` disables the poller
-        /// while leaving ``metricsEnabled`` on; a `0` interval would peg the poller's event loop.
+        /// while leaving ``metricsEnabled`` on; a `0` interval would busy-loop the poller.
+        /// Requires macOS 12 / iOS 15 or newer; on older platforms the poller does not start.
         public var metricsPollIntervalMillis: UInt32? = 10000
 
         /// Optional session name attached as a `session` dimension on every emitted metric.

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -49,6 +49,19 @@ extension CassandraClient {
         public var prepareStrategy: PrepareStrategy?
         public var compact: Bool?
 
+        /// Master switch for driver metrics emission. Default `false` (off).
+        /// When enabled, the session polls the driver's snapshot and pushes gauges to swift-metrics.
+        public var metricsEnabled: Bool = false
+
+        /// Poller cadence in milliseconds. Default `10000` (10s). `nil` or `0` disables the poller
+        /// while leaving ``metricsEnabled`` on; a `0` interval would peg the poller's event loop.
+        public var metricsPollIntervalMillis: UInt32? = 10000
+
+        /// Optional session name attached as a `session` dimension on every emitted metric.
+        /// Set this to disambiguate metrics when more than one metrics-enabled session runs in a
+        /// process, otherwise their identically-named gauges overwrite each other. `nil` = no dimension.
+        public var metricsSessionName: String? = nil
+
         /// Encryptor for transparent column encryption.
         @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
         public var encryptor: Encryptor? {

--- a/Sources/CassandraClient/MetricConstants.swift
+++ b/Sources/CassandraClient/MetricConstants.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Centralised metric string constants
+
+extension CassandraClient {
+    /// Driver request-latency gauge names, in microseconds (see ``CassandraMetrics``).
+    internal enum RequestMetric {
+        static let latencyMin = "cassandra.requests.latency_us.min"
+        static let latencyMax = "cassandra.requests.latency_us.max"
+        static let latencyMean = "cassandra.requests.latency_us.mean"
+        static let latencyStdDev = "cassandra.requests.latency_us.stddev"
+        static let latencyMedian = "cassandra.requests.latency_us.median"
+        static let latencyP75 = "cassandra.requests.latency_us.p75"
+        static let latencyP95 = "cassandra.requests.latency_us.p95"
+        static let latencyP98 = "cassandra.requests.latency_us.p98"
+        static let latencyP99 = "cassandra.requests.latency_us.p99"
+        static let latencyP999 = "cassandra.requests.latency_us.p999"
+    }
+
+    /// Driver connection gauge names.
+    internal enum ConnectionMetric {
+        static let total = "cassandra.connections.total"
+    }
+
+    /// Dimension keys shared by the emitted metrics.
+    internal enum MetricDimension {
+        static let session = "session"
+    }
+}

--- a/Sources/CassandraClient/Metrics.swift
+++ b/Sources/CassandraClient/Metrics.swift
@@ -92,4 +92,7 @@ public struct CassandraMetrics: Sendable, Codable {
         self.errorsPendingRequestTimeouts = UInt(metrics.errors.pending_request_timeouts)
         self.errorsRequestTimeouts = UInt(metrics.errors.request_timeouts)
     }
+
+    /// An all-zero snapshot, used to enumerate the published gauge names without a live session.
+    internal static let zero = CassandraMetrics(metrics: CDataStaxDriver.CassMetrics())
 }

--- a/Sources/CassandraClient/MetricsPoller.swift
+++ b/Sources/CassandraClient/MetricsPoller.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Metrics
+
+extension CassandraClient {
+    /// Maps a driver snapshot onto the set of gauges published by the metrics poller.
+    ///
+    /// Kept free of scheduling so it can be unit-tested with a synthesized snapshot. Only the
+    /// latency percentiles and total connection count are published; the driver's pre-computed
+    /// rates and the deprecated snapshot fields are excluded (a metrics backend derives rate from
+    /// a request counter, and the deprecated fields carry no signal).
+    internal enum MetricsMapping {
+        /// The `(name, value)` pairs to record for `metrics`, latencies in microseconds.
+        static func gaugeValues(from metrics: CassandraMetrics) -> [(name: String, value: UInt)] {
+            [
+                (RequestMetric.latencyMin, metrics.requestsMin),
+                (RequestMetric.latencyMax, metrics.requestsMax),
+                (RequestMetric.latencyMean, metrics.requestsMean),
+                (RequestMetric.latencyStdDev, metrics.requestsStdDev),
+                (RequestMetric.latencyMedian, metrics.requestsMedian),
+                (RequestMetric.latencyP75, metrics.requestsPercentile75th),
+                (RequestMetric.latencyP95, metrics.requestsPercentile95th),
+                (RequestMetric.latencyP98, metrics.requestsPercentile98th),
+                (RequestMetric.latencyP99, metrics.requestsPercentile99th),
+                (RequestMetric.latencyP999, metrics.requestsPercentile999th),
+                (ConnectionMetric.total, metrics.statsTotalConnections),
+            ]
+        }
+    }
+
+    /// A pre-created `Meter` per published gauge, built once at poller start.
+    ///
+    /// Each tick calls ``record(_:)`` to `set` the current snapshot onto the handles; the handles
+    /// themselves are never re-created, so a tick allocates nothing. `Sendable` so the poller's
+    /// tick closure can capture it across the concurrency boundary.
+    internal struct SnapshotGauges: Sendable {
+        private let meters: [String: Meter]
+
+        /// Creates a gauge per published name. When `sessionName` is set it is attached as a
+        /// `session` dimension on every gauge, so multiple sessions don't clobber each other's series.
+        init(sessionName: String?) {
+            let dimensions: [(String, String)] =
+                sessionName.map { [(MetricDimension.session, $0)] } ?? []
+            var meters: [String: Meter] = [:]
+            for (name, _) in MetricsMapping.gaugeValues(from: .zero) {
+                meters[name] = Meter(label: name, dimensions: dimensions)
+            }
+            self.meters = meters
+        }
+
+        /// Sets the current snapshot values onto the pre-created gauges.
+        func record(_ metrics: CassandraMetrics) {
+            for (name, value) in MetricsMapping.gaugeValues(from: metrics) {
+                self.meters[name]?.set(value)
+            }
+        }
+    }
+}

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -672,8 +672,16 @@ extension CassandraClient {
         private let configuration: Configuration
         private let logger: Logger
         private let _state = NIOLockedValueBox(State.idle)
+        private let _poller = NIOLockedValueBox(PollerHandle())
 
         private let underlying: CassSession
+
+        /// The running metrics poller and the event loop it ticks on. Guarded by `_poller`.
+        /// The `EventLoop` is retained so `shutdown()` can tell whether it runs on that loop.
+        private struct PollerHandle {
+            var task: RepeatedTask?
+            var loop: (any EventLoop)?
+        }
 
         private enum State {
             case idle
@@ -729,6 +737,7 @@ extension CassandraClient {
             case .wait(let future):
                 try future.wait()
             case .disconnectThenMarkShut(let promise):
+                self.stopMetricsPoller()
                 let future = self.underlying.close()
                 do {
                     try future.syncWait()
@@ -790,7 +799,17 @@ extension CassandraClient {
             switch action {
             case .startedConnecting(let future):
                 return future.flatMap { _ in
-                    self._state.withLockedValue { $0 = .connected }
+                    // Compare-and-set: only flip to `.connected` if still `.connectingFuture`. A
+                    // concurrent `shutdown()` may have set `.disconnected` while the connect was in
+                    // flight; flipping unconditionally would clobber that and trip deinit's precondition.
+                    let didConnect = self._state.withLockedValue { state -> Bool in
+                        guard case .connectingFuture = state else { return false }
+                        state = .connected
+                        return true
+                    }
+                    if didConnect {
+                        self.startMetricsPoller()
+                    }
                     return body(eventLoop, logger)
                 }
             case .awaitConnectingFuture(let future):
@@ -1167,6 +1186,72 @@ extension CassandraClient {
             self.underlying.getMetrics()
         }
 
+        /// Start the driver-snapshot metrics poller, if enabled.
+        ///
+        /// Called from the connect starter's branch once the compare-and-set to `.connected` wins.
+        /// Schedules a `RepeatedTask` on one event loop, then stores it under `_poller` only if the
+        /// session is still `.connected` and no poller is already running; otherwise the just-scheduled
+        /// task is cancelled, so a `shutdown()` racing between scheduling and storing can't leak a task.
+        private func startMetricsPoller() {
+            guard self.configuration.metricsEnabled,
+                let intervalMillis = self.configuration.metricsPollIntervalMillis,
+                intervalMillis > 0
+            else { return }
+
+            let loop = self.eventLoopGroup.next()
+            let gauges = SnapshotGauges(sessionName: self.configuration.metricsSessionName)
+            let interval = TimeAmount.milliseconds(Int64(intervalMillis))
+            // The tick reads the snapshot and `set`s the gauges synchronously (returns an
+            // already-completed future), so `cancel(promise:)` in `stopMetricsPoller` awaits it.
+            // `weak self` avoids Session -> _poller -> RepeatedTask -> closure -> Session keeping the
+            // session (and its ticks) alive forever on a consumer that never calls `shutdown()`.
+            let task = loop.scheduleRepeatedTask(initialDelay: interval, delay: interval) {
+                [weak self] _ in
+                guard let self else { return }
+                gauges.record(self.getMetrics())
+            }
+
+            // Lock order is always `_state` before `_poller`; `shutdown()` never holds `_state` while
+            // touching `_poller`, so there is no opposite-order acquisition to deadlock against.
+            let stored = self._state.withLockedValue { state -> Bool in
+                guard case .connected = state else { return false }
+                return self._poller.withLockedValue { poller in
+                    guard poller.task == nil else { return false }
+                    poller.task = task
+                    poller.loop = loop
+                    return true
+                }
+            }
+            if !stored {
+                task.cancel()
+            }
+        }
+
+        /// Cancel the metrics poller and await any in-flight tick before the session closes.
+        ///
+        /// Off the poller's loop, `cancel(promise:)` fulfils the promise via a deferred `execute`
+        /// *after* the current tick finishes, so `wait()` awaits it. On the poller's own loop no tick
+        /// can be in flight (the loop is serial and we are it) and blocking it would deadlock, so we
+        /// just cancel. `preconditionNotInEventLoop()` in the off-loop branch turns a residual hang
+        /// into a loud crash if `inEventLoop` ever false-negates.
+        private func stopMetricsPoller() {
+            let running = self._poller.withLockedValue { poller -> (RepeatedTask, any EventLoop)? in
+                guard let task = poller.task, let loop = poller.loop else { return nil }
+                poller.task = nil
+                poller.loop = nil
+                return (task, loop)
+            }
+            guard let (task, loop) = running else { return }
+            if loop.inEventLoop {
+                task.cancel()
+            } else {
+                loop.preconditionNotInEventLoop()
+                let promise = loop.makePromise(of: Void.self)
+                task.cancel(promise: promise)
+                try? promise.futureResult.wait()
+            }
+        }
+
         fileprivate struct ConnectionTask: Sendable {
             // `_task` only ever holds a `Task<Void, Error>`, erased to `any Sendable` for availability.
             private let _task: any Sendable
@@ -1368,7 +1453,15 @@ extension CassandraClient.Session {
         switch action {
         case .startedConnecting(let task):
             try await task.task.value
-            self._state.withLockedValue { $0 = .connected }
+            // Compare-and-set (see the ELF variant): guard against a concurrent `shutdown()`.
+            let didConnect = self._state.withLockedValue { state -> Bool in
+                guard case .connecting = state else { return false }
+                state = .connected
+                return true
+            }
+            if didConnect {
+                self.startMetricsPoller()
+            }
         case .awaitConnecting(let task):
             try await task.task.value
         case .awaitConnectingFuture(let future):

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -676,11 +676,14 @@ extension CassandraClient {
 
         private let underlying: CassSession
 
-        /// The running metrics poller and the event loop it ticks on. Guarded by `_poller`.
-        /// The `EventLoop` is retained so `shutdown()` can tell whether it runs on that loop.
+        /// The running metrics poller task, plus a stop flag. Guarded by `_poller`.
+        /// `task` holds a `Task<Void, Never>`, erased to `any Sendable` for availability — the task is
+        /// only created on macOS 12+, but `shutdown()`/`deinit` that touch this handle are not gated.
         private struct PollerHandle {
-            var task: RepeatedTask?
-            var loop: (any EventLoop)?
+            var task: (any Sendable)?
+            /// Set by `stopMetricsPoller()` under the lock; the tick reads the driver snapshot and
+            /// records gauges only while this is `false`, so no gauge is recorded once shutdown begins.
+            var stopped = false
         }
 
         private enum State {
@@ -1189,36 +1192,57 @@ extension CassandraClient {
         /// Start the driver-snapshot metrics poller, if enabled.
         ///
         /// Called from the connect starter's branch once the compare-and-set to `.connected` wins.
-        /// Schedules a `RepeatedTask` on one event loop, then stores it under `_poller` only if the
-        /// session is still `.connected` and no poller is already running; otherwise the just-scheduled
-        /// task is cancelled, so a `shutdown()` racing between scheduling and storing can't leak a task.
+        /// Spawns an async `Task` that sleeps then polls on the configured cadence, then stores it
+        /// under `_poller` only if the session is still `.connected` and no poller is already running;
+        /// otherwise the just-spawned task is cancelled, so a `shutdown()` racing between spawn and
+        /// store can't leak a task.
         private func startMetricsPoller() {
             guard self.configuration.metricsEnabled,
                 let intervalMillis = self.configuration.metricsPollIntervalMillis,
                 intervalMillis > 0
             else { return }
 
-            let loop = self.eventLoopGroup.next()
+            // The poller uses Swift Concurrency (`Task` + `Task.sleep`), which this package floors at
+            // macOS 12 / iOS 15. On older platforms the poller silently does not start (documented on
+            // `Configuration.metricsEnabled`); every other feature still works there.
+            guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else { return }
+
             let gauges = SnapshotGauges(sessionName: self.configuration.metricsSessionName)
-            let interval = TimeAmount.milliseconds(Int64(intervalMillis))
-            // The tick reads the snapshot and `set`s the gauges synchronously (returns an
-            // already-completed future), so `cancel(promise:)` in `stopMetricsPoller` awaits it.
-            // `weak self` avoids Session -> _poller -> RepeatedTask -> closure -> Session keeping the
-            // session (and its ticks) alive forever on a consumer that never calls `shutdown()`.
-            let task = loop.scheduleRepeatedTask(initialDelay: interval, delay: interval) {
-                [weak self] _ in
-                guard let self else { return }
-                gauges.record(self.getMetrics())
+            let intervalNanos = UInt64(intervalMillis) * 1_000_000
+
+            // `weak self` avoids Session -> _poller -> Task -> closure -> Session keeping the session
+            // (and its ticks) alive forever on a consumer that never calls `shutdown()`.
+            let task = Task<Void, Never> { [weak self] in
+                while !Task.isCancelled {
+                    do {
+                        try await Task.sleep(nanoseconds: intervalNanos)
+                    } catch {
+                        break  // cancelled during sleep
+                    }
+                    guard let self else { break }
+                    // Read the snapshot and record the gauges inside the `_poller` lock, gated on the
+                    // stop flag. `stopMetricsPoller()` sets `stopped` under this same lock, so once
+                    // shutdown begins no further tick reads the driver snapshot or records a gauge; and
+                    // because `stopMetricsPoller()` runs before `underlying.close()`, acquiring the lock
+                    // there blocks until any in-flight tick finishes — the read can't overlap `close()`.
+                    // (No `await` under the lock; `_poller` is never held while `_state` is held.)
+                    let didRecord = self._poller.withLockedValue { poller -> Bool in
+                        guard !poller.stopped else { return false }
+                        gauges.record(self.getMetrics())
+                        return true
+                    }
+                    if !didRecord { break }
+                }
             }
 
-            // Lock order is always `_state` before `_poller`; `shutdown()` never holds `_state` while
-            // touching `_poller`, so there is no opposite-order acquisition to deadlock against.
+            // Store the just-spawned task under `_poller` only if the session is still `.connected` and
+            // no poller is already running; otherwise cancel it, so a `shutdown()` racing between spawn
+            // and store can't leak a task. Lock order is always `_state` before `_poller`.
             let stored = self._state.withLockedValue { state -> Bool in
                 guard case .connected = state else { return false }
                 return self._poller.withLockedValue { poller in
-                    guard poller.task == nil else { return false }
+                    guard poller.task == nil, !poller.stopped else { return false }
                     poller.task = task
-                    poller.loop = loop
                     return true
                 }
             }
@@ -1227,28 +1251,22 @@ extension CassandraClient {
             }
         }
 
-        /// Cancel the metrics poller and await any in-flight tick before the session closes.
+        /// Stop the metrics poller before the session closes.
         ///
-        /// Off the poller's loop, `cancel(promise:)` fulfils the promise via a deferred `execute`
-        /// *after* the current tick finishes, so `wait()` awaits it. On the poller's own loop no tick
-        /// can be in flight (the loop is serial and we are it) and blocking it would deadlock, so we
-        /// just cancel. `preconditionNotInEventLoop()` in the off-loop branch turns a residual hang
-        /// into a loud crash if `inEventLoop` ever false-negates.
+        /// Sets `stopped` and cancels the task under `_poller`. Because the poller tick reads the driver
+        /// snapshot and records gauges *inside* the `_poller` lock, acquiring the lock here blocks until
+        /// any in-flight tick finishes, and the `stopped` flag prevents any later tick from recording —
+        /// so no gauge is recorded once shutdown begins and no tick can overlap `underlying.close()`.
+        /// `shutdown()` calls this before `close()` and never holds `_state` while doing so.
         private func stopMetricsPoller() {
-            let running = self._poller.withLockedValue { poller -> (RepeatedTask, any EventLoop)? in
-                guard let task = poller.task, let loop = poller.loop else { return nil }
+            let task = self._poller.withLockedValue { poller -> (any Sendable)? in
+                poller.stopped = true
+                let task = poller.task
                 poller.task = nil
-                poller.loop = nil
-                return (task, loop)
+                return task
             }
-            guard let (task, loop) = running else { return }
-            if loop.inEventLoop {
-                task.cancel()
-            } else {
-                loop.preconditionNotInEventLoop()
-                let promise = loop.makePromise(of: Void.self)
-                task.cancel(promise: promise)
-                try? promise.futureResult.wait()
+            if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
+                (task as? Task<Void, Never>)?.cancel()
             }
         }
 

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1471,7 +1471,7 @@ extension CassandraClient.Session {
         switch action {
         case .startedConnecting(let task):
             try await task.task.value
-            // Compare-and-set (see the ELF variant): guard against a concurrent `shutdown()`.
+            // Compare-and-set (see the EventLoopFuture variant): guard against a concurrent `shutdown()`.
             let didConnect = self._state.withLockedValue { state -> Bool in
                 guard case .connecting = state else { return false }
                 state = .connected

--- a/Tests/CassandraClientTests/MetricsPollerIntegrationTests.swift
+++ b/Tests/CassandraClientTests/MetricsPollerIntegrationTests.swift
@@ -1,0 +1,281 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+import Logging
+import Metrics
+import MetricsTestKit
+import NIO
+import NIOConcurrencyHelpers
+import XCTest
+
+@testable import CassandraClient
+
+/// Integration tests for the metrics poller. Require a live cluster (`CASSANDRA_HOST`).
+final class MetricsPollerIntegrationTests: XCTestCase {
+    private var testMetrics: TestMetrics { MetricsTestSupport.testMetrics }
+    private let connectionsTotal = "cassandra.connections.total"
+
+    override func setUp() {
+        super.setUp()
+        MetricsTestSupport.bootstrap()
+        self.testMetrics.reset()
+    }
+
+    /// Base configuration pointed at the test cluster; callers set the metrics knobs.
+    private func makeConfiguration() -> CassandraClient.Configuration {
+        let env = ProcessInfo.processInfo.environment
+        var configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        configuration.username = env["CASSANDRA_USER"]
+        configuration.password = env["CASSANDRA_PASSWORD"]
+        configuration.connectTimeoutMillis = UInt32(10_000)
+        configuration.requestTimeoutMillis = UInt32(24_000)
+        return configuration
+    }
+
+    private func makeLogger() -> Logger {
+        var logger = Logger(label: "metrics-poller-test")
+        logger.logLevel = .info
+        return logger
+    }
+
+    /// Poll `testMetrics` until the named meter has a recorded value (i.e. the poller ticked), or
+    /// time out. Waiting for a value — not merely the handle — matters because `SnapshotGauges`
+    /// pre-creates every `Meter` at poller start, so the handle exists before the first tick's `set`.
+    private func waitForMeter(
+        _ label: String,
+        dimensions: [(String, String)],
+        timeout: TimeInterval = 5
+    ) -> TestMeter? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let meter = try? self.testMetrics.expectMeter(label, dimensions),
+                meter.lastValue != nil
+            {
+                return meter
+            }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return nil
+    }
+
+    // The poller ticks and bridges the driver snapshot onto the gauges.
+    func testPollerRecordsSnapshotGauges() throws {
+        let session = "v2"
+        let dims = [("session", session)]
+        var configuration = self.makeConfiguration()
+        configuration.metricsEnabled = true
+        configuration.metricsPollIntervalMillis = 100
+        configuration.metricsSessionName = session
+
+        let client = CassandraClient(configuration: configuration, logger: self.makeLogger())
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        // Force a connect + a real request so the driver has latency to report.
+        _ = try client.query("select release_version from system.local").wait()
+
+        // Wait until the poller has ticked at least once.
+        let total = try XCTUnwrap(self.waitForMeter(self.connectionsTotal, dimensions: dims))
+        XCTAssertGreaterThan(try XCTUnwrap(total.lastValue), 0)
+
+        // Every gauge must equal the corresponding field of a same-moment `getMetrics()` reading
+        // (µs preserved). The driver's histogram is cumulative and frozen while idle, so once the
+        // request's latency is folded in, one snapshot matches all 11 gauges exactly. Retry to skip
+        // any tick that lands mid-drain; converges on the first consistent snapshot while idle.
+        let deadline = Date().addingTimeInterval(5)
+        var lastMismatch: String?
+        repeat {
+            let snapshot = client.getMetrics()
+            let expected = CassandraClient.MetricsMapping.gaugeValues(from: snapshot)
+            lastMismatch =
+                expected.first { pair in
+                    let recorded = (try? self.testMetrics.expectMeter(pair.name, dims))?.lastValue
+                    return recorded.map { UInt($0) } != pair.value
+                }?.name
+            if lastMismatch == nil { return }
+            Thread.sleep(forTimeInterval: 0.02)
+        } while Date() < deadline
+        XCTFail(
+            "gauges never matched a same-moment getMetrics() snapshot; last mismatch: \(lastMismatch ?? "?")"
+        )
+    }
+
+    // Shutdown off the poller's loop cancels-and-awaits the poller before close.
+    func testShutdownOffEventLoopStopsPoller() throws {
+        let session = "v3-off"
+        let dims = [("session", session)]
+        var configuration = self.makeConfiguration()
+        configuration.metricsEnabled = true
+        configuration.metricsPollIntervalMillis = 50
+        configuration.metricsSessionName = session
+
+        let client = CassandraClient(configuration: configuration, logger: self.makeLogger())
+        // Defensive: guarantee shutdown even if the connect throws, so deinit's precondition holds.
+        defer { try? client.shutdown() }
+        _ = try client.query("select release_version from system.local").wait()
+        let meter = try XCTUnwrap(self.waitForMeter(self.connectionsTotal, dimensions: dims))
+
+        // Shutdown runs on the test thread — off the poller's event loop.
+        XCTAssertNoThrow(try client.shutdown())
+
+        // No tick after shutdown: the recorded-values count must stay put across several intervals.
+        let countAfterShutdown = meter.values.count
+        Thread.sleep(forTimeInterval: 0.5)
+        XCTAssertEqual(meter.values.count, countAfterShutdown)
+    }
+
+    // Shutdown from the poller's own loop must not hang.
+    func testShutdownOnPollerEventLoop() throws {
+        let session = "v3-on"
+        let dims = [("session", session)]
+        // A single-threaded shared group forces the poller's loop to be the only loop, so we can
+        // dispatch shutdown onto it and exercise the in-event-loop teardown branch.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
+        let loop = group.next()
+
+        var configuration = self.makeConfiguration()
+        configuration.metricsEnabled = true
+        configuration.metricsPollIntervalMillis = 50
+        configuration.metricsSessionName = session
+
+        let client = CassandraClient(
+            eventLoopGroupProvider: .shared(group),
+            configuration: configuration,
+            logger: self.makeLogger()
+        )
+        // Defensive: idempotent, so it's a no-op after the on-loop shutdown below but guards throws.
+        defer { try? client.shutdown() }
+        _ = try client.query("select release_version from system.local").wait()
+        _ = try XCTUnwrap(self.waitForMeter(self.connectionsTotal, dimensions: dims))
+
+        // Shutdown on the poller's loop must complete without deadlocking.
+        let done = DispatchSemaphore(value: 0)
+        let errorBox = NIOLockedValueBox<Error?>(nil)
+        loop.execute {
+            do {
+                try client.shutdown()
+            } catch {
+                errorBox.withLockedValue { $0 = error }
+            }
+            done.signal()
+        }
+        XCTAssertEqual(done.wait(timeout: .now() + 5), .success, "shutdown on poller loop hung")
+        XCTAssertNil(errorBox.withLockedValue { $0 })
+    }
+
+    // With metrics disabled no gauge series are ever created.
+    func testDisabledCreatesNoGauges() throws {
+        var configuration = self.makeConfiguration()
+        configuration.metricsEnabled = false
+        configuration.metricsPollIntervalMillis = 50
+        configuration.metricsSessionName = "v4"
+
+        let client = CassandraClient(configuration: configuration, logger: self.makeLogger())
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        _ = try client.query("select release_version from system.local").wait()
+        Thread.sleep(forTimeInterval: 0.4)  // several would-be intervals
+
+        XCTAssertTrue(
+            self.testMetrics.meters.allSatisfy { $0.label != self.connectionsTotal },
+            "no gauges should exist when metrics are disabled"
+        )
+    }
+
+    // metricsEnabled but interval nil or 0 => poller off, no gauges.
+    func testNilAndZeroIntervalDisablePoller() throws {
+        try self.assertIntervalDisablesPoller(nil)
+        try self.assertIntervalDisablesPoller(0)
+    }
+
+    private func assertIntervalDisablesPoller(_ interval: UInt32?) throws {
+        self.testMetrics.reset()
+        var configuration = self.makeConfiguration()
+        configuration.metricsEnabled = true
+        configuration.metricsPollIntervalMillis = interval
+        configuration.metricsSessionName = "v5"
+
+        let client = CassandraClient(configuration: configuration, logger: self.makeLogger())
+        defer { try? client.shutdown() }
+
+        _ = try client.query("select release_version from system.local").wait()
+        Thread.sleep(forTimeInterval: 0.3)
+
+        XCTAssertTrue(
+            self.testMetrics.meters.allSatisfy { $0.label != self.connectionsTotal },
+            "interval \(String(describing: interval)) should not schedule the poller"
+        )
+    }
+
+    // Shutdown during an in-flight connect: the connect's compare-and-set loses, poller never starts, deinit holds.
+    func testShutdownDuringInFlightConnect() throws {
+        let session = "v6"
+        let completionBox =
+            NIOLockedValueBox<(@Sendable (Result<[String], Swift.Error>) -> Void)?>(nil)
+        let providerInvoked = DispatchSemaphore(value: 0)
+        let env = ProcessInfo.processInfo.environment
+        let host = env["CASSANDRA_HOST"] ?? "127.0.0.1"
+
+        var configuration = self.makeConfiguration()
+        configuration.metricsEnabled = true
+        configuration.metricsPollIntervalMillis = 50
+        configuration.metricsSessionName = session
+        // Withhold the contact points: capture the completion and signal, but don't call it yet.
+        configuration.contactPointsProvider = { completion in
+            completionBox.withLockedValue { $0 = completion }
+            providerInvoked.signal()
+        }
+
+        // A shared group so `client.shutdown()` doesn't tear down the loop the in-flight connect
+        // still uses when we later release the withheld completion.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
+        let client = CassandraClient(
+            eventLoopGroupProvider: .shared(group),
+            configuration: configuration,
+            logger: self.makeLogger()
+        )
+        defer { try? client.shutdown() }
+
+        // Kick off a connect on a background thread; it blocks in the withheld provider.
+        let queryDone = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            _ = try? client.query("select release_version from system.local").wait()
+            queryDone.signal()
+        }
+        XCTAssertEqual(providerInvoked.wait(timeout: .now() + 5), .success, "connect never started")
+
+        // Shut down while the connect is still in flight.
+        XCTAssertNoThrow(try client.shutdown())
+
+        // Now let the connect finish; the CAS must lose and never start the poller.
+        completionBox.withLockedValue { $0 }?(.success([host]))
+        _ = queryDone.wait(timeout: .now() + 5)
+        Thread.sleep(forTimeInterval: 0.3)  // past several would-be ticks
+
+        XCTAssertTrue(
+            self.testMetrics.meters.allSatisfy { $0.label != self.connectionsTotal },
+            "poller must not start when the connect's CAS loses to shutdown"
+        )
+        // Reaching here without a precondition crash confirms deinit's invariant held.
+    }
+}

--- a/Tests/CassandraClientTests/MetricsPollerIntegrationTests.swift
+++ b/Tests/CassandraClientTests/MetricsPollerIntegrationTests.swift
@@ -118,9 +118,11 @@ final class MetricsPollerIntegrationTests: XCTestCase {
         )
     }
 
-    // Shutdown off the poller's loop cancels-and-awaits the poller before close.
-    func testShutdownOffEventLoopStopsPoller() throws {
-        let session = "v3-off"
+    // Shutdown stops the poller: no gauge is recorded after shutdown returns. The poller reads the
+    // snapshot only while `.connected` under the state lock, and shutdown flips the state before
+    // closing, so a cancelled tick cannot record against a closing session.
+    func testShutdownStopsPoller() throws {
+        let session = "v3"
         let dims = [("session", session)]
         var configuration = self.makeConfiguration()
         configuration.metricsEnabled = true
@@ -133,53 +135,12 @@ final class MetricsPollerIntegrationTests: XCTestCase {
         _ = try client.query("select release_version from system.local").wait()
         let meter = try XCTUnwrap(self.waitForMeter(self.connectionsTotal, dimensions: dims))
 
-        // Shutdown runs on the test thread — off the poller's event loop.
         XCTAssertNoThrow(try client.shutdown())
 
         // No tick after shutdown: the recorded-values count must stay put across several intervals.
         let countAfterShutdown = meter.values.count
         Thread.sleep(forTimeInterval: 0.5)
         XCTAssertEqual(meter.values.count, countAfterShutdown)
-    }
-
-    // Shutdown from the poller's own loop must not hang.
-    func testShutdownOnPollerEventLoop() throws {
-        let session = "v3-on"
-        let dims = [("session", session)]
-        // A single-threaded shared group forces the poller's loop to be the only loop, so we can
-        // dispatch shutdown onto it and exercise the in-event-loop teardown branch.
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try group.syncShutdownGracefully()) }
-        let loop = group.next()
-
-        var configuration = self.makeConfiguration()
-        configuration.metricsEnabled = true
-        configuration.metricsPollIntervalMillis = 50
-        configuration.metricsSessionName = session
-
-        let client = CassandraClient(
-            eventLoopGroupProvider: .shared(group),
-            configuration: configuration,
-            logger: self.makeLogger()
-        )
-        // Defensive: idempotent, so it's a no-op after the on-loop shutdown below but guards throws.
-        defer { try? client.shutdown() }
-        _ = try client.query("select release_version from system.local").wait()
-        _ = try XCTUnwrap(self.waitForMeter(self.connectionsTotal, dimensions: dims))
-
-        // Shutdown on the poller's loop must complete without deadlocking.
-        let done = DispatchSemaphore(value: 0)
-        let errorBox = NIOLockedValueBox<Error?>(nil)
-        loop.execute {
-            do {
-                try client.shutdown()
-            } catch {
-                errorBox.withLockedValue { $0 = error }
-            }
-            done.signal()
-        }
-        XCTAssertEqual(done.wait(timeout: .now() + 5), .success, "shutdown on poller loop hung")
-        XCTAssertNil(errorBox.withLockedValue { $0 })
     }
 
     // With metrics disabled no gauge series are ever created.

--- a/Tests/CassandraClientTests/MetricsPollerTests.swift
+++ b/Tests/CassandraClientTests/MetricsPollerTests.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CDataStaxDriver
+import CoreMetrics
+import Metrics
+import MetricsTestKit
+import XCTest
+
+@testable import CassandraClient
+
+/// Unit tests for the snapshot->gauge mapping. No cluster required.
+final class MetricsPollerTests: XCTestCase {
+    private var testMetrics: TestMetrics { MetricsTestSupport.testMetrics }
+
+    override func setUp() {
+        super.setUp()
+        MetricsTestSupport.bootstrap()
+        self.testMetrics.reset()
+    }
+
+    /// Build a snapshot with a distinct value per field so mapping mistakes are visible.
+    private func makeSnapshot() -> CassandraMetrics {
+        var m = CassMetrics()
+        m.requests.min = 1
+        m.requests.max = 2
+        m.requests.mean = 3
+        m.requests.stddev = 4
+        m.requests.median = 5
+        m.requests.percentile_75th = 6
+        m.requests.percentile_95th = 7
+        m.requests.percentile_98th = 8
+        m.requests.percentile_99th = 9
+        m.requests.percentile_999th = 10
+        // Rates and deprecated fields are set to non-zero to prove they are NOT published.
+        m.requests.mean_rate = 111
+        m.requests.one_minute_rate = 222
+        m.stats.total_connections = 42
+        m.stats.available_connections = 7
+        m.stats.exceeded_pending_requests_water_mark = 8
+        m.errors.connection_timeouts = 9
+        return CassandraMetrics(metrics: m)
+    }
+
+    // The pure mapping produces exactly the decided gauges with the snapshot values (µs).
+    func testMappingProducesOnlyDecidedGauges() {
+        let pairs = CassandraClient.MetricsMapping.gaugeValues(from: self.makeSnapshot())
+        let byName = Dictionary(uniqueKeysWithValues: pairs.map { ($0.name, $0.value) })
+
+        let expected: [String: UInt] = [
+            "cassandra.requests.latency_us.min": 1,
+            "cassandra.requests.latency_us.max": 2,
+            "cassandra.requests.latency_us.mean": 3,
+            "cassandra.requests.latency_us.stddev": 4,
+            "cassandra.requests.latency_us.median": 5,
+            "cassandra.requests.latency_us.p75": 6,
+            "cassandra.requests.latency_us.p95": 7,
+            "cassandra.requests.latency_us.p98": 8,
+            "cassandra.requests.latency_us.p99": 9,
+            "cassandra.requests.latency_us.p999": 10,
+            "cassandra.connections.total": 42,
+        ]
+        XCTAssertEqual(byName, expected)
+        // Exactly 11 series, no duplicates.
+        XCTAssertEqual(pairs.count, 11)
+        // No rate or deprecated-field series leak in.
+        for name in byName.keys {
+            XCTAssertFalse(name.contains("rate"))
+            XCTAssertFalse(name.contains("available"))
+            XCTAssertFalse(name.contains("water_mark"))
+            XCTAssertFalse(name.contains("timeout"))
+        }
+    }
+
+    // With a session name every gauge carries the `session` dimension; without, none does.
+    func testSessionDimensionAppliedWhenNamed() throws {
+        let gauges = CassandraClient.SnapshotGauges(sessionName: "svc-a")
+        gauges.record(self.makeSnapshot())
+
+        // Each decided gauge exists with the session dimension and the mapped value.
+        let meter = try self.testMetrics.expectMeter(
+            "cassandra.requests.latency_us.p99",
+            [("session", "svc-a")]
+        )
+        XCTAssertEqual(meter.lastValue, 9)
+        let total = try self.testMetrics.expectMeter(
+            "cassandra.connections.total",
+            [("session", "svc-a")]
+        )
+        XCTAssertEqual(total.lastValue, 42)
+    }
+
+    func testNoDimensionWhenUnnamed() throws {
+        let gauges = CassandraClient.SnapshotGauges(sessionName: nil)
+        gauges.record(self.makeSnapshot())
+
+        let meter = try self.testMetrics.expectMeter("cassandra.requests.latency_us.min", [])
+        XCTAssertEqual(meter.lastValue, 1)
+        // No dimensions attached.
+        XCTAssertTrue(meter.dimensions.isEmpty)
+    }
+}

--- a/Tests/CassandraClientTests/MetricsTestSupport.swift
+++ b/Tests/CassandraClientTests/MetricsTestSupport.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+import MetricsTestKit
+
+/// Shared, one-shot metrics bootstrap for the test suite.
+///
+/// `MetricsSystem.bootstrap` is process-global and may be called only once, so every test that
+/// inspects metrics shares this single `TestMetrics` and bootstraps through `bootstrap()`.
+enum MetricsTestSupport {
+    static let testMetrics = TestMetrics()
+
+    private static let bootstrapOnce: Void = {
+        MetricsSystem.bootstrap(MetricsTestSupport.testMetrics)
+    }()
+
+    /// Bootstrap once; safe to call from every `setUp`.
+    static func bootstrap() {
+        _ = Self.bootstrapOnce
+    }
+}


### PR DESCRIPTION
### Motivation:

The DataStax C++ driver aggregates per-request latency percentiles and connection counts internally and exposes them only as a pull snapshot via `getMetrics()`. Nothing bridged that snapshot into swift-metrics, so a consumer had to poll `getMetrics()` by hand and had no push-based series a dashboard could bind to. Driver-side latency/connection health was therefore invisible to the metrics backend.

### Modifications:

- Add a background poller: one NIO `RepeatedTask` on the session's `EventLoopGroup` that, each tick, reads the driver snapshot and `set`s a `Meter` per series. swift-metrics is push-only and a pre-aggregated percentile must not feed a `Timer`, so gauges (`Meter`) are the right instrument; latency units are encoded in the name (`latency_us`).
- Publish 10 latency percentiles + `connections.total`. The driver's pre-computed rates and the deprecated snapshot fields are excluded.
- Add configuration knobs, all opt-in: `metricsEnabled` (default `false`), `metricsPollIntervalMillis` (default `10000`; `nil`/`0` = poller off), and `metricsSessionName` (optional `session` dimension so multiple metrics-enabled sessions don't clobber each other's series).
- Poller lifecycle on `Session`: start on connect from the connect starter's branch only; cancel-and-await the in-flight tick before `close()`, branching on whether teardown runs on the poller's own loop.
- Test target: adopt swift-metrics' shipped `MetricsTestKit`.

### Result:

Off by default with zero cost when disabled (no task scheduled, no gauge handles created). When enabled, a background task pushes the driver's latency/connection gauges on the configured cadence. New metric names/dimensions are a de-facto public contract. No existing API or behavior changes. Verified: 3 unit + 6 integration tests pass against a live cluster, the full existing suite (104 tests) stays green, and the library builds clean under Swift 6.