### PR TITLE
Add client-side distributed tracing for async requests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,6 +106,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.12.0")),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "2.0.0")),
+        .package(url: "https://github.com/apple/swift-distributed-tracing", .upToNextMajor(from: "1.1.0")),
     ],
     targets: [
         .target(
@@ -166,6 +167,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
             ]
         ),
 
@@ -175,6 +177,9 @@ let package = Package(
                 "CassandraClient",
                 "CDataStaxDriver",
                 .product(name: "MetricsTestKit", package: "swift-metrics"),
+                // For the in-memory test tracer. Could instead rely on the transitive `Tracing` import (as the
+                // test target does for `Logging`); explicit here to keep the dependency obvious.
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Package.swift
+++ b/Package.swift
@@ -107,6 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/apple/swift-distributed-tracing", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/swift-otel/swift-otel-semantic-conventions", .upToNextMajor(from: "1.39.0")),
     ],
     targets: [
         .target(
@@ -168,6 +169,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .product(name: "OTelSemanticConventions", package: "swift-otel-semantic-conventions"),
             ]
         ),
 
@@ -177,9 +179,9 @@ let package = Package(
                 "CassandraClient",
                 "CDataStaxDriver",
                 .product(name: "MetricsTestKit", package: "swift-metrics"),
-                // For the in-memory test tracer. Could instead rely on the transitive `Tracing` import (as the
-                // test target does for `Logging`); explicit here to keep the dependency obvious.
+                // The tests bootstrap swift-distributed-tracing's shipped in-memory tracer.
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .product(name: "InMemoryTracing", package: "swift-distributed-tracing"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Sources/CassandraClient/RequestTracing.swift
+++ b/Sources/CassandraClient/RequestTracing.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+extension CassandraClient {
+    /// Shared request-tracing helper. Like ``RequestLog``, it holds no `Session` reference, so it is unit-testable
+    /// with an in-memory tracer and a synthesized error — no cluster.
+    internal enum RequestTrace {
+        /// Wrap an async request body in a `.client` span carrying the OpenTelemetry DB attributes, recording a
+        /// sanitized error status on throw, and rethrowing the original error unchanged.
+        ///
+        /// Uses a *manual* span (not the `withSpan` closure) deliberately: it avoids the operation-closure
+        /// `@Sendable` capture question for the non-`Sendable` `Statement`, and it avoids `withSpan`'s
+        /// auto-`recordError`, which would serialize the raw `Error.description` (the server message is PII).
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        static func traced<Value>(
+            _ operation: SpanName,
+            query: String?,
+            consistency: CassandraClient.Consistency?,
+            keyspace: String?,
+            _ body: () async throws -> Value
+        ) async throws -> Value {
+            var span = InstrumentationSystem.tracer.startAnySpan(operation.label, ofKind: .client)
+            defer { span.end() }
+
+            // Skip all attribute/string work when the span isn't recording (e.g. the NoOp tracer or a
+            // sampled-out span), so the disabled path stays cheap.
+            if span.isRecording {
+                span.attributes[TraceAttributeKey.system] = "cassandra"
+                span.attributes[TraceAttributeKey.operation] = operation.operation
+                if let query {
+                    span.attributes[TraceAttributeKey.queryText] = query
+                }
+                if let keyspace {
+                    span.attributes[TraceAttributeKey.namespace] = keyspace
+                }
+                if let consistency {
+                    span.attributes[TraceAttributeKey.consistencyLevel] = Self.otelToken(consistency)
+                }
+            }
+
+            do {
+                return try await body()
+            } catch {
+                if span.isRecording {
+                    // PII: never hand the raw error to the span — `Error.description` embeds the server message.
+                    // Set the status from the code label only, and tag the shared failure category
+                    // (`db.cassandra.error.category`).
+                    if let cassError = error as? CassandraClient.Error {
+                        span.setStatus(SpanStatus(code: .error, message: cassError.shortDescription))
+                        span.attributes[TraceAttributeKey.errorCategory] = cassError.category.rawValue
+                    } else {
+                        span.setStatus(SpanStatus(code: .error))
+                    }
+                }
+                throw error
+            }
+        }
+
+        /// Map a consistency level to its OpenTelemetry `db.cassandra.consistency_level` token. Kept here (not a
+        /// `CustomStringConvertible` on the public ``CassandraClient/Consistency``) and exhaustive, so a new
+        /// enum case can't silently emit a wrong string.
+        static func otelToken(_ consistency: CassandraClient.Consistency) -> String {
+            switch consistency {
+            case .any: return "any"
+            case .one: return "one"
+            case .two: return "two"
+            case .three: return "three"
+            case .quorum: return "quorum"
+            case .all: return "all"
+            case .localQuorum: return "local_quorum"
+            case .eachQuorum: return "each_quorum"
+            case .serial: return "serial"
+            case .localSerial: return "local_serial"
+            case .localOne: return "local_one"
+            }
+        }
+    }
+}

--- a/Sources/CassandraClient/RequestTracing.swift
+++ b/Sources/CassandraClient/RequestTracing.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import OTelSemanticConventions
 import Tracing
 
 extension CassandraClient {
@@ -19,11 +20,11 @@ extension CassandraClient {
     /// with an in-memory tracer and a synthesized error — no cluster.
     internal enum RequestTrace {
         /// Wrap an async request body in a `.client` span carrying the OpenTelemetry DB attributes, recording a
-        /// sanitized error status on throw, and rethrowing the original error unchanged.
+        /// sanitized error status on failure, and rethrowing the original error unchanged.
         ///
-        /// Uses a *manual* span (not the `withSpan` closure) deliberately: it avoids the operation-closure
-        /// `@Sendable` capture question for the non-`Sendable` `Statement`, and it avoids `withSpan`'s
-        /// auto-`recordError`, which would serialize the raw `Error.description` (the server message is PII).
+        /// The operation closure returns a `Result` rather than throwing so that `withSpan`'s built-in error
+        /// recording never runs — it would serialize the raw `Error.description`, which embeds the
+        /// server-provided message (PII). We record only the code label + shared category ourselves.
         @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
         static func traced<Value>(
             _ operation: SpanName,
@@ -32,46 +33,45 @@ extension CassandraClient {
             keyspace: String?,
             _ body: () async throws -> Value
         ) async throws -> Value {
-            var span = InstrumentationSystem.tracer.startAnySpan(operation.label, ofKind: .client)
-            defer { span.end() }
-
-            // Skip all attribute/string work when the span isn't recording (e.g. the NoOp tracer or a
-            // sampled-out span), so the disabled path stays cheap.
-            if span.isRecording {
-                span.attributes[TraceAttributeKey.system] = "cassandra"
-                span.attributes[TraceAttributeKey.operation] = operation.operation
-                if let query {
-                    span.attributes[TraceAttributeKey.queryText] = query
-                }
-                if let keyspace {
-                    span.attributes[TraceAttributeKey.namespace] = keyspace
-                }
-                if let consistency {
-                    span.attributes[TraceAttributeKey.consistencyLevel] = Self.otelToken(consistency)
-                }
-            }
-
-            do {
-                return try await body()
-            } catch {
+            // Use `withSpan` for span lifecycle + task-local context propagation. The operation closure
+            // returns a `Result` instead of throwing, so `withSpan`'s built-in error recording — which would
+            // serialize the raw `Error.description` (the server-provided message, PII) — never fires; we record
+            // a sanitized status ourselves and rethrow the original error to the caller.
+            let result: Result<Value, Swift.Error> = await withSpan(operation.label, ofKind: .client) { span in
                 if span.isRecording {
-                    // PII: never hand the raw error to the span — `Error.description` embeds the server message.
-                    // Set the status from the code label only, and tag the shared failure category
-                    // (`db.cassandra.error.category`).
-                    if let cassError = error as? CassandraClient.Error {
-                        span.setStatus(SpanStatus(code: .error, message: cassError.shortDescription))
-                        span.attributes[TraceAttributeKey.errorCategory] = cassError.category.rawValue
-                    } else {
-                        span.setStatus(SpanStatus(code: .error))
+                    span.attributes.db.system.name = .init(rawValue: "cassandra")
+                    span.attributes.db.operation.name = operation.operation
+                    if let query {
+                        span.attributes.db.query.text = query
+                    }
+                    if let keyspace {
+                        span.attributes.db.namespace = keyspace
+                    }
+                    if let consistency {
+                        span.attributes[TraceAttributeKey.consistencyLevel] = Self.otelToken(consistency)
                     }
                 }
-                throw error
+                do {
+                    return .success(try await body())
+                } catch {
+                    if span.isRecording {
+                        // PII: never hand the raw error to the span — `Error.description` embeds the server
+                        // message. Record the code label only, plus the shared failure category.
+                        if let cassError = error as? CassandraClient.Error {
+                            span.setStatus(SpanStatus(code: .error, message: cassError.shortDescription))
+                            span.attributes[TraceAttributeKey.errorCategory] = cassError.category.rawValue
+                        } else {
+                            span.setStatus(SpanStatus(code: .error))
+                        }
+                    }
+                    return .failure(error)
+                }
             }
+            return try result.get()
         }
 
-        /// Map a consistency level to its OpenTelemetry `db.cassandra.consistency_level` token. Kept here (not a
-        /// `CustomStringConvertible` on the public ``CassandraClient/Consistency``) and exhaustive, so a new
-        /// enum case can't silently emit a wrong string.
+        /// Map a consistency level to its OpenTelemetry `cassandra.consistency.level` token — exhaustive, so a
+        /// new ``CassandraClient/Consistency`` case can't silently emit a wrong string.
         static func otelToken(_ consistency: CassandraClient.Consistency) -> String {
             switch consistency {
             case .any: return "any"

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1661,15 +1661,22 @@ extension CassandraClient.Session {
                 self.configuration.logBoundValues
                 ? CassandraClient.RequestLog.formatValues(statement.parameters) : nil
             let startedAt = DispatchTime.now()
-            return try await CassandraClient.RequestLog.instrumented(
-                startedAt: startedAt,
+            return try await CassandraClient.RequestTrace.traced(
+                .execute,
                 query: query,
                 consistency: consistency,
-                thresholdMillis: self.configuration.slowQueryThresholdMillis,
-                boundValues: boundValues,
-                logger: logger
+                keyspace: self.configuration.keyspace
             ) {
-                try await self.underlying.execute(statement: statement).await()
+                try await CassandraClient.RequestLog.instrumented(
+                    startedAt: startedAt,
+                    query: query,
+                    consistency: consistency,
+                    thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                    boundValues: boundValues,
+                    logger: logger
+                ) {
+                    try await self.underlying.execute(statement: statement).await()
+                }
             }
         }
     }
@@ -1707,14 +1714,21 @@ extension CassandraClient.Session {
         try await self.withConnection(logger: logger) { logger in
             logger.debug("executing batch")
             let startedAt = DispatchTime.now()
-            try await CassandraClient.RequestLog.instrumented(
-                startedAt: startedAt,
+            try await CassandraClient.RequestTrace.traced(
+                .batch,
                 query: "batch",
                 consistency: nil,
-                thresholdMillis: self.configuration.slowQueryThresholdMillis,
-                logger: logger
+                keyspace: self.configuration.keyspace
             ) {
-                try await self.underlying.execute(batch: optionalBatch.take()!).await()
+                try await CassandraClient.RequestLog.instrumented(
+                    startedAt: startedAt,
+                    query: "batch",
+                    consistency: nil,
+                    thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                    logger: logger
+                ) {
+                    try await self.underlying.execute(batch: optionalBatch.take()!).await()
+                }
             }
         }
     }
@@ -1790,14 +1804,21 @@ extension CassandraClient.Session {
         let prepared: CassPrepared = try await self.withConnection(logger: logger) { logger in
             logger.debug("preparing: \(query)")
             let startedAt = DispatchTime.now()
-            return try await CassandraClient.RequestLog.instrumented(
-                startedAt: startedAt,
+            return try await CassandraClient.RequestTrace.traced(
+                .prepare,
                 query: query,
                 consistency: nil,
-                thresholdMillis: self.configuration.slowQueryThresholdMillis,
-                logger: logger
+                keyspace: self.configuration.keyspace
             ) {
-                try await self.underlying.prepare(query: query).await()
+                try await CassandraClient.RequestLog.instrumented(
+                    startedAt: startedAt,
+                    query: query,
+                    consistency: nil,
+                    thresholdMillis: self.configuration.slowQueryThresholdMillis,
+                    logger: logger
+                ) {
+                    try await self.underlying.prepare(query: query).await()
+                }
             }
         }
         let pkColumns: [String]

--- a/Sources/CassandraClient/TraceConstants.swift
+++ b/Sources/CassandraClient/TraceConstants.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Centralised tracing span-name and attribute-key constants
+
+extension CassandraClient {
+    /// Low-cardinality span operation names + their OpenTelemetry `db.operation.name` value. The span name
+    /// is the operation (never the query text) so trace backends can group requests.
+    internal enum SpanName {
+        case execute
+        case prepare
+        case batch
+
+        /// The span's display name (low cardinality).
+        var label: String {
+            switch self {
+            case .execute: return "Cassandra execute"
+            case .prepare: return "Cassandra prepare"
+            case .batch: return "Cassandra batch"
+            }
+        }
+
+        /// The `db.operation.name` attribute value.
+        var operation: String {
+            switch self {
+            case .execute: return "execute"
+            case .prepare: return "prepare"
+            case .batch: return "batch"
+            }
+        }
+    }
+
+    /// OpenTelemetry span attribute keys (frozen — a de-facto public contract; trace backends bind to them).
+    /// Target: the stabilized OpenTelemetry DB semantic conventions. Named `TraceAttributeKey` (not
+    /// `SpanAttributeKey`) to avoid confusion with `Tracing`'s own `SpanAttribute`/`SpanAttributes`.
+    internal enum TraceAttributeKey {
+        static let system = "db.system.name"
+        static let operation = "db.operation.name"
+        static let queryText = "db.query.text"
+        static let namespace = "db.namespace"
+        static let consistencyLevel = "db.cassandra.consistency_level"
+        /// Shared failure classification — the same concept logging emits as `request.errorCategory` and
+        /// metrics tag as `errorCategory`; value is the ``CassandraClient/Error`` category (`category.rawValue`).
+        static let errorCategory = "db.cassandra.error.category"
+    }
+}

--- a/Sources/CassandraClient/TraceConstants.swift
+++ b/Sources/CassandraClient/TraceConstants.swift
@@ -41,17 +41,14 @@ extension CassandraClient {
         }
     }
 
-    /// OpenTelemetry span attribute keys (frozen — a de-facto public contract; trace backends bind to them).
-    /// Target: the stabilized OpenTelemetry DB semantic conventions. Named `TraceAttributeKey` (not
-    /// `SpanAttributeKey`) to avoid confusion with `Tracing`'s own `SpanAttribute`/`SpanAttributes`.
+    /// Attribute keys not taken from swift-otel-semantic-conventions' stable `db.*` API. The Cassandra
+    /// (`cassandra.*`) attributes are gated behind that package's non-default `Experimental` trait (they're
+    /// UNSTABLE upstream), so we emit them as our own constants rather than depend on an experimental surface.
     internal enum TraceAttributeKey {
-        static let system = "db.system.name"
-        static let operation = "db.operation.name"
-        static let queryText = "db.query.text"
-        static let namespace = "db.namespace"
-        static let consistencyLevel = "db.cassandra.consistency_level"
+        /// Current OTel key (`db.cassandra.consistency_level` is deprecated upstream in favor of this).
+        static let consistencyLevel = "cassandra.consistency.level"
         /// Shared failure classification — the same concept logging emits as `request.errorCategory` and
         /// metrics tag as `errorCategory`; value is the ``CassandraClient/Error`` category (`category.rawValue`).
-        static let errorCategory = "db.cassandra.error.category"
+        static let errorCategory = "cassandra.error.category"
     }
 }

--- a/Tests/CassandraClientTests/TracingSupport.swift
+++ b/Tests/CassandraClientTests/TracingSupport.swift
@@ -1,0 +1,183 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Tracing
+
+// In-memory test tracer: swift-distributed-tracing ships no test tracer, so these tests provide one. It
+// captures each span's name / kind / attributes / status / recorded errors and its parent span id, so tests
+// can assert real parent-child linkage — not merely that a span exists.
+
+/// Parent-linkage key: the current span's id, carried in `ServiceContext` so a child span can find its parent.
+private enum TestSpanIDKey: ServiceContextKey {
+    typealias Value = Int
+}
+
+extension ServiceContext {
+    fileprivate var testSpanID: Int? {
+        get { self[TestSpanIDKey.self] }
+        set { self[TestSpanIDKey.self] = newValue }
+    }
+}
+
+/// A captured span — the immutable record a test asserts against.
+struct CapturedSpan {
+    let operationName: String
+    let kind: SpanKind
+    let spanID: Int
+    let parentSpanID: Int?
+    let attributes: [String: String]
+    let statusCode: SpanStatus.Code?
+    let statusMessage: String?
+    /// Stringified errors handed to `recordError` (should never contain the raw server message — see V2b).
+    let recordedErrors: [String]
+}
+
+/// Test span: accumulates state, and on `end()` flushes an immutable `CapturedSpan` into the tracer.
+final class TestSpan: Span, @unchecked Sendable {
+    var operationName: String
+    private let kind: SpanKind
+    private let spanID: Int
+    private let parentSpanID: Int?
+    private unowned let sink: TestTracer
+
+    private let lock = NSLock()
+    private var _attributes = SpanAttributes()
+    private var _status: SpanStatus?
+    private var _errors: [String] = []
+
+    var context: ServiceContext
+
+    init(operationName: String, kind: SpanKind, parent: ServiceContext, sink: TestTracer) {
+        self.operationName = operationName
+        self.kind = kind
+        self.spanID = sink.nextID()
+        self.parentSpanID = parent.testSpanID
+        self.sink = sink
+        var ctx = parent
+        ctx.testSpanID = self.spanID
+        self.context = ctx
+    }
+
+    var isRecording: Bool { true }
+
+    var attributes: SpanAttributes {
+        get { self.lock.withLock { self._attributes } }
+        set { self.lock.withLock { self._attributes = newValue } }
+    }
+
+    func setStatus(_ status: SpanStatus) {
+        self.lock.withLock { self._status = status }
+    }
+
+    func recordError(_ error: Error, attributes: SpanAttributes, at instant: @autoclosure () -> some TracerInstant) {
+        self.lock.withLock { self._errors.append("\(error)") }
+    }
+
+    func addEvent(_ event: SpanEvent) {}
+    func addLink(_ link: SpanLink) {}
+
+    func end(at instant: @autoclosure () -> some TracerInstant) {
+        let captured = self.lock.withLock {
+            CapturedSpan(
+                operationName: self.operationName,
+                kind: self.kind,
+                spanID: self.spanID,
+                parentSpanID: self.parentSpanID,
+                attributes: self._attributes.prettyStrings,
+                statusCode: self._status?.code,
+                statusMessage: self._status?.message,
+                recordedErrors: self._errors
+            )
+        }
+        self.sink.record(captured)
+    }
+}
+
+/// In-memory tracer: hands out `TestSpan`s and collects `CapturedSpan`s. Bootstrap once per process (guarded),
+/// `reset()` per test.
+final class TestTracer: Tracer, @unchecked Sendable {
+    private let lock = NSLock()
+    private var spans: [CapturedSpan] = []
+    private var counter = 0
+
+    func nextID() -> Int {
+        self.lock.withLock {
+            self.counter += 1
+            return self.counter
+        }
+    }
+
+    func record(_ span: CapturedSpan) {
+        self.lock.withLock { self.spans.append(span) }
+    }
+
+    /// All spans that have ended, in end order.
+    var recorded: [CapturedSpan] {
+        self.lock.withLock { self.spans }
+    }
+
+    func reset() {
+        self.lock.withLock { self.spans.removeAll() }
+    }
+
+    func startSpan(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> some TracerInstant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> TestSpan {
+        TestSpan(operationName: operationName, kind: kind, parent: context(), sink: self)
+    }
+
+    func forceFlush() {}
+
+    // Instrument conformance — no cross-process propagation needed for these tests.
+    func inject<Carrier, Inject>(_ context: ServiceContext, into carrier: inout Carrier, using injector: Inject)
+    where Inject: Injector, Carrier == Inject.Carrier {}
+
+    func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContext, using extractor: Extract)
+    where Extract: Extractor, Carrier == Extract.Carrier {}
+}
+
+extension SpanAttributes {
+    /// Flatten to `[key: stringValue]` for easy assertion (only string-valued attributes are read here).
+    fileprivate var prettyStrings: [String: String] {
+        var out: [String: String] = [:]
+        // `SpanAttributes` isn't a `Sequence`; this is its own `forEach`, so a for-in loop won't compile.
+        // swift-format-ignore: ReplaceForEachWithForLoop
+        self.forEach { name, attribute in
+            if case .string(let value) = attribute {
+                out[name] = value
+            }
+        }
+        return out
+    }
+}
+
+/// Bootstrap the shared `TestTracer` exactly once (process-global `InstrumentationSystem.bootstrap` is
+/// one-shot); every test uses this instance and calls `reset()` in `setUp`.
+enum SharedTestTracer {
+    static let instance = TestTracer()
+    private static let bootstrapOnce: Void = {
+        InstrumentationSystem.bootstrap(SharedTestTracer.instance)
+    }()
+
+    static func bootstrap() {
+        _ = Self.bootstrapOnce
+    }
+}

--- a/Tests/CassandraClientTests/TracingSupport.swift
+++ b/Tests/CassandraClientTests/TracingSupport.swift
@@ -13,150 +13,40 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import InMemoryTracing
 import Tracing
 
-// In-memory test tracer: swift-distributed-tracing ships no test tracer, so these tests provide one. It
-// captures each span's name / kind / attributes / status / recorded errors and its parent span id, so tests
-// can assert real parent-child linkage — not merely that a span exists.
+// Tests use swift-distributed-tracing's shipped `InMemoryTracer`. `CapturedSpan` is a thin read-model over its
+// finished spans so assertions read name / kind / attributes / status / parent linkage without unpacking
+// `SpanAttributes` at each call site.
 
-/// Parent-linkage key: the current span's id, carried in `ServiceContext` so a child span can find its parent.
-private enum TestSpanIDKey: ServiceContextKey {
-    typealias Value = Int
-}
-
-extension ServiceContext {
-    fileprivate var testSpanID: Int? {
-        get { self[TestSpanIDKey.self] }
-        set { self[TestSpanIDKey.self] = newValue }
-    }
-}
-
-/// A captured span — the immutable record a test asserts against.
+/// A finished in-memory span, flattened for assertions.
 struct CapturedSpan {
     let operationName: String
     let kind: SpanKind
-    let spanID: Int
-    let parentSpanID: Int?
+    let spanID: String
+    let parentSpanID: String?
     let attributes: [String: String]
     let statusCode: SpanStatus.Code?
     let statusMessage: String?
-    /// Stringified errors handed to `recordError` (should never contain the raw server message — see V2b).
+    /// Errors recorded on the span (should be empty — the tracing helper records status, not the raw error).
     let recordedErrors: [String]
-}
 
-/// Test span: accumulates state, and on `end()` flushes an immutable `CapturedSpan` into the tracer.
-final class TestSpan: Span, @unchecked Sendable {
-    var operationName: String
-    private let kind: SpanKind
-    private let spanID: Int
-    private let parentSpanID: Int?
-    private unowned let sink: TestTracer
-
-    private let lock = NSLock()
-    private var _attributes = SpanAttributes()
-    private var _status: SpanStatus?
-    private var _errors: [String] = []
-
-    var context: ServiceContext
-
-    init(operationName: String, kind: SpanKind, parent: ServiceContext, sink: TestTracer) {
-        self.operationName = operationName
-        self.kind = kind
-        self.spanID = sink.nextID()
-        self.parentSpanID = parent.testSpanID
-        self.sink = sink
-        var ctx = parent
-        ctx.testSpanID = self.spanID
-        self.context = ctx
+    init(_ span: FinishedInMemorySpan) {
+        self.operationName = span.operationName
+        self.kind = span.kind
+        self.spanID = span.spanID
+        self.parentSpanID = span.parentSpanID
+        self.attributes = span.attributes.stringValues
+        self.statusCode = span.status?.code
+        self.statusMessage = span.status?.message
+        self.recordedErrors = span.errors.map { "\($0.error)" }
     }
-
-    var isRecording: Bool { true }
-
-    var attributes: SpanAttributes {
-        get { self.lock.withLock { self._attributes } }
-        set { self.lock.withLock { self._attributes = newValue } }
-    }
-
-    func setStatus(_ status: SpanStatus) {
-        self.lock.withLock { self._status = status }
-    }
-
-    func recordError(_ error: Error, attributes: SpanAttributes, at instant: @autoclosure () -> some TracerInstant) {
-        self.lock.withLock { self._errors.append("\(error)") }
-    }
-
-    func addEvent(_ event: SpanEvent) {}
-    func addLink(_ link: SpanLink) {}
-
-    func end(at instant: @autoclosure () -> some TracerInstant) {
-        let captured = self.lock.withLock {
-            CapturedSpan(
-                operationName: self.operationName,
-                kind: self.kind,
-                spanID: self.spanID,
-                parentSpanID: self.parentSpanID,
-                attributes: self._attributes.prettyStrings,
-                statusCode: self._status?.code,
-                statusMessage: self._status?.message,
-                recordedErrors: self._errors
-            )
-        }
-        self.sink.record(captured)
-    }
-}
-
-/// In-memory tracer: hands out `TestSpan`s and collects `CapturedSpan`s. Bootstrap once per process (guarded),
-/// `reset()` per test.
-final class TestTracer: Tracer, @unchecked Sendable {
-    private let lock = NSLock()
-    private var spans: [CapturedSpan] = []
-    private var counter = 0
-
-    func nextID() -> Int {
-        self.lock.withLock {
-            self.counter += 1
-            return self.counter
-        }
-    }
-
-    func record(_ span: CapturedSpan) {
-        self.lock.withLock { self.spans.append(span) }
-    }
-
-    /// All spans that have ended, in end order.
-    var recorded: [CapturedSpan] {
-        self.lock.withLock { self.spans }
-    }
-
-    func reset() {
-        self.lock.withLock { self.spans.removeAll() }
-    }
-
-    func startSpan(
-        _ operationName: String,
-        context: @autoclosure () -> ServiceContext,
-        ofKind kind: SpanKind,
-        at instant: @autoclosure () -> some TracerInstant,
-        function: String,
-        file fileID: String,
-        line: UInt
-    ) -> TestSpan {
-        TestSpan(operationName: operationName, kind: kind, parent: context(), sink: self)
-    }
-
-    func forceFlush() {}
-
-    // Instrument conformance — no cross-process propagation needed for these tests.
-    func inject<Carrier, Inject>(_ context: ServiceContext, into carrier: inout Carrier, using injector: Inject)
-    where Inject: Injector, Carrier == Inject.Carrier {}
-
-    func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContext, using extractor: Extract)
-    where Extract: Extractor, Carrier == Extract.Carrier {}
 }
 
 extension SpanAttributes {
-    /// Flatten to `[key: stringValue]` for easy assertion (only string-valued attributes are read here).
-    fileprivate var prettyStrings: [String: String] {
+    /// Flatten string-valued attributes to `[key: value]` for assertions.
+    fileprivate var stringValues: [String: String] {
         var out: [String: String] = [:]
         // `SpanAttributes` isn't a `Sequence`; this is its own `forEach`, so a for-in loop won't compile.
         // swift-format-ignore: ReplaceForEachWithForLoop
@@ -169,15 +59,22 @@ extension SpanAttributes {
     }
 }
 
-/// Bootstrap the shared `TestTracer` exactly once (process-global `InstrumentationSystem.bootstrap` is
-/// one-shot); every test uses this instance and calls `reset()` in `setUp`.
+/// Bootstraps the shipped `InMemoryTracer` exactly once (process-global `InstrumentationSystem.bootstrap` is
+/// one-shot); every test reads finished spans through `instance` and calls `reset()` in `setUp`.
 enum SharedTestTracer {
-    static let instance = TestTracer()
+    static let instance = Recorder()
     private static let bootstrapOnce: Void = {
-        InstrumentationSystem.bootstrap(SharedTestTracer.instance)
+        InstrumentationSystem.bootstrap(instance.tracer)
     }()
 
     static func bootstrap() {
         _ = Self.bootstrapOnce
+    }
+
+    /// Thin accessor around the shipped `InMemoryTracer`, exposing finished spans as `CapturedSpan`s.
+    final class Recorder {
+        let tracer = InMemoryTracer()
+        var recorded: [CapturedSpan] { self.tracer.finishedSpans.map(CapturedSpan.init) }
+        func reset() { self.tracer.clearAll(includingActive: true) }
     }
 }

--- a/Tests/CassandraClientTests/TracingTests.swift
+++ b/Tests/CassandraClientTests/TracingTests.swift
@@ -1,0 +1,582 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Tracing
+import XCTest
+
+@testable import CassandraClient
+
+// Tracing tests: client-side span behaviour for the async execute / prepare / batch path.
+//
+// Prerequisites for a green run:
+//  1. The failure attribute key is asserted as `db.cassandra.error.category` (the same "errorCategory"
+//     concept logging emits as `request.errorCategory` and metrics tag as `errorCategory`; value is
+//     `Error.category.rawValue`). The tracing helper must emit that key, not `error.type`.
+//  2. `swift-distributed-tracing` must resolve so `RequestTrace` and the in-memory tracer
+//     (`TracingSupport.swift`) compile; a few API spellings there are provisional.
+//  3. Integration tests need a live cluster:  CASSANDRA_HOST=<host> swift test --filter TracingIntegrationTests
+//
+// The in-memory `TestTracer` is bootstrapped once (process-global, one-shot) and `reset()` per test; span
+// captures therefore require serial in-process execution.
+
+// MARK: - Unit (no cluster) — deterministic, load-bearing
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class TracingUnitTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        SharedTestTracer.bootstrap()
+        SharedTestTracer.instance.reset()
+    }
+
+    /// V0 — the builder derives exactly the frozen attributes from its inputs (not a hardcoded dict).
+    func testV0_builderDerivesFrozenAttributesFromInputs() {
+        runAsyncAndWaitFor {
+            try await CassandraClient.RequestTrace.traced(
+                .execute,
+                query: "SELECT id FROM t WHERE id = ?",
+                consistency: .localOne,
+                keyspace: "shop"
+            ) {
+                // no-op body — assertions below are on what the builder derived from the inputs above
+            }
+
+            let spans = SharedTestTracer.instance.recorded
+            XCTAssertEqual(spans.count, 1)
+            let span = try XCTUnwrap(spans.first)
+            XCTAssertEqual(span.operationName, "Cassandra execute")
+            XCTAssertEqual(span.kind, .client)
+            XCTAssertEqual(span.attributes["db.system.name"], "cassandra")
+            XCTAssertEqual(span.attributes["db.operation.name"], "execute")
+            XCTAssertEqual(span.attributes["db.query.text"], "SELECT id FROM t WHERE id = ?")
+            XCTAssertEqual(span.attributes["db.namespace"], "shop")
+            XCTAssertEqual(span.attributes["db.cassandra.consistency_level"], "local_one")
+            // Bound values are never attached; a success carries no error status/category.
+            XCTAssertNil(span.attributes["db.query.parameters"])
+            XCTAssertNil(span.statusCode)
+            XCTAssertNil(span.attributes["db.cassandra.error.category"])
+        }
+    }
+
+    /// V0b — an unresolved consistency (and unset keyspace) is omitted, not fabricated.
+    func testV0b_consistencyAndNamespaceOmittedWhenNil() {
+        runAsyncAndWaitFor {
+            try await CassandraClient.RequestTrace.traced(
+                .prepare,
+                query: "SELECT 1",
+                consistency: nil,
+                keyspace: nil
+            ) {}
+
+            let span = try XCTUnwrap(SharedTestTracer.instance.recorded.first)
+            XCTAssertEqual(span.attributes["db.operation.name"], "prepare")
+            XCTAssertNil(span.attributes["db.cassandra.consistency_level"], "omit, do not fabricate 'default'")
+            XCTAssertNil(span.attributes["db.namespace"])
+        }
+    }
+
+    /// The consistency -> OpenTelemetry-token mapping is exhaustive and correct (guards the frozen contract).
+    func testConsistencyTokenMappingIsExhaustiveAndCorrect() {
+        let expected: [(CassandraClient.Consistency, String)] = [
+            (.any, "any"), (.one, "one"), (.two, "two"), (.three, "three"),
+            (.quorum, "quorum"), (.all, "all"), (.localQuorum, "local_quorum"),
+            (.eachQuorum, "each_quorum"), (.serial, "serial"), (.localSerial, "local_serial"),
+            (.localOne, "local_one"),
+        ]
+        for (consistency, token) in expected {
+            XCTAssertEqual(CassandraClient.RequestTrace.otelToken(consistency), token)
+        }
+    }
+
+    /// V2 (unit slice, + error-identity) — a `CassandraClient.Error` failure records `.error` status and the
+    /// shared category, carries no server text, and rethrows the original error unchanged.
+    func testV2_failureRecordsSanitizedCategoryAndRethrowsUnchanged() {
+        runAsyncAndWaitFor {
+            let thrown = CassandraClient.Error.serverError("secret keyspace 'pii' does not exist")
+            var caught: Error?
+            do {
+                try await CassandraClient.RequestTrace.traced(
+                    .execute,
+                    query: "SELECT 1",
+                    consistency: .one,
+                    keyspace: "k"
+                ) {
+                    throw thrown
+                }
+                XCTFail("expected the body to throw")
+            } catch {
+                caught = error
+            }
+
+            // Observation-only: the original error propagates unchanged (`Error` is Equatable).
+            XCTAssertEqual(caught as? CassandraClient.Error, thrown)
+
+            let span = try XCTUnwrap(SharedTestTracer.instance.recorded.first)
+            XCTAssertEqual(span.statusCode, .error)
+            XCTAssertEqual(span.attributes["db.cassandra.error.category"], thrown.category.rawValue)
+            // PII: neither the status message nor any recorded error may carry the server text.
+            XCTAssertEqual(span.statusMessage, thrown.shortDescription)
+            XCTAssertFalse((span.statusMessage ?? "").contains("secret keyspace"))
+            XCTAssertFalse(span.recordedErrors.contains { $0.contains("secret keyspace") })
+        }
+    }
+
+    /// A5 — a non-`CassandraClient.Error` failure sets `.error` status with no category and no message
+    /// (no PII surface), and rethrows unchanged. Covers the helper's non-Cassandra error branch.
+    func testA5_nonCassandraErrorSetsErrorStatusWithoutCategoryOrMessage() {
+        runAsyncAndWaitFor {
+            struct Boom: Error {}
+            var caught: Error?
+            do {
+                try await CassandraClient.RequestTrace.traced(
+                    .execute,
+                    query: "SELECT 1",
+                    consistency: .one,
+                    keyspace: "k"
+                ) {
+                    throw Boom()
+                }
+                XCTFail("expected the body to throw")
+            } catch {
+                caught = error
+            }
+
+            XCTAssertTrue(caught is Boom, "the original non-Cassandra error is rethrown unchanged")
+            let span = try XCTUnwrap(SharedTestTracer.instance.recorded.first)
+            XCTAssertEqual(span.statusCode, .error)
+            XCTAssertNil(span.attributes["db.cassandra.error.category"], "no category for a non-Cassandra error")
+            XCTAssertNil(span.statusMessage, "no message set for a non-Cassandra error")
+        }
+    }
+}
+
+// MARK: - Integration (live cluster) — CASSANDRA_HOST=<host> swift test --filter TracingIntegrationTests
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class TracingIntegrationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        SharedTestTracer.bootstrap()
+        SharedTestTracer.instance.reset()
+    }
+
+    private func makeConfig() -> CassandraClient.Configuration {
+        let env = ProcessInfo.processInfo.environment
+        var config = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        config.username = env["CASSANDRA_USER"]
+        config.password = env["CASSANDRA_PASSWORD"]
+        config.keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        config.requestTimeoutMillis = 24_000
+        config.connectTimeoutMillis = 10_000
+        return config
+    }
+
+    private func createKeyspaceAndTable(
+        _ client: CassandraClient,
+        keyspace: String,
+        table: String,
+        schema: String
+    ) async throws {
+        try await client.withSession(keyspace: .none) { session in
+            try await session.run(
+                "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+            )
+        }
+        let session = client.makeSession(keyspace: keyspace)
+        defer { try? session.shutdown() }
+        try await session.run("create table \(keyspace).\(table) \(schema)")
+    }
+
+    private func spans(named name: String) -> [CapturedSpan] {
+        SharedTestTracer.instance.recorded.filter { $0.operationName == name }
+    }
+
+    private var executeSpans: [CapturedSpan] { self.spans(named: "Cassandra execute") }
+
+    /// V1 (+ positive control for V7) — a successful query emits exactly one `.client` "Cassandra execute"
+    /// span with the frozen attributes and no error status.
+    func testV1_successEmitsOneClientExecuteSpan() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+
+                SharedTestTracer.instance.reset()
+                try await client.withSession(keyspace: .none) { session in
+                    _ = try await session.query("select release_version from system.local")
+                }
+
+                XCTAssertEqual(self.executeSpans.count, 1, "exactly one execute span (delta control for V7)")
+                let span = try XCTUnwrap(self.executeSpans.first)
+                XCTAssertEqual(span.kind, .client)
+                XCTAssertEqual(span.attributes["db.system.name"], "cassandra")
+                XCTAssertEqual(span.attributes["db.operation.name"], "execute")
+                XCTAssertEqual(span.attributes["db.query.text"], "select release_version from system.local")
+                XCTAssertNil(span.statusCode, "success -> no error status")
+            },
+            30.0
+        )
+    }
+
+    /// V2b — a server-side syntax error records `.error` + the shared `callerFault` category, and the server
+    /// text / offending query never lands on the span.
+    func testV2b_serverErrorRecordsCategoryWithoutServerText() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+
+                SharedTestTracer.instance.reset()
+                do {
+                    try await client.withSession(keyspace: .none) { session in
+                        _ = try await session.query("SELCT bad syntax from system.local")  // deliberate syntax error
+                    }
+                    XCTFail("expected a syntax error")
+                } catch {
+                    // expected
+                }
+
+                let span = try XCTUnwrap(self.executeSpans.first)
+                XCTAssertEqual(span.statusCode, .error)
+                XCTAssertEqual(
+                    span.attributes["db.cassandra.error.category"],
+                    "callerFault",
+                    "syntax error -> callerFault via the shared categoriser"
+                )
+                // PII: the offending query text must not be echoed onto the span.
+                XCTAssertNotNil(span.statusMessage)
+                XCTAssertFalse((span.statusMessage ?? "").contains("SELCT"))
+                XCTAssertFalse(span.recordedErrors.contains { $0.contains("SELCT") })
+            },
+            30.0
+        )
+    }
+
+    /// V3 — the request span is a child of the caller's span (task-local `ServiceContext` propagation).
+    /// Depends on the helper opening the span with `context: .current`; if parenting fails here, the helper
+    /// must pass `.current` explicitly.
+    func testV3_executeSpanParentsToCallerSpan() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+
+                SharedTestTracer.instance.reset()
+                try await withSpan("caller") { _ in
+                    try await client.withSession(keyspace: .none) { session in
+                        _ = try await session.query("select release_version from system.local")
+                    }
+                }
+
+                let caller = try XCTUnwrap(self.spans(named: "caller").first)
+                let execute = try XCTUnwrap(self.executeSpans.first)
+                XCTAssertEqual(execute.parentSpanID, caller.spanID, "execute span must parent to the caller span")
+            },
+            30.0
+        )
+    }
+
+    // V4 (no-tracer / NoOp safety) is intentionally not an in-suite test: `InstrumentationSystem.bootstrap`
+    // is process-global and one-shot, so once the capturing tracer is installed a genuine `NoOpTracer` default
+    // is unreachable in this process. The baseline (non-tracing) suites already exercise every query path with
+    // no tracer bootstrapped; a real NoOp assertion would need a dedicated non-bootstrapping test target.
+
+    /// V5 — direct `nextPage()` x N emits one execute span per fetched page.
+    func testV5_directNextPageEmitsOneSpanPerPage() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+                let keyspace = self.makeConfig().keyspace!
+                let table = "trace_v5_\(DispatchTime.now().uptimeNanoseconds)"
+                try await self.createKeyspaceAndTable(
+                    client,
+                    keyspace: keyspace,
+                    table: table,
+                    schema: "(id int primary key)"
+                )
+                let session = client.makeSession(keyspace: keyspace)
+                defer { try? session.shutdown() }
+                for i in 0..<3 { try await session.run("insert into \(table) (id) values (\(i));") }
+
+                SharedTestTracer.instance.reset()
+                let paginated = try await session.query("select id from \(table);", pageSize: Int32(1))
+                for _ in 0..<3 {
+                    _ = try await paginated.nextPage()
+                }
+
+                XCTAssertEqual(self.executeSpans.count, 3, "one execute span per fetched page")
+            },
+            30.0
+        )
+    }
+
+    /// V5b — pages fetched through the `for await` iterator (built inside an unstructured `Task {}`) parent to
+    /// the caller's span.
+    func testV5b_forAwaitPagesParentToCallerSpan() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+                let keyspace = self.makeConfig().keyspace!
+                let table = "trace_v5b_\(DispatchTime.now().uptimeNanoseconds)"
+                try await self.createKeyspaceAndTable(
+                    client,
+                    keyspace: keyspace,
+                    table: table,
+                    schema: "(id int primary key)"
+                )
+                let session = client.makeSession(keyspace: keyspace)
+                defer { try? session.shutdown() }
+                for i in 0..<3 { try await session.run("insert into \(table) (id) values (\(i));") }
+
+                SharedTestTracer.instance.reset()
+                try await withSpan("caller") { _ in
+                    // Iterate inline in the caller's span scope so the iterator's Task {} inherits `.current`.
+                    let paginated = try await session.query("select id from \(table);", pageSize: Int32(1))
+                    var seen = 0
+                    for try await _ in paginated { seen += 1 }
+                    XCTAssertEqual(seen, 3)
+                }
+
+                let caller = try XCTUnwrap(self.spans(named: "caller").first)
+                let pages = self.executeSpans
+                XCTAssertFalse(pages.isEmpty, "for-await should fetch pages via execute spans")
+                for page in pages {
+                    XCTAssertEqual(
+                        page.parentSpanID,
+                        caller.spanID,
+                        "each page span must parent to the caller span through the Task {}"
+                    )
+                }
+            },
+            30.0
+        )
+    }
+
+    /// V6 (+ prepare-span attributes, + no double-span) — a statement prepared by the real prepare path shows
+    /// the real CQL on the EXECUTE span (not "(prepared)"), and `execute(prepared:)` yields exactly one span.
+    func testV6_preparedExecuteShowsRealCQLAndYieldsOneSpan() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+                let keyspace = self.makeConfig().keyspace!
+                let table = "trace_v6_\(DispatchTime.now().uptimeNanoseconds)"
+                try await self.createKeyspaceAndTable(
+                    client,
+                    keyspace: keyspace,
+                    table: table,
+                    schema: "(id bigint primary key, v text)"
+                )
+                let session = client.makeSession(keyspace: keyspace)
+                defer { try? session.shutdown() }
+
+                let cql = "insert into \(table) (id, v) values (?, ?)"
+
+                // The prepare site opens a "Cassandra prepare" span carrying the real CQL, .client, no consistency.
+                SharedTestTracer.instance.reset()
+                let prepared = try await session.prepare(cql)
+                let prepareSpan = try XCTUnwrap(self.spans(named: "Cassandra prepare").first)
+                XCTAssertEqual(prepareSpan.kind, .client)
+                XCTAssertEqual(prepareSpan.attributes["db.operation.name"], "prepare")
+                XCTAssertEqual(prepareSpan.attributes["db.query.text"], cql)
+                XCTAssertNil(prepareSpan.attributes["db.cassandra.consistency_level"])
+
+                // Executing the prepared statement: the EXECUTE span shows real CQL, and there is exactly one.
+                SharedTestTracer.instance.reset()
+                _ = try await session.execute(prepared: prepared, parameters: [.int64(1), .string("x")])
+                XCTAssertEqual(
+                    self.executeSpans.count,
+                    1,
+                    "execute(prepared:) delegates to execute(statement:) — one span, not two"
+                )
+                let execute = try XCTUnwrap(self.executeSpans.first)
+                XCTAssertEqual(execute.attributes["db.query.text"], cql)
+                XCTAssertNotEqual(execute.attributes["db.query.text"], "(prepared)")
+            },
+            30.0
+        )
+    }
+
+    /// V7 — connect fails => NO execute span (the span opens post-connect). Negative arm of the V1 delta.
+    /// Uses an unroutable host; needs no live cluster.
+    func testV7_noExecuteSpanWhenConnectFails() {
+        runAsyncAndWaitFor(
+            {
+                var config = CassandraClient.Configuration(
+                    contactPointsProvider: { callback in callback(.success(["240.0.0.1"])) },  // unroutable, reserved
+                    port: 9042,
+                    protocolVersion: .v3
+                )
+                config.keyspace = "test"
+                config.connectTimeoutMillis = 2_000
+                let client = CassandraClient(configuration: config)
+                defer { try? client.shutdown() }
+
+                SharedTestTracer.instance.reset()
+                do {
+                    try await client.withSession(keyspace: .none) { session in
+                        _ = try await session.query("select release_version from system.local")
+                    }
+                    XCTFail("expected a connect failure")
+                } catch {
+                    // expected
+                }
+
+                XCTAssertEqual(self.executeSpans.count, 0, "span opens post-connect, so a failed connect emits none")
+            },
+            15.0
+        )
+    }
+
+    /// A1 — a batch opens exactly one `.client` "Cassandra batch" span (operation `batch`, query text `batch`,
+    /// no consistency).
+    func testA1_batchOpensBatchSpan() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+                let keyspace = self.makeConfig().keyspace!
+                let table = "trace_batch_\(DispatchTime.now().uptimeNanoseconds)"
+                try await self.createKeyspaceAndTable(
+                    client,
+                    keyspace: keyspace,
+                    table: table,
+                    schema: "(id int primary key, name text)"
+                )
+
+                SharedTestTracer.instance.reset()
+                try await client.batch { batch in
+                    try batch.add(
+                        statement: CassandraClient.Statement(
+                            query: "insert into \(table) (id, name) values (?, ?);",
+                            parameters: [.int32(1), .string("a")]
+                        )
+                    )
+                }
+
+                let batchSpans = self.spans(named: "Cassandra batch")
+                XCTAssertEqual(batchSpans.count, 1)
+                let span = try XCTUnwrap(batchSpans.first)
+                XCTAssertEqual(span.kind, .client)
+                XCTAssertEqual(span.attributes["db.system.name"], "cassandra")
+                XCTAssertEqual(span.attributes["db.operation.name"], "batch")
+                XCTAssertEqual(span.attributes["db.query.text"], "batch")
+                XCTAssertNil(span.attributes["db.cassandra.consistency_level"], "batch carries no consistency")
+                XCTAssertNil(span.statusCode)
+            },
+            30.0
+        )
+    }
+
+    /// A4 — constructing a `PaginatedRows` via `query(pageSize:)` opens NO span; the span appears only when a
+    /// page is fetched.
+    func testA4_pageSizeConstructionEmitsNoSpanUntilFetch() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+
+                try await client.withSession(keyspace: .none) { session in
+                    SharedTestTracer.instance.reset()
+                    let paginated = try await session.query(
+                        "select release_version from system.local",
+                        pageSize: Int32(100)
+                    )
+                    XCTAssertEqual(self.executeSpans.count, 0, "constructing PaginatedRows opens no span")
+
+                    _ = try await paginated.nextPage()
+                    XCTAssertEqual(self.executeSpans.count, 1, "the span opens when a page is fetched")
+                }
+            },
+            30.0
+        )
+    }
+
+    /// A7 — the consistency attribute is the value the real code resolves: the statement's level wins over the
+    /// session config's, and the config's is used when the statement sets none. Drives the real
+    /// `statement.options.consistency ?? configuration.consistency` decision (not a hand-fed value).
+    func testA7_consistencyResolvedFromStatementThenConfig() {
+        runAsyncAndWaitFor(
+            {
+                var config = self.makeConfig()
+                config.consistency = .quorum
+                let client = CassandraClient(configuration: config)
+                defer { try? client.shutdown() }
+
+                // Statement-level consistency wins over the config default.
+                SharedTestTracer.instance.reset()
+                let explicit = try CassandraClient.Statement(
+                    query: "select release_version from system.local",
+                    options: .init(consistency: .one)
+                )
+                _ = try await client.execute(statement: explicit)
+                XCTAssertEqual(self.executeSpans.first?.attributes["db.cassandra.consistency_level"], "one")
+
+                // No statement-level consistency -> the config default is used.
+                SharedTestTracer.instance.reset()
+                let inherited = try CassandraClient.Statement(query: "select release_version from system.local")
+                _ = try await client.execute(statement: inherited)
+                XCTAssertEqual(self.executeSpans.first?.attributes["db.cassandra.consistency_level"], "quorum")
+            },
+            30.0
+        )
+    }
+
+    /// A9 — a preflight (binding) failure throws before the span opens, so NO execute span is created
+    /// (the boundary the "not traced" scope depends on).
+    func testA9_preflightFailureNotTraced() {
+        runAsyncAndWaitFor(
+            {
+                let client = CassandraClient(configuration: self.makeConfig())
+                defer { try? client.shutdown() }
+                let keyspace = self.makeConfig().keyspace!
+                let table = "trace_preflight_\(DispatchTime.now().uptimeNanoseconds)"
+                try await self.createKeyspaceAndTable(
+                    client,
+                    keyspace: keyspace,
+                    table: table,
+                    schema: "(id bigint primary key, v text)"
+                )
+
+                let session = client.makeSession(keyspace: keyspace)
+                defer { try? session.shutdown() }
+                let prepared = try await session.prepare("insert into \(table) (id, v) values (?, ?)")
+
+                SharedTestTracer.instance.reset()  // ignore the prepare span
+                do {
+                    // Bind more parameters than there are placeholders -> preflight bind failure before the span.
+                    _ = try await session.execute(
+                        prepared: prepared,
+                        parameters: [.int64(1), .string("x"), .string("extra")]
+                    )
+                    XCTFail("expected a preflight binding failure")
+                } catch {
+                    // expected
+                }
+
+                XCTAssertEqual(self.executeSpans.count, 0, "preflight failure throws before the span opens")
+            },
+            30.0
+        )
+    }
+}

--- a/Tests/CassandraClientTests/TracingTests.swift
+++ b/Tests/CassandraClientTests/TracingTests.swift
@@ -21,7 +21,7 @@ import XCTest
 // Tracing tests: client-side span behaviour for the async execute / prepare / batch path.
 //
 // Prerequisites for a green run:
-//  1. The failure attribute key is asserted as `db.cassandra.error.category` (the same "errorCategory"
+//  1. The failure attribute key is asserted as `cassandra.error.category` (the same "errorCategory"
 //     concept logging emits as `request.errorCategory` and metrics tag as `errorCategory`; value is
 //     `Error.category.rawValue`). The tracing helper must emit that key, not `error.type`.
 //  2. `swift-distributed-tracing` must resolve so `RequestTrace` and the in-memory tracer
@@ -62,11 +62,11 @@ final class TracingUnitTests: XCTestCase {
             XCTAssertEqual(span.attributes["db.operation.name"], "execute")
             XCTAssertEqual(span.attributes["db.query.text"], "SELECT id FROM t WHERE id = ?")
             XCTAssertEqual(span.attributes["db.namespace"], "shop")
-            XCTAssertEqual(span.attributes["db.cassandra.consistency_level"], "local_one")
+            XCTAssertEqual(span.attributes["cassandra.consistency.level"], "local_one")
             // Bound values are never attached; a success carries no error status/category.
             XCTAssertNil(span.attributes["db.query.parameters"])
             XCTAssertNil(span.statusCode)
-            XCTAssertNil(span.attributes["db.cassandra.error.category"])
+            XCTAssertNil(span.attributes["cassandra.error.category"])
         }
     }
 
@@ -82,7 +82,7 @@ final class TracingUnitTests: XCTestCase {
 
             let span = try XCTUnwrap(SharedTestTracer.instance.recorded.first)
             XCTAssertEqual(span.attributes["db.operation.name"], "prepare")
-            XCTAssertNil(span.attributes["db.cassandra.consistency_level"], "omit, do not fabricate 'default'")
+            XCTAssertNil(span.attributes["cassandra.consistency.level"], "omit, do not fabricate 'default'")
             XCTAssertNil(span.attributes["db.namespace"])
         }
     }
@@ -125,7 +125,7 @@ final class TracingUnitTests: XCTestCase {
 
             let span = try XCTUnwrap(SharedTestTracer.instance.recorded.first)
             XCTAssertEqual(span.statusCode, .error)
-            XCTAssertEqual(span.attributes["db.cassandra.error.category"], thrown.category.rawValue)
+            XCTAssertEqual(span.attributes["cassandra.error.category"], thrown.category.rawValue)
             // PII: neither the status message nor any recorded error may carry the server text.
             XCTAssertEqual(span.statusMessage, thrown.shortDescription)
             XCTAssertFalse((span.statusMessage ?? "").contains("secret keyspace"))
@@ -156,7 +156,7 @@ final class TracingUnitTests: XCTestCase {
             XCTAssertTrue(caught is Boom, "the original non-Cassandra error is rethrown unchanged")
             let span = try XCTUnwrap(SharedTestTracer.instance.recorded.first)
             XCTAssertEqual(span.statusCode, .error)
-            XCTAssertNil(span.attributes["db.cassandra.error.category"], "no category for a non-Cassandra error")
+            XCTAssertNil(span.attributes["cassandra.error.category"], "no category for a non-Cassandra error")
             XCTAssertNil(span.statusMessage, "no message set for a non-Cassandra error")
         }
     }
@@ -257,7 +257,7 @@ final class TracingIntegrationTests: XCTestCase {
                 let span = try XCTUnwrap(self.executeSpans.first)
                 XCTAssertEqual(span.statusCode, .error)
                 XCTAssertEqual(
-                    span.attributes["db.cassandra.error.category"],
+                    span.attributes["cassandra.error.category"],
                     "callerFault",
                     "syntax error -> callerFault via the shared categoriser"
                 )
@@ -399,7 +399,7 @@ final class TracingIntegrationTests: XCTestCase {
                 XCTAssertEqual(prepareSpan.kind, .client)
                 XCTAssertEqual(prepareSpan.attributes["db.operation.name"], "prepare")
                 XCTAssertEqual(prepareSpan.attributes["db.query.text"], cql)
-                XCTAssertNil(prepareSpan.attributes["db.cassandra.consistency_level"])
+                XCTAssertNil(prepareSpan.attributes["cassandra.consistency.level"])
 
                 // Executing the prepared statement: the EXECUTE span shows real CQL, and there is exactly one.
                 SharedTestTracer.instance.reset()
@@ -481,7 +481,7 @@ final class TracingIntegrationTests: XCTestCase {
                 XCTAssertEqual(span.attributes["db.system.name"], "cassandra")
                 XCTAssertEqual(span.attributes["db.operation.name"], "batch")
                 XCTAssertEqual(span.attributes["db.query.text"], "batch")
-                XCTAssertNil(span.attributes["db.cassandra.consistency_level"], "batch carries no consistency")
+                XCTAssertNil(span.attributes["cassandra.consistency.level"], "batch carries no consistency")
                 XCTAssertNil(span.statusCode)
             },
             30.0
@@ -530,13 +530,13 @@ final class TracingIntegrationTests: XCTestCase {
                     options: .init(consistency: .one)
                 )
                 _ = try await client.execute(statement: explicit)
-                XCTAssertEqual(self.executeSpans.first?.attributes["db.cassandra.consistency_level"], "one")
+                XCTAssertEqual(self.executeSpans.first?.attributes["cassandra.consistency.level"], "one")
 
                 // No statement-level consistency -> the config default is used.
                 SharedTestTracer.instance.reset()
                 let inherited = try CassandraClient.Statement(query: "select release_version from system.local")
                 _ = try await client.execute(statement: inherited)
-                XCTAssertEqual(self.executeSpans.first?.attributes["db.cassandra.consistency_level"], "quorum")
+                XCTAssertEqual(self.executeSpans.first?.attributes["cassandra.consistency.level"], "quorum")
             },
             30.0
         )


### PR DESCRIPTION
### Motivation:
  
The async request API is instrumented for logging, but a request is invisible on a distributed trace: a caller running inside a parent span gets no child span for the Cassandra round-trip, so the query never appears on the trace timeline and its latency/errors can't be attributed to the request that caused it. 
  
  ### Modifications:
  
  - Wrap the async `execute` / `prepare` / `batch` primitives in a `.client` OpenTelemetry span, opened inside the connection body (so lazy-connect latency isn't folded in). Prepared statements and pagination are covered transitively.
  - The span nests into the caller's trace via the task-local `ServiceContext`, so there is no API or signature change. Tracing self-gates on whether a tracer is  bootstrapped (`NoOpTracer` default = near-zero cost); no configuration flag.
  - Failure spans record a sanitized status — the error code label only, never the server-provided message — plus the shared error category, so logs and traces describe a failure the same way. The original error is rethrown unchanged.
  - Adds `swift-distributed-tracing` (and transitive `swift-service-context`) as dependencies.
  - Tests: unit coverage for the attribute/error builder and consistency mapping; integration coverage (`CASSANDRA_HOST=<host>`) for span emission, parent linkage, prepared-execute CQL, batch, per-page pagination spans + parenting, and connect-fail ⇒ no span.
  
  ### Result:
  
 Applications that bootstrap a tracer get a `.client` span per async Cassandra request, nested in the caller's trace, with DB attributes and a sanitized failure status.
Applications that don't bootstrap a tracer see no behavior change (NoOp). `EventLoopFuture` callers get no spans; adopt the async API to gain them.