### PR TITLE
Add column dimension to encryption metrics

### DIFF
--- a/Sources/CassandraClient/EncryptionConstants.swift
+++ b/Sources/CassandraClient/EncryptionConstants.swift
@@ -23,5 +23,6 @@ extension CassandraClient {
         static let decryptFailures = "cassandra.encryption.decrypt.failures"
         static let keyRotationTotal = "cassandra.encryption.key_rotation.total"
         static let dimensionKeyName = "keyName"
+        static let dimensionColumn = "column"
     }
 }

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -262,17 +262,18 @@ extension CassandraClient {
             var keysHolder: KeysHolder
             var metricsCache: [String: EncryptorMetrics] = [:]
 
-            mutating func metrics(forKey keyName: String) -> EncryptorMetrics {
-                if let cached = metricsCache[keyName] {
+            mutating func metrics(forKey keyName: String, column: String) -> EncryptorMetrics {
+                let cacheKey = "\(keyName):\(column)"
+                if let cached = metricsCache[cacheKey] {
                     return cached
                 }
-                let m = EncryptorMetrics(keyName: keyName)
-                metricsCache[keyName] = m
+                let m = EncryptorMetrics(keyName: keyName, column: column)
+                metricsCache[cacheKey] = m
                 return m
             }
         }
 
-        /// Cached metric handles for a single key name, avoiding per-call allocation.
+        /// Cached metric handles for a single key name and column, avoiding per-call allocation.
         private struct EncryptorMetrics {
             let encryptTotal: Counter
             let encryptDuration: Timer
@@ -280,8 +281,11 @@ extension CassandraClient {
             let decryptDuration: Timer
             let decryptFailures: Counter
 
-            init(keyName: String) {
-                let dims = [(EncryptionMetric.dimensionKeyName, keyName)]
+            init(keyName: String, column: String) {
+                let dims = [
+                    (EncryptionMetric.dimensionKeyName, keyName),
+                    (EncryptionMetric.dimensionColumn, column),
+                ]
                 self.encryptTotal = Counter(label: EncryptionMetric.encryptTotal, dimensions: dims)
                 self.encryptDuration = Timer(label: EncryptionMetric.encryptDuration, dimensions: dims)
                 self.decryptTotal = Counter(label: EncryptionMetric.decryptTotal, dimensions: dims)
@@ -412,7 +416,7 @@ extension CassandraClient {
                     context: context.contextString,
                     primaryKey: context.primaryKey
                 )
-                let m = $0.metrics(forKey: name)
+                let m = $0.metrics(forKey: name, column: context.column)
                 return (name, key, m)
             }
 
@@ -540,7 +544,7 @@ extension CassandraClient {
                         context: context.contextString,
                         primaryKey: context.primaryKey
                     )
-                    let m = $0.metrics(forKey: keyName)
+                    let m = $0.metrics(forKey: keyName, column: context.column)
                     return (key, m)
                 }
             } catch {
@@ -625,7 +629,10 @@ extension CassandraClient {
             } else {
                 Counter(
                     label: EncryptionMetric.decryptFailures,
-                    dimensions: [(EncryptionMetric.dimensionKeyName, keyName)]
+                    dimensions: [
+                        (EncryptionMetric.dimensionKeyName, keyName),
+                        (EncryptionMetric.dimensionColumn, column),
+                    ]
                 ).increment()
             }
         }

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -12,8 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CoreMetrics
 import Foundation
 import Logging
+import MetricsTestKit
 import XCTest
 
 @testable import CassandraClient
@@ -567,5 +569,36 @@ final class EncryptorTests: XCTestCase {
             let description = String(describing: error)
             XCTAssertTrue(description.contains("user_id"), "Error should mention the overlapping column")
         }
+    }
+
+    // MARK: - Metrics dimensions
+
+    /// Encrypt, decrypt, and decrypt-failure metrics carry both the keyName and column dimensions.
+    func testMetricsCarryKeyNameAndColumnDimensions() throws {
+        MetricsTestSupport.bootstrap()
+        let metrics = MetricsTestSupport.testMetrics
+
+        // Unique keyName/column so the exact-dimension lookup isolates this test's
+        // counters from the shared, process-global TestMetrics.
+        let keyName = "key-metric-dims"
+        let column = "col_metric_dims"
+        let (encryptor, _) = try makeEncryptor(keyName: keyName)
+        let context = testContext(column: column)
+        let dims = [
+            (CassandraClient.EncryptionMetric.dimensionKeyName, keyName),
+            (CassandraClient.EncryptionMetric.dimensionColumn, column),
+        ]
+
+        let encrypted = try encryptor.encrypt(Data("hello".utf8), context: context)
+        _ = try encryptor.decrypt(encrypted, context: context)
+
+        XCTAssertEqual(try metrics.expectCounter(CassandraClient.EncryptionMetric.encryptTotal, dims).totalValue, 1)
+        XCTAssertEqual(try metrics.expectCounter(CassandraClient.EncryptionMetric.decryptTotal, dims).totalValue, 1)
+
+        // Corrupt the tag so AES-GCM authentication fails, driving the decrypt-failure path.
+        var corrupted = encrypted
+        corrupted[corrupted.count - 1] ^= 0xFF
+        XCTAssertThrowsError(try encryptor.decrypt(corrupted, context: context))
+        XCTAssertEqual(try metrics.expectCounter(CassandraClient.EncryptionMetric.decryptFailures, dims).totalValue, 1)
     }
 }


### PR DESCRIPTION
 ### Motivation:
  
The encryption metrics (cassandra.encryption.encrypt.* and cassandra.encryption.decrypt.*) were dimensioned by key name only. When several columns are encrypted under the same key, their metrics are indistinguishable — there is no way to tell which column drives encrypt or decrypt volume, latency, or decryption failures.

  ### Modifications:
  
  - Add a `column` dimension alongside the existing `keyName` on every encryption metric emission: encrypt total/duration, decrypt total/duration, and decrypt failures (including the early-parse failure path).
  - Key the cached metric handles by (keyName, column) rather than keyName alone.
  - Leave the key-rotation metric unchanged — it is not column-scoped.
  - Add a test asserting both dimensions on the encrypt, decrypt, and decrypt-failure counters.
    
Column values come from the table schema, so the added dimension stays bounded in cardinality. 

  ### Result:

Encryption metrics can be sliced by column as well as key name. The key-rotation metric is unaffected.