### PR TITLE
Add custom SASL authenticator

### DIFF
--- a/.github/cassandra/Dockerfile
+++ b/.github/cassandra/Dockerfile
@@ -1,0 +1,14 @@
+# CI-only image: stock Cassandra 3.11 with password authentication enabled.
+#
+# The stock `cassandra:3.11` image defaults to `AllowAllAuthenticator` and exposes no environment variable
+# for the authenticator, so the only way to enable auth is to edit `cassandra.yaml`. Do it at build time
+# (a layer, always root) so the container runs the stock entrypoint unchanged. The `grep` fails the build
+# if the authenticator line is ever missing/renamed in a future base image, rather than silently booting an
+# AllowAll node — `sed` alone exits 0 on no match.
+#
+# BASE_IMAGE is overridable only so a local build can pull from a fully-qualified registry
+# (e.g. `--build-arg BASE_IMAGE=docker.io/library/cassandra:3.11`); CI uses the default.
+ARG BASE_IMAGE=cassandra:3.11
+FROM ${BASE_IMAGE}
+RUN sed -ri 's/^(authenticator:).*/\1 PasswordAuthenticator/' /etc/cassandra/cassandra.yaml \
+    && grep -q '^authenticator: PasswordAuthenticator' /etc/cassandra/cassandra.yaml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -71,6 +71,12 @@ jobs:
           - image: "swiftlang/swift:nightly-main-jammy"
             swift_version: "nightly-main"
             enabled: ${{ inputs.linux_nightly_main_enabled }}
+    # The Cassandra service is run with PasswordAuthenticator (see the "Start Cassandra" step), which the
+    # stock `cassandra:3.11` image has no env var to enable and cannot be reconfigured after start. That
+    # rules out a job-level `services:` block (its container starts before checkout, so a mounted
+    # cassandra.yaml is unavailable, and a containerized job has no Docker socket to patch it). So this job
+    # runs on the host runner and drives both Cassandra and the Swift toolchain via `docker run`, sharing a
+    # user-defined network so the tests reach the node by name.
     steps:
       - name: Checkout repository
         if: ${{ matrix.swift.enabled }}
@@ -78,35 +84,56 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - name: Mark the workspace as safe
+      - name: Start Cassandra with PasswordAuthenticator
         if: ${{ matrix.swift.enabled }}
-        # https://github.com/actions/checkout/issues/766
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        # `cassandra:3.11` defaults to AllowAllAuthenticator and exposes no env var for the authenticator,
+        # so the auth-enabled node is built from `.github/cassandra/Dockerfile` (a one-line cassandra.yaml
+        # patch at build time). The container then runs the stock entrypoint unchanged.
+        run: |
+          docker network create cassandra-net
+          docker build -t cassandra-auth:3.11 .github/cassandra
+          docker run -d --name cassandra --network cassandra-net cassandra-auth:3.11
+      - name: Wait for Cassandra auth to be ready
+        if: ${{ matrix.swift.enabled }}
+        # PasswordAuthenticator creates the default `cassandra`/`cassandra` superuser only after system_auth
+        # is bootstrapped (a short, replication-dependent delay), so wait until a credentialed query works
+        # rather than just for the port to open.
+        run: |
+          ready=0
+          for i in $(seq 1 60); do
+            if docker exec cassandra sh -c 'cqlsh -u cassandra -p cassandra "$(hostname -i)" -e "SELECT release_version FROM system.local"' >/dev/null 2>&1; then
+              echo "Cassandra auth ready after $((i * 5))s"
+              ready=1
+              break
+            fi
+            echo "waiting for Cassandra auth ($i/60)"
+            sleep 5
+          done
+          if [ "$ready" -ne 1 ]; then
+            echo "Cassandra did not become ready with auth enabled"
+            docker logs cassandra || true
+            exit 1
+          fi
       - name: Run matrix job
         if: ${{ matrix.swift.enabled }}
-        env:
-          SWIFT_VERSION: ${{ matrix.swift.swift_version }}
-          COMMAND: "swift test"
-          COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"
-          COMMAND_OVERRIDE_6_2: "swift test ${{ inputs.linux_6_2_arguments_override }}"
-          COMMAND_OVERRIDE_6_3: "swift test ${{ inputs.linux_6_3_arguments_override }}"
-          COMMAND_OVERRIDE_NIGHTLY_NEXT: "swift test ${{ inputs.linux_nightly_next_arguments_override }}"
-          COMMAND_OVERRIDE_NIGHTLY_MAIN: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
-          CASSANDRA_HOST: cassandra
-          CASSANDRA_CQL_PORT: 9042
-          CASSANDRA_USER: cassandra
-          CASSANDRA_PASSWORD: cassandra
-          CASSANDRA_KEYSPACE: cassandra
+        # Run `swift test` inside the matrix Swift image, on the same network as Cassandra so the tests
+        # reach it at `cassandra:9042`. The existing integration tests already send `cassandra`/`cassandra`,
+        # which now traverses real authentication.
         run: |
-          apt-get -qq update && apt-get -qq -y install curl
-          curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.sh | bash
-    container:
-      image: ${{ matrix.swift.image }}
-    services:
-      cassandra:
-        image: cassandra:3.11
-        env:
-          CASSANDRA_CQL_PORT: 9042
-          CASSANDRA_USER: cassandra
-          CASSANDRA_PASSWORD: cassandra
-          CASSANDRA_KEYSPACE: cassandra
+          docker run --rm --network cassandra-net \
+            -v "${GITHUB_WORKSPACE}:/workspace" -w /workspace \
+            -e SWIFT_VERSION="${{ matrix.swift.swift_version }}" \
+            -e COMMAND="swift test" \
+            -e COMMAND_OVERRIDE_6_1="swift test ${{ inputs.linux_6_1_arguments_override }}" \
+            -e COMMAND_OVERRIDE_6_2="swift test ${{ inputs.linux_6_2_arguments_override }}" \
+            -e COMMAND_OVERRIDE_6_3="swift test ${{ inputs.linux_6_3_arguments_override }}" \
+            -e COMMAND_OVERRIDE_NIGHTLY_NEXT="swift test ${{ inputs.linux_nightly_next_arguments_override }}" \
+            -e COMMAND_OVERRIDE_NIGHTLY_MAIN="swift test ${{ inputs.linux_nightly_main_arguments_override }}" \
+            -e CASSANDRA_HOST=cassandra \
+            -e CASSANDRA_CQL_PORT=9042 \
+            -e CASSANDRA_USER=cassandra \
+            -e CASSANDRA_PASSWORD=cassandra \
+            -e CASSANDRA_KEYSPACE=cassandra \
+            -e CASSANDRA_REQUIRE_AUTH=1 \
+            "${{ matrix.swift.image }}" \
+            bash -c "git config --global --add safe.directory /workspace && apt-get -qq update && apt-get -qq -y install curl && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-matrix-job.sh | bash"

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -30,6 +30,12 @@ extension CassandraClient {
         public var protocolVersion: ProtocolVersion
         public var username: String?
         public var password: String?
+
+        /// A custom SASL authenticator. When set, it takes precedence over ``username``/``password``.
+        /// The instance is shared across all connections and invoked concurrently; see
+        /// ``CassandraClient/Authenticator``.
+        public var authenticator: (any CassandraClient.Authenticator)? = nil
+
         public var ssl: SSL?
         public var keyspace: String?
         public var numIOThreads: UInt32?
@@ -230,7 +236,9 @@ extension CassandraClient {
 
             try cluster.setPort(self.port)
             try cluster.setProtocolVersion(self.protocolVersion.rawValue)
-            if let username = self.username, let password = self.password {
+            if let authenticator = self.authenticator {
+                try cluster.setAuthenticator(authenticator)
+            } else if let username = self.username, let password = self.password {
                 try cluster.setCredentials(username: username, password: password)
             }
             if let ssl = self.ssl {
@@ -312,7 +320,8 @@ extension CassandraClient {
             [\(Configuration.self):
             port: \(self.port),
             username: \(self.username ?? "none"),
-            password: *****]
+            password: *****,
+            authenticator: \(self.authenticator == nil ? "none" : "custom")]
             """
         }
     }

--- a/Sources/CassandraClient/CustomAuthentication.swift
+++ b/Sources/CassandraClient/CustomAuthentication.swift
@@ -1,0 +1,218 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+internal import CDataStaxDriver
+
+extension CassandraClient {
+    /// A custom SASL authenticator, for mechanisms beyond username/password (e.g. AWS SigV4 for
+    /// Amazon Keyspaces, or Kerberos).
+    ///
+    /// The client drives a SASL (Simple Authentication and Security Layer) handshake: it produces an
+    /// initial response, answers any server challenges, then observes success. Set an instance on
+    /// ``Configuration/authenticator`` to use it; when set, it takes precedence over
+    /// ``Configuration/username``/``Configuration/password``.
+    ///
+    /// Tokens are opaque bytes. Returned responses are `[UInt8]?` where `nil` sends an empty response;
+    /// received challenge/success tokens are always a (possibly empty) `[UInt8]`.
+    ///
+    /// - Important: A single authenticator instance is shared across every connection the driver opens —
+    ///   the initial connection and every reconnect over the session's lifetime — and its methods are
+    ///   invoked **concurrently** by the driver's I/O threads. Conforming types must therefore be
+    ///   `Sendable` and safe under concurrent invocation. `Sendable` governs transfer between concurrency
+    ///   domains, not concurrent entry into these synchronous methods, so **the compiler enforces none of
+    ///   this**: an `@unchecked Sendable` conformer over mutable state can compile and still race. A
+    ///   mechanism carrying mutable state must serialize its own access.
+    ///
+    /// A single-token mechanism such as SASL PLAIN implements only ``initialResponse()``:
+    ///
+    /// ```swift
+    /// struct PlaintextAuthenticator: CassandraClient.Authenticator {
+    ///     let username: String
+    ///     let password: String
+    ///     func initialResponse() throws -> [UInt8]? {
+    ///         [0x00] + Array(username.utf8) + [0x00] + Array(password.utf8)
+    ///     }
+    /// }
+    /// ```
+    public protocol Authenticator: Sendable {
+        /// The initial response that begins the SASL handshake. `nil` sends an empty response.
+        func initialResponse() throws -> [UInt8]?
+
+        /// Answer a server challenge. The challenge is always present (possibly empty). Return `nil` when
+        /// the client has nothing further to send.
+        func evaluateChallenge(_ challenge: [UInt8]) throws -> [UInt8]?
+
+        /// Called once the server reports success, with any final token it sent (always present, may be empty).
+        func onSuccess(_ token: [UInt8]) throws
+    }
+}
+
+extension CassandraClient.Authenticator {
+    /// Default: a single-token mechanism (e.g. SASL PLAIN) sends nothing further after its initial response.
+    public func evaluateChallenge(_ challenge: [UInt8]) throws -> [UInt8]? { nil }
+
+    /// Default: nothing to do on success.
+    public func onSuccess(_ token: [UInt8]) throws {}
+}
+
+// MARK: - Bridging to CassAuthenticatorCallbacks
+
+/// Retained payload carried through the driver's `void* data` slot. Recovered (unretained) in each
+/// exchange trampoline and released once by ``authDataCleanup`` when the driver destroys its provider.
+private final class AuthenticatorBox {
+    let authenticator: any CassandraClient.Authenticator
+
+    init(_ authenticator: any CassandraClient.Authenticator) {
+        self.authenticator = authenticator
+    }
+}
+
+/// Namespaces the callback struct and the marshaling helpers. `internal` (not `private`) so the pure
+/// helpers below are reachable from the unit tests via `@testable import`.
+internal enum AuthBridge {
+    /// Maximum UTF-8 byte length of a client-produced auth error message before it crosses the C boundary.
+    /// Unrelated to the log-truncation caps on ``CassandraClient/Configuration``.
+    static let maxAuthErrorLength = 1024
+
+    /// The four `@convention(c)` callbacks the driver invokes during a SASL exchange. Copied by value into
+    /// the driver's refcounted provider at registration, so it only needs to outlive that one call — but it
+    /// is `static` (file-scope) because the transient `Cluster` cannot own it.
+    static let authCallbacks = CassAuthenticatorCallbacks(
+        initial_callback: authInitial,
+        challenge_callback: authChallenge,
+        success_callback: authSuccess,
+        cleanup_callback: authExchangeCleanup
+    )
+
+    /// Reads a driver token into an owned `[UInt8]`, empty for a NULL-or-empty token. The driver never
+    /// passes NULL on the challenge/success paths (`std::string::data()`); the guard is defensive.
+    static func readToken(_ token: UnsafePointer<CChar>?, _ size: Int) -> [UInt8] {
+        guard let token, size > 0 else { return [] }
+        return [UInt8](UnsafeRawBufferPointer(start: token, count: size))
+    }
+
+    /// Caps an auth error message at ``maxAuthErrorLength`` UTF-8 bytes — the length `writeError` sends —
+    /// backing off to a scalar boundary so a multi-byte scalar is never split, with room reserved for the
+    /// appended ellipsis. Pure, so it unit-tests without a live `CassAuthenticator*`.
+    static func truncatedAuthError(_ message: String) -> String {
+        guard message.utf8.count > maxAuthErrorLength else { return message }
+        let budget = maxAuthErrorLength - "…".utf8.count
+        var truncated = ""
+        var bytes = 0
+        for scalar in message.unicodeScalars {
+            let width = String(scalar).utf8.count
+            if bytes + width > budget { break }
+            truncated.unicodeScalars.append(scalar)
+            bytes += width
+        }
+        return truncated + "…"
+    }
+
+    /// Sets the response token on the exchange; a `nil` (or empty) response sends empty bytes.
+    static func writeResponse(_ auth: OpaquePointer, _ bytes: [UInt8]?) {
+        let bytes = bytes ?? []
+        bytes.withUnsafeBytes { raw in
+            cass_authenticator_set_response(
+                auth,
+                raw.baseAddress?.assumingMemoryBound(to: CChar.self),
+                bytes.count
+            )
+        }
+    }
+
+    /// Reports a failure on the exchange so the driver aborts it; the message is expected pre-truncated.
+    static func writeError(_ auth: OpaquePointer, _ message: String) {
+        cass_authenticator_set_error_n(auth, message, message.utf8.count)
+    }
+}
+
+// File-scope, non-capturing trampolines (implicitly bridged to `@convention(c)` in `authCallbacks`). Each
+// recovers the authenticator via `takeUnretainedValue()` — the driver's retained `data` owns the box. A
+// throw is capped and reported via `set_error` so the driver aborts the exchange, not crossing the C boundary.
+
+private func authInitial(_ auth: OpaquePointer?, _ data: UnsafeMutableRawPointer?) {
+    guard let auth, let data else { return }
+    let box = Unmanaged<AuthenticatorBox>.fromOpaque(data).takeUnretainedValue()
+    do {
+        AuthBridge.writeResponse(auth, try box.authenticator.initialResponse())
+    } catch {
+        AuthBridge.writeError(auth, AuthBridge.truncatedAuthError(String(describing: error)))
+    }
+}
+
+private func authChallenge(
+    _ auth: OpaquePointer?,
+    _ data: UnsafeMutableRawPointer?,
+    _ token: UnsafePointer<CChar>?,
+    _ size: Int
+) {
+    guard let auth, let data else { return }
+    let box = Unmanaged<AuthenticatorBox>.fromOpaque(data).takeUnretainedValue()
+    do {
+        let response = try box.authenticator.evaluateChallenge(AuthBridge.readToken(token, size))
+        AuthBridge.writeResponse(auth, response)
+    } catch {
+        AuthBridge.writeError(auth, AuthBridge.truncatedAuthError(String(describing: error)))
+    }
+}
+
+private func authSuccess(
+    _ auth: OpaquePointer?,
+    _ data: UnsafeMutableRawPointer?,
+    _ token: UnsafePointer<CChar>?,
+    _ size: Int
+) {
+    guard let auth, let data else { return }
+    let box = Unmanaged<AuthenticatorBox>.fromOpaque(data).takeUnretainedValue()
+    do {
+        try box.authenticator.onSuccess(AuthBridge.readToken(token, size))
+    } catch {
+        AuthBridge.writeError(auth, AuthBridge.truncatedAuthError(String(describing: error)))
+    }
+}
+
+/// Per-exchange cleanup: no per-exchange scratch state to release. This fires once per connection; the box
+/// is freed by ``authDataCleanup``, not here (releasing here would over-release).
+private func authExchangeCleanup(_ auth: OpaquePointer?, _ data: UnsafeMutableRawPointer?) {}
+
+/// Data-cleanup: releases the box's single retain when the driver destroys its provider (once, at refcount
+/// zero — after `cass_cluster_free` and every connection is gone).
+private func authDataCleanup(_ data: UnsafeMutableRawPointer?) {
+    guard let data else { return }
+    Unmanaged<AuthenticatorBox>.fromOpaque(data).release()
+}
+
+// MARK: - Cluster wiring
+
+// Declared here (not in Configuration.swift, where `Cluster` lives) to reach the file-scope bridge symbols;
+// `Cluster.rawPointer` is module-internal, so the extension can still register the callbacks.
+extension Cluster {
+    func setAuthenticator(_ authenticator: any CassandraClient.Authenticator) throws {
+        let box = AuthenticatorBox(authenticator)
+        let result = withUnsafePointer(to: AuthBridge.authCallbacks) { callbacks in
+            cass_cluster_set_authenticator_callbacks(
+                self.rawPointer,
+                callbacks,
+                authDataCleanup,
+                Unmanaged.passRetained(box).toOpaque()
+            )
+        }
+        // Ownership transfers to the driver at the call above (it builds its provider unconditionally), so
+        // no release-on-throw — the driver's data-cleanup frees the box; a release here would double-free.
+        // The setter always returns CASS_OK; this guard is a formality against the CassError return type.
+        guard result == CASS_OK else {
+            throw CassandraClient.Error(result, message: "Failed to configure cluster")
+        }
+    }
+}

--- a/Tests/CassandraClientTests/CustomAuthenticationIntegrationTests.swift
+++ b/Tests/CassandraClientTests/CustomAuthenticationIntegrationTests.swift
@@ -1,0 +1,245 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIO
+import NIOConcurrencyHelpers
+import XCTest
+
+@testable import CassandraClient
+
+/// Custom-authenticator INTEGRATION tests — need a live Cassandra that enforces `PasswordAuthenticator`:
+///
+///     CASSANDRA_REQUIRE_AUTH=1 CASSANDRA_HOST=<host> swift test --filter CustomAuthenticationIntegrationTests
+///
+/// Credentials come from `CASSANDRA_USER`/`CASSANDRA_PASSWORD` (default `cassandra`/`cassandra`). Against a
+/// default `AllowAllAuthenticator` cluster the callbacks never fire, so all but the teardown test are gated
+/// behind `CASSANDRA_REQUIRE_AUTH` and `XCTSkip` when it is unset. The flag is set out-of-band, not probed,
+/// because `testClusterEnforcesAuthentication` is itself the probe.
+final class CustomAuthenticationIntegrationTests: XCTestCase {
+    private var environment: [String: String] { ProcessInfo.processInfo.environment }
+    private var validUsername: String { self.environment["CASSANDRA_USER"] ?? "cassandra" }
+    private var validPassword: String { self.environment["CASSANDRA_PASSWORD"] ?? "cassandra" }
+
+    /// Skips a test unless `CASSANDRA_REQUIRE_AUTH` is set to a non-empty value, i.e. the caller asserts the
+    /// target cluster enforces `PasswordAuthenticator`. See the type doc for why this is opt-in, not probed.
+    private func requireAuthEnforcement() throws {
+        guard let value = self.environment["CASSANDRA_REQUIRE_AUTH"], !value.isEmpty else {
+            throw XCTSkip(
+                "set CASSANDRA_REQUIRE_AUTH=1 against an auth-enforcing cluster to run this test"
+            )
+        }
+    }
+
+    /// A config that authenticates only via the custom-authenticator path: no `username`/`password` and no
+    /// keyspace (tests query `system.local`). Callers set `.authenticator` (or leave it nil for the
+    /// enforcement-guard test).
+    private func makeConfiguration() -> CassandraClient.Configuration {
+        var configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([self.environment["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: self.environment["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        configuration.connectTimeoutMillis = 10_000
+        configuration.requestTimeoutMillis = 24_000
+        return configuration
+    }
+
+    private func makeClient(_ configuration: CassandraClient.Configuration) -> CassandraClient {
+        CassandraClient(configuration: configuration, logger: Logger(label: "test.custom-auth"))
+    }
+
+    /// A failed handshake surfaces as `Error.badCredentials`. Compares `shortDescription` since the driver's
+    /// message text is not fixed.
+    private func assertAuthFailure(_ error: Swift.Error, file: StaticString = #filePath, line: UInt = #line) {
+        guard let cassError = error as? CassandraClient.Error else {
+            return XCTFail("expected CassandraClient.Error, got \(error)", file: file, line: line)
+        }
+        XCTAssertEqual(
+            cassError.shortDescription,
+            "Bad credentials",
+            "expected an authentication failure, got \(cassError)",
+            file: file,
+            line: line
+        )
+    }
+
+    /// A valid authenticator connects, `SELECT` returns, and `onSuccess` fired (the success callback).
+    func testAuthenticatorConnectsAndSucceeds() throws {
+        try self.requireAuthEnforcement()
+        let authenticator = RecordingPlaintextAuthenticator(
+            username: self.validUsername,
+            password: self.validPassword
+        )
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = authenticator
+        let client = self.makeClient(configuration)
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        let rows = try client.query("select release_version from system.local").wait()
+        XCTAssertEqual(Array(rows).count, 1, "system.local returns exactly one row")
+        XCTAssertTrue(authenticator.onSuccessFired, "onSuccess must fire once the server reports success")
+    }
+
+    /// Wrong credentials fail with an auth error rather than stalling or crashing.
+    func testWrongCredentialsFailWithAuthError() throws {
+        try self.requireAuthEnforcement()
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = PlaintextAuthenticator(
+            username: self.validUsername,
+            password: "wrong-\(UUID().uuidString)"
+        )
+        let client = self.makeClient(configuration)
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        XCTAssertThrowsError(try client.query("select release_version from system.local").wait()) { error in
+            self.assertAuthFailure(error)
+        }
+    }
+
+    /// A valid authenticator plus bogus `username`/`password` still connects — the authenticator takes
+    /// precedence over credentials in `makeCluster` (bogus credentials would otherwise fail the connect).
+    func testCustomAuthenticatorTakesPrecedenceOverCredentials() throws {
+        try self.requireAuthEnforcement()
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = PlaintextAuthenticator(
+            username: self.validUsername,
+            password: self.validPassword
+        )
+        configuration.username = "bogus-\(UUID().uuidString)"
+        configuration.password = "bogus-\(UUID().uuidString)"
+        let client = self.makeClient(configuration)
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        let rows = try client.query("select release_version from system.local").wait()
+        XCTAssertEqual(Array(rows).count, 1)
+    }
+
+    /// One shared authenticator instance under concurrent fan-out: all queries succeed and its shared,
+    /// lock-protected counters advance (a stateless authenticator would leave them at 0). Exercises the
+    /// shared-instance path under load; does not prove race-freedom.
+    func testConcurrentSharedAuthenticator() throws {
+        try self.requireAuthEnforcement()
+        let authenticator = RecordingPlaintextAuthenticator(
+            username: self.validUsername,
+            password: self.validPassword
+        )
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = authenticator
+        configuration.numIOThreads = 4
+        let client = self.makeClient(configuration)
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        let iterations = 50
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var errors = [Swift.Error]()
+        var rowCounts = [Int]()
+
+        for _ in 0..<iterations {
+            group.enter()
+            DispatchQueue.global().async {
+                defer { group.leave() }
+                do {
+                    let count = Array(try client.query("select release_version from system.local").wait()).count
+                    lock.lock()
+                    rowCounts.append(count)
+                    lock.unlock()
+                } catch {
+                    lock.lock()
+                    errors.append(error)
+                    lock.unlock()
+                }
+            }
+        }
+        group.wait()
+
+        XCTAssertEqual(errors.count, 0, "concurrent queries through the shared authenticator: \(errors)")
+        XCTAssertEqual(rowCounts.count, iterations)
+        XCTAssertTrue(rowCounts.allSatisfy { $0 == 1 }, "every query returns exactly one row")
+        // The shared instance was actually driven under load (exact counts are not deterministic — the
+        // driver decides how many connections to open — so assert only that the handshake ran).
+        XCTAssertGreaterThan(authenticator.initialResponseCount, 0)
+        XCTAssertGreaterThan(authenticator.onSuccessCount, 0)
+    }
+
+    /// An authenticator that throws from `initialResponse()` fails the connect cleanly (the trampoline's
+    /// `do/catch` → `set_error_n` path).
+    func testThrowingAuthenticatorFailsConnectCleanly() throws {
+        try self.requireAuthEnforcement()
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = ThrowingAuthenticator()
+        let client = self.makeClient(configuration)
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        XCTAssertThrowsError(try client.query("select release_version from system.local").wait()) { error in
+            self.assertAuthFailure(error)
+        }
+    }
+
+    /// The enforcement guard: a no-authenticator, no-credential connect must be rejected. If it connects,
+    /// auth is silently off and this fails the build, so the other gated tests can't pass vacuously. This
+    /// test is the probe, which is why the suite is gated by an out-of-band flag rather than by probing.
+    func testClusterEnforcesAuthentication() throws {
+        try self.requireAuthEnforcement()
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = nil
+        configuration.username = nil
+        configuration.password = nil
+        let client = self.makeClient(configuration)
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        XCTAssertThrowsError(
+            try client.query("select release_version from system.local").wait(),
+            "CASSANDRA_REQUIRE_AUTH is set but the cluster accepted a no-credential connect — auth is not enforced, so the auth tests cannot be trusted"
+        ) { error in
+            self.assertAuthFailure(error)
+        }
+    }
+
+    /// After a connect/query/close, the retained authenticator box is released — its `deinit` runs — showing
+    /// the driver's data-cleanup fired on teardown. Proves release on normal teardown only.
+    func testBoxReleasedOnSessionTeardown() throws {
+        let deinitCounter = NIOLockedValueBox<Int>(0)
+
+        func connectQueryAndShutdown() throws {
+            let authenticator = DeinitCountingAuthenticator(
+                username: self.validUsername,
+                password: self.validPassword,
+                deinitCounter: deinitCounter
+            )
+            var configuration = self.makeConfiguration()
+            configuration.authenticator = authenticator
+            let client = self.makeClient(configuration)
+            defer { try? client.shutdown() }
+            let rows = try client.query("select release_version from system.local").wait()
+            XCTAssertEqual(Array(rows).count, 1)
+        }
+        try connectQueryAndShutdown()
+
+        // The data-cleanup trampoline may run on a driver thread during teardown, so poll briefly.
+        let deadline = Date().addingTimeInterval(5)
+        while deinitCounter.withLockedValue({ $0 }) == 0, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        XCTAssertEqual(
+            deinitCounter.withLockedValue { $0 },
+            1,
+            "the authenticator box must be released exactly once when the driver destroys its provider"
+        )
+    }
+}

--- a/Tests/CassandraClientTests/CustomAuthenticationTestSupport.swift
+++ b/Tests/CassandraClientTests/CustomAuthenticationTestSupport.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+
+@testable import CassandraClient
+
+// Test authenticators shared by the custom-authenticator unit and integration suites. Kept `internal`
+// (not `fileprivate`) so both files reuse one definition. Stateful ones lock their own state to satisfy
+// the `Sendable` protocol under the driver's concurrent invocation.
+
+/// SASL PLAIN (`\0username\0password`) — the single-token mechanism `PasswordAuthenticator` accepts.
+/// Doubles as the doc-comment example on ``CassandraClient/Authenticator``.
+struct PlaintextAuthenticator: CassandraClient.Authenticator {
+    let username: String
+    let password: String
+
+    func initialResponse() throws -> [UInt8]? {
+        [0x00] + Array(self.username.utf8) + [0x00] + Array(self.password.utf8)
+    }
+}
+
+/// Implements only `initialResponse()`; leaves `evaluateChallenge`/`onSuccess` to the protocol defaults.
+struct MinimalAuthenticator: CassandraClient.Authenticator {
+    let response: [UInt8]?
+    func initialResponse() throws -> [UInt8]? { self.response }
+}
+
+/// Thrown by ``ThrowingAuthenticator`` to drive the trampoline's `do/catch` → `set_error` path.
+struct AuthenticatorTestError: Swift.Error {}
+
+/// `initialResponse()` throws, so the exchange aborts before any token is produced.
+struct ThrowingAuthenticator: CassandraClient.Authenticator {
+    func initialResponse() throws -> [UInt8]? { throw AuthenticatorTestError() }
+}
+
+/// Byte-reverses each challenge and records challenges and the success token, for the challenge/success
+/// round-trip that no live `PasswordAuthenticator` exchange reaches.
+final class RecordingChallengeAuthenticator: CassandraClient.Authenticator, @unchecked Sendable {
+    private let state = NIOLockedValueBox<(challenges: [[UInt8]], successToken: [UInt8]?)>(([], nil))
+
+    func initialResponse() throws -> [UInt8]? { [] }
+
+    func evaluateChallenge(_ challenge: [UInt8]) throws -> [UInt8]? {
+        self.state.withLockedValue { $0.challenges.append(challenge) }
+        return Array(challenge.reversed())
+    }
+
+    func onSuccess(_ token: [UInt8]) throws {
+        self.state.withLockedValue { $0.successToken = token }
+    }
+
+    var recordedChallenges: [[UInt8]] { self.state.withLockedValue { $0.challenges } }
+    var recordedSuccessToken: [UInt8]? { self.state.withLockedValue { $0.successToken } }
+}
+
+/// Plaintext credentials plus lock-protected invocation counts. Serves the success-observability test
+/// (`onSuccessFired`) and the shared-instance concurrency test (counts under fan-out).
+final class RecordingPlaintextAuthenticator: CassandraClient.Authenticator, @unchecked Sendable {
+    let username: String
+    let password: String
+    private let counts = NIOLockedValueBox<(initial: Int, success: Int)>((0, 0))
+
+    init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+
+    func initialResponse() throws -> [UInt8]? {
+        self.counts.withLockedValue { $0.initial += 1 }
+        return [0x00] + Array(self.username.utf8) + [0x00] + Array(self.password.utf8)
+    }
+
+    func onSuccess(_ token: [UInt8]) throws {
+        self.counts.withLockedValue { $0.success += 1 }
+    }
+
+    var initialResponseCount: Int { self.counts.withLockedValue { $0.initial } }
+    var onSuccessCount: Int { self.counts.withLockedValue { $0.success } }
+    var onSuccessFired: Bool { self.onSuccessCount > 0 }
+}
+
+/// Increments an external, box-outliving counter in `deinit`, to witness the driver's data-cleanup
+/// releasing the retained box on session teardown.
+final class DeinitCountingAuthenticator: CassandraClient.Authenticator, @unchecked Sendable {
+    let username: String
+    let password: String
+    private let deinitCounter: NIOLockedValueBox<Int>
+
+    init(username: String, password: String, deinitCounter: NIOLockedValueBox<Int>) {
+        self.username = username
+        self.password = password
+        self.deinitCounter = deinitCounter
+    }
+
+    deinit {
+        self.deinitCounter.withLockedValue { $0 += 1 }
+    }
+
+    func initialResponse() throws -> [UInt8]? {
+        [0x00] + Array(self.username.utf8) + [0x00] + Array(self.password.utf8)
+    }
+}

--- a/Tests/CassandraClientTests/CustomAuthenticationTests.swift
+++ b/Tests/CassandraClientTests/CustomAuthenticationTests.swift
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+@testable import CassandraClient
+
+/// Custom-authenticator UNIT tests. No cluster required — cover the authenticator protocol and the pure
+/// marshaling helpers in ``AuthBridge`` (the trampolines and C setter are exercised by the integration
+/// suite, since a `CassAuthenticator*` cannot be fabricated outside a live exchange).
+final class CustomAuthenticationTests: XCTestCase {
+
+    private func makeConfiguration() -> CassandraClient.Configuration {
+        CassandraClient.Configuration(
+            contactPointsProvider: { callback in callback(.success(["127.0.0.1"])) },
+            port: 9042,
+            protocolVersion: .v3
+        )
+    }
+
+    // MARK: - Authenticator byte output
+
+    /// Plaintext `initialResponse()` is exactly the SASL PLAIN encoding `\0user\0pass`.
+    func testPlaintextInitialResponseEncoding() throws {
+        let authenticator = PlaintextAuthenticator(username: "u", password: "p")
+        XCTAssertEqual(
+            try authenticator.initialResponse(),
+            [0x00] + Array("u".utf8) + [0x00] + Array("p".utf8)
+        )
+    }
+
+    /// Empty credentials still frame the two NUL separators.
+    func testPlaintextEmptyCredentials() throws {
+        let authenticator = PlaintextAuthenticator(username: "", password: "")
+        XCTAssertEqual(try authenticator.initialResponse(), [0x00, 0x00])
+    }
+
+    /// Multi-byte credentials are encoded as their UTF-8 bytes, not scalars.
+    func testPlaintextUnicodeCredentials() throws {
+        let username = "usér"
+        let password = "pä🔑"
+        let authenticator = PlaintextAuthenticator(username: username, password: password)
+        XCTAssertEqual(
+            try authenticator.initialResponse(),
+            [0x00] + Array(username.utf8) + [0x00] + Array(password.utf8)
+        )
+    }
+
+    /// A challenge is transformed and returned; the success token is recorded verbatim. Byte content
+    /// (including an embedded NUL) survives the `[UInt8]` round-trips.
+    func testChallengeTransformAndSuccessRecording() throws {
+        let authenticator = RecordingChallengeAuthenticator()
+
+        let challenge: [UInt8] = [0x01, 0x02, 0x00, 0x03]  // embedded NUL — tokens are binary, not C strings
+        XCTAssertEqual(try authenticator.evaluateChallenge(challenge), [0x03, 0x00, 0x02, 0x01])
+        XCTAssertEqual(authenticator.recordedChallenges, [challenge])
+
+        let successToken: [UInt8] = [0xAA, 0x00, 0xBB]
+        try authenticator.onSuccess(successToken)
+        XCTAssertEqual(authenticator.recordedSuccessToken, successToken)
+    }
+
+    /// A mechanism that implements only `initialResponse()` gets `nil` from `evaluateChallenge`
+    /// and a no-op `onSuccess` from the protocol extension.
+    func testDefaultProtocolMethods() throws {
+        let authenticator = MinimalAuthenticator(response: [0x2A])
+        XCTAssertEqual(try authenticator.initialResponse(), [0x2A])
+        XCTAssertNil(try authenticator.evaluateChallenge([0x01, 0x02]))
+        XCTAssertNoThrow(try authenticator.onSuccess([0x03]))
+    }
+
+    // MARK: - readToken
+
+    /// A NULL token reads as empty — never a crash. The NULL input is synthetic; the driver passes
+    /// `std::string::data()` (never NULL) on the challenge/success paths, so this covers only the guard.
+    func testReadTokenNilYieldsEmpty() {
+        XCTAssertEqual(AuthBridge.readToken(nil, 0), [])
+        XCTAssertEqual(AuthBridge.readToken(nil, 8), [])  // NULL with a positive size the driver never sends
+    }
+
+    /// A non-NULL token with size 0 reads as empty (an absent server token arrives as empty, not NULL).
+    func testReadTokenZeroSizeYieldsEmpty() {
+        let bytes: [UInt8] = [0x01, 0x02]
+        let result = bytes.withUnsafeBytes { raw in
+            AuthBridge.readToken(raw.baseAddress?.assumingMemoryBound(to: CChar.self), 0)
+        }
+        XCTAssertEqual(result, [])
+    }
+
+    /// A non-empty token is copied byte-for-byte, embedded NULs and high bytes included.
+    func testReadTokenPreservesBytes() {
+        let input: [UInt8] = [0x00, 0x75, 0x00, 0x70, 0xFF, 0x80]
+        let result = input.withUnsafeBytes { raw in
+            AuthBridge.readToken(raw.baseAddress?.assumingMemoryBound(to: CChar.self), input.count)
+        }
+        XCTAssertEqual(result, input)
+    }
+
+    // MARK: - truncatedAuthError
+
+    /// A message within the cap is returned unchanged.
+    func testTruncatedAuthErrorShortMessageUnchanged() {
+        let message = "authentication failed"
+        XCTAssertEqual(AuthBridge.truncatedAuthError(message), message)
+    }
+
+    /// An empty message is returned unchanged.
+    func testTruncatedAuthErrorEmptyMessage() {
+        XCTAssertEqual(AuthBridge.truncatedAuthError(""), "")
+    }
+
+    /// A message of exactly `maxAuthErrorLength` bytes is at the boundary (cap is `>`, not `>=`) — unchanged.
+    func testTruncatedAuthErrorAtBoundaryUnchanged() {
+        let message = String(repeating: "a", count: AuthBridge.maxAuthErrorLength)
+        let result = AuthBridge.truncatedAuthError(message)
+        XCTAssertEqual(result, message)
+        XCTAssertEqual(result.utf8.count, AuthBridge.maxAuthErrorLength)
+    }
+
+    /// An over-long message is capped at `maxAuthErrorLength` UTF-8 bytes (the length `writeError` sends),
+    /// ending in an ellipsis whose room is reserved within the cap.
+    func testTruncatedAuthErrorCapsLongMessage() {
+        let message = String(repeating: "a", count: AuthBridge.maxAuthErrorLength + 500)
+        let result = AuthBridge.truncatedAuthError(message)
+        XCTAssertLessThanOrEqual(result.utf8.count, AuthBridge.maxAuthErrorLength)
+        XCTAssertTrue(result.hasSuffix("…"))
+        XCTAssertTrue(message.hasPrefix(String(result.dropLast())))  // kept content is a prefix of the original
+    }
+
+    /// Truncation backs off to a scalar boundary: a run of 4-byte scalars is never split into a
+    /// replacement character, and the byte cap still holds.
+    func testTruncatedAuthErrorDoesNotSplitScalar() {
+        let message = String(repeating: "🔑", count: 1000)  // 4 UTF-8 bytes each, far over the cap
+        let result = AuthBridge.truncatedAuthError(message)
+        XCTAssertLessThanOrEqual(result.utf8.count, AuthBridge.maxAuthErrorLength)
+        XCTAssertEqual(result.unicodeScalars.last, "…")
+        XCTAssertTrue(
+            result.unicodeScalars.dropLast().allSatisfy { $0 == "🔑" },
+            "no scalar should be split into U+FFFD"
+        )
+    }
+
+    // MARK: - Configuration.description redaction
+
+    /// With an authenticator set, `description` shows `authenticator: custom` and none of the
+    /// authenticator's internals (potential secrets).
+    func testDescriptionRedactsAuthenticatorInternals() {
+        let secret = "TOP_SECRET_TOKEN_\(UUID().uuidString)"
+        var configuration = self.makeConfiguration()
+        configuration.authenticator = PlaintextAuthenticator(username: "u", password: secret)
+
+        let description = configuration.description
+        XCTAssertTrue(description.contains("authenticator: custom"))
+        XCTAssertFalse(description.contains(secret), "authenticator internals must not appear in description")
+    }
+
+    /// With no authenticator, `description` shows `authenticator: none`.
+    func testDescriptionShowsNoneWithoutAuthenticator() {
+        let configuration = self.makeConfiguration()
+        XCTAssertTrue(configuration.description.contains("authenticator: none"))
+    }
+}


### PR DESCRIPTION
Resolves #16

### Motivation:

The client can only authenticate with username/password today (`Configuration.username`/`password` feed `cass_cluster_set_credentials`). Systems that require a custom SASL exchange — AWS SigV4 for Amazon Keyspaces, or Kerberos — cannot be used. The DataStax C++ driver exposes the mechanism via `cass_cluster_set_authenticator_callbacks`, but nothing in the Swift layer surfaced it.

### Modifications:

- New public `CassandraClient.Authenticator` protocol (`Sendable`) with `initialResponse()`, `evaluateChallenge(_:)`, and `onSuccess(_:)`. The latter  two are defaulted, so a single-token mechanism such as SASL PLAIN implements  only `initialResponse()`.
- Bridge to the C driver: four non-capturing `@convention(c)` trampolines and a  file-scope `CassAuthenticatorCallbacks`. The authenticator travels through the  driver's `void* data` in a retained box, released by the data-cleanup callback,  so it survives `cass_cluster_free` and every reconnect. `[UInt8]` tokens are  marshaled to/from the C buffers; a thrown error is reported via  `cass_authenticator_set_error_n` so a failed exchange aborts cleanly.
- Add `Configuration.authenticator` and `Cluster.setAuthenticator(_:)`. When set,  the authenticator takes precedence over `username`/`password` in `makeCluster`.  `Configuration.description` shows `authenticator: custom`/`none` and never the  authenticator's contents.
- The single instance is shared across all connections and invoked concurrently;  the protocol doc states this and that `Sendable` does not enforce it, so a  stateful conformer must self-synchronize.
- Tests: unit coverage for authenticator byte output, the pure marshaling helpers, protocol defaults, and `description` redaction; integration coverage for connect + `onSuccess`, wrong-credential and throwing-authenticator failures, credential precedence, concurrent shared use, and box release on teardown. The  auth-dependent integration tests are gated behind `CASSANDRA_REQUIRE_AUTH` and skip otherwise.
- CI: enable `PasswordAuthenticator` on the test Cassandra, built from `.github/cassandra/Dockerfile` (the stock image has no env var for it), and set `CASSANDRA_REQUIRE_AUTH` so the auth tests run.

### Result:

Users can supply a custom SASL authenticator for mechanisms beyond username/password. Behavior is unchanged unless `authenticator` is set, and the new API is additive: the `Configuration` initializer isn't memberwise and the new field is defaulted, so existing call sites are unaffected.
