### PR TITLE
Bump swift-nio-ssl to 2.37.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,7 +101,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.41.1")),
-        .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.36.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl", exact: "2.37.2"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.12.0")),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),


### PR DESCRIPTION
### Motivation:
 `swift-nio-ssl` is required at 2.36.0, which falls in the range affected by GHSA-xfxg-9975-pc2j / CVE-2026-43820 (2.18.0 through 2.37.1): https://github.com/apple/swift-nio-ssl/security/advisories/GHSA-xfxg-9975-pc2j
The affected API, `NIOSSLCertificate._subjectAlternativeNames()`, is not used by this package. `NIOSSL` is a dependency of the C++ target `CDataStaxDriver`, which uses it for BoringSSL headers through the shims in `Sources/CDataStaxDriver/custom/include/openssl/`.

  ### Modifications:
Requirement changed to `exact: "2.37.2"`, the first release outside the affected range.
The requirement stays exact because `CDataStaxDriver` compiles against swift-nio-ssl's vendored BoringSSL headers, which change across minor releases.

  ### Result:
 `swift-nio-ssl` resolves to 2.37.2. No other resolved version changes, and no source changes.