### PR TITLE
Add a paginated query variant that decodes rows into a Decodable type

### DIFF
--- a/Sources/CassandraClient/Data+PaginatedRows.swift
+++ b/Sources/CassandraClient/Data+PaginatedRows.swift
@@ -252,7 +252,7 @@ extension CassandraClient.PaginatedRows: AsyncSequence {
             // to overwrite previous rows so that the iterated rows differ from those
             // yielded to continuation.
             self.pageStream = AsyncThrowingStream { continuation in
-                Task {
+                let task = Task {
                     do {
                         repeat {
                             // This shouldn't throw `rowExhausted` error, but if it does
@@ -260,13 +260,16 @@ extension CassandraClient.PaginatedRows: AsyncSequence {
                             // through, which indicates usage error so it's ok to throw.
                             let rows = try await paginatedRows.nextPage()
                             continuation.yield(rows)
-                        } while paginatedRows.hasMorePages
+                        } while paginatedRows.hasMorePages && !Task.isCancelled
 
                         continuation.finish()
                     } catch {
                         continuation.finish(throwing: error)
                     }
                 }
+                // Stop paging when the consumer stops early (break, `prefix`, a decode error in a
+                // downstream `map`): otherwise the producer keeps fetching pages to exhaustion.
+                continuation.onTermination = { _ in task.cancel() }
             }.makeAsyncIterator()
         }
 

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1612,29 +1612,25 @@ extension CassandraSession {
     }
 
     /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`,
-    /// decoding each row into `T` as pages are fetched rather than buffering the whole result set in memory.
+    /// decoding each row into `T` as the sequence is iterated, rather than materializing the whole
+    /// decoded result set as an array.
     ///
-    /// - Important:
-    ///   - Advancing the returned sequence invalidates values retrieved by the previous iteration,
-    ///     same as ``query(_:parameters:pageSize:options:logger:)``.
+    /// - Note: Unlike the raw ``query(_:parameters:pageSize:options:logger:)`` sequence, decoded values
+    ///   are independent Swift values and remain valid after the sequence is advanced.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    public func query<T: Decodable>(
+    public func query<T: Decodable & Sendable>(
         _ query: String,
         parameters: sending [CassandraClient.Statement.Value] = [],
         pageSize: Int32,
         options: CassandraClient.Statement.Options = .init(),
-        logger: Logger? = .none,
-        file: String = #fileID,
-        line: UInt = #line
+        logger: Logger? = .none
     ) async throws -> AsyncThrowingMapSequence<CassandraClient.PaginatedRows, T> {
         let paginatedRows = try await self.query(
             query,
             parameters: parameters,
             pageSize: pageSize,
             options: options,
-            logger: logger,
-            file: file,
-            line: line
+            logger: logger
         )
         return paginatedRows.map { row in
             try T(from: self.makeDecoder(row: row, options: options))

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1611,6 +1611,36 @@ extension CassandraSession {
         return try await self.execute(statement: statement, pageSize: pageSize, logger: logger)
     }
 
+    /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`,
+    /// decoding each row into `T` as pages are fetched rather than buffering the whole result set in memory.
+    ///
+    /// - Important:
+    ///   - Advancing the returned sequence invalidates values retrieved by the previous iteration,
+    ///     same as ``query(_:parameters:pageSize:options:logger:)``.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func query<T: Decodable>(
+        _ query: String,
+        parameters: sending [CassandraClient.Statement.Value] = [],
+        pageSize: Int32,
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        file: String = #fileID,
+        line: UInt = #line
+    ) async throws -> AsyncThrowingMapSequence<CassandraClient.PaginatedRows, T> {
+        let paginatedRows = try await self.query(
+            query,
+            parameters: parameters,
+            pageSize: pageSize,
+            options: options,
+            logger: logger,
+            file: file,
+            line: line
+        )
+        return paginatedRows.map { row in
+            try T(from: self.makeDecoder(row: row, options: options))
+        }
+    }
+
     /// Prepare a CQL query for repeated execution.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func prepare(

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -470,6 +470,68 @@ final class EncryptionIntegrationTests: XCTestCase {
         }
     }
 
+    // MARK: - Paged Codable reads
+
+    /// Paged decoding goes through the same decoder as the buffered decoding query, so an encrypted
+    /// column read a page at a time comes back as plaintext: 12 rows over a page size of 5 decrypt to
+    /// the values the buffered decoding query returns.
+    func testPagedCodableDecrypt() async throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_enc_paged_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        try await session.run("create table \(tableName) (user_id text primary key, secret blob)")
+
+        let users = (0..<12).map { ("paged-user-\($0)", "paged-secret-\($0)") }
+
+        var options = CassandraClient.Statement.Options()
+        options.encryptionContextBuilder = { row in
+            guard let uid: String = row.column("user_id") else {
+                throw CassandraClient.Error.badParams("user_id not found in row")
+            }
+            return CassandraClient.EncryptionContext.Base(
+                keyspace: keyspace,
+                table: tableName,
+                primaryKey: .init(from: .string(uid))
+            )
+        }
+
+        for (userId, secretValue) in users {
+            let context = CassandraClient.EncryptionContext(
+                keyspace: keyspace,
+                table: tableName,
+                column: "secret",
+                primaryKey: .init(from: .string(userId))
+            )
+            try await session.run(
+                "insert into \(tableName) (user_id, secret) values (?, ?)",
+                parameters: [
+                    .string(userId),
+                    .encryptedString(CassandraClient.Encrypted(secretValue), context: context),
+                ],
+                options: options
+            )
+        }
+
+        let cql = "select user_id, secret from \(tableName)"
+        let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, UserWithSecret> =
+            try await session.query(cql, pageSize: 5, options: options)
+        var decoded: [UserWithSecret] = []
+        for try await user in paged {
+            decoded.append(user)
+        }
+        let buffered: [UserWithSecret] = try await session.query(cql, options: options)
+
+        // Keyed by user_id: rows come back in partition-key order, which is not the insertion order.
+        let pagedSecrets = Dictionary(uniqueKeysWithValues: decoded.map { ($0.user_id, $0.secret.value) })
+        let bufferedSecrets = Dictionary(uniqueKeysWithValues: buffered.map { ($0.user_id, $0.secret.value) })
+        XCTAssertEqual(decoded.count, users.count)
+        XCTAssertEqual(pagedSecrets, Dictionary(uniqueKeysWithValues: users))
+        XCTAssertEqual(pagedSecrets, bufferedSecrets)
+    }
+
     // MARK: - Codable with multiple encrypted columns
 
     /// Struct with two Encrypted fields of different types, decoded via Codable.

--- a/Tests/CassandraClientTests/PaginatedDecodingIntegrationTests.swift
+++ b/Tests/CassandraClientTests/PaginatedDecodingIntegrationTests.swift
@@ -1,0 +1,288 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+/// Integration tests for the paginated decoding query — the `query(_:parameters:pageSize:options:logger:)`
+/// overload returning a sequence of decoded `T`. Paged results need multi-page data, so these require a
+/// live cluster:
+///
+///     CASSANDRA_HOST=<your-test-cluster-host> swift test --filter PaginatedDecodingIntegrationTests
+///
+/// The fixture puts every row in one partition behind a clustering key, so pages come back in `ck` order
+/// and the ordering and mid-stream failure assertions are deterministic.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class PaginatedDecodingIntegrationTests: XCTestCase {
+    private static let partition: Int32 = 1
+    private static let pageSize: Int32 = 10
+
+    private var cassandraClient: CassandraClient!
+    private var keyspace: String!
+
+    /// A fixture row. Field names match the selected columns; `payload` is non-optional, so a null
+    /// `payload` fails to decode.
+    private struct Item: Decodable, Equatable, Sendable {
+        let pk: Int32
+        let ck: Int32
+        let payload: String
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        let env = ProcessInfo.processInfo.environment
+        let keyspace = env["CASSANDRA_KEYSPACE"] ?? "test"
+        var configuration = CassandraClient.Configuration(
+            contactPointsProvider: { callback in
+                callback(.success([env["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+            },
+            port: env["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            protocolVersion: .v3
+        )
+        configuration.username = env["CASSANDRA_USER"]
+        configuration.password = env["CASSANDRA_PASSWORD"]
+        configuration.keyspace = keyspace
+        configuration.requestTimeoutMillis = UInt32(24_000)
+        configuration.connectTimeoutMillis = UInt32(10_000)
+        self.keyspace = keyspace
+
+        var logger = Logger(label: "test")
+        logger.logLevel = .debug
+
+        self.cassandraClient = CassandraClient(configuration: configuration, logger: logger)
+        XCTAssertNoThrow(
+            try self.cassandraClient.withSession(keyspace: .none) { session in
+                try session
+                    .run(
+                        "create keyspace if not exists \(keyspace) with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+                    )
+                    .wait()
+            }
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        XCTAssertNoThrow(try self.cassandraClient.shutdown())
+        self.cassandraClient = nil  // FIXME: for tsan
+    }
+
+    /// Create the fixture table and insert `count` rows into one partition with `ck` 0..<count.
+    /// `nullPayloadAt` writes a null `payload` at that clustering key.
+    private func makeTable(rows count: Int, nullPayloadAt: Int? = nil) throws -> String {
+        let table = "test_paged_decode_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run(
+            "create table \(table) (pk int, ck int, payload text, primary key (pk, ck));"
+        ).wait()
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            let payload: CassandraClient.Statement.Value =
+                index == nullPayloadAt ? .null : .string("payload-\(index)")
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(table) (pk, ck, payload) values (?, ?, ?);",
+                    parameters: [.int32(Self.partition), .int32(Int32(index)), payload],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait()
+        return table
+    }
+
+    private func selectAll(_ table: String) -> String {
+        "select pk, ck, payload from \(table) where pk = \(Self.partition);"
+    }
+
+    /// Every row is decoded and yielded across page boundaries, in clustering order and with the same
+    /// contents as the buffered decoding query over the same rows. Collecting the whole sequence before
+    /// asserting also covers the documented difference from raw paging: a decoded value is an independent
+    /// Swift value, so values taken earlier stay valid as the sequence advances.
+    func testYieldsEveryRowInOrder() throws {
+        let count = 25  // > pageSize: 3 pages
+        let table = try self.makeTable(rows: count)
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                for try await item in paged {
+                    decoded.append(item)
+                }
+
+                let buffered: [Item] = try await self.cassandraClient.query(self.selectAll(table))
+                XCTAssertEqual(decoded.count, count, "every row should be yielded")
+                XCTAssertEqual(decoded, buffered, "paged decoding should match the buffered decoding query")
+                XCTAssertEqual(
+                    decoded.map(\.ck),
+                    Array(Int32(0)..<Int32(count)),
+                    "rows should arrive in clustering order"
+                )
+                XCTAssertEqual(
+                    decoded.map(\.payload),
+                    (0..<count).map { "payload-\($0)" },
+                    "decoded values should carry the written contents"
+                )
+            },
+            30.0
+        )
+    }
+
+    /// A row that cannot be decoded fails the iteration at that element: the rows before it — more than
+    /// a full page of them — are still yielded, so rows are decoded one at a time as the sequence
+    /// advances rather than up front.
+    func testSurfacesDecodeFailureMidStream() throws {
+        let count = 25
+        let failingIndex = 15  // second page, so a full page is consumed before the failure
+        let table = try self.makeTable(rows: count, nullPayloadAt: failingIndex)
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                do {
+                    for try await item in paged {
+                        decoded.append(item)
+                    }
+                    XCTFail("expected the null payload row to fail decoding")
+                } catch {
+                    XCTAssertTrue(
+                        "\(error)".contains("payload"),
+                        "the failure should name the column that could not be decoded, got \(error)"
+                    )
+                }
+                XCTAssertEqual(
+                    decoded.map(\.ck),
+                    Array(Int32(0)..<Int32(failingIndex)),
+                    "every row before the failing one should have been yielded"
+                )
+            },
+            30.0
+        )
+    }
+
+    /// A first-row decode failure throws before anything is yielded.
+    func testSurfacesDecodeFailureOnFirstRow() throws {
+        let table = try self.makeTable(rows: 25, nullPayloadAt: 0)
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                do {
+                    for try await item in paged {
+                        decoded.append(item)
+                    }
+                    XCTFail("expected the null payload row to fail decoding")
+                } catch {
+                    // expected
+                }
+                XCTAssertTrue(decoded.isEmpty, "nothing should be yielded when the first row fails to decode")
+            },
+            30.0
+        )
+    }
+
+    /// An empty result set yields no elements and no error.
+    func testEmptyResult() throws {
+        let table = try self.makeTable(rows: 0)
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                for try await item in paged {
+                    decoded.append(item)
+                }
+                XCTAssertTrue(decoded.isEmpty, "an empty result set should yield no values")
+            },
+            30.0
+        )
+    }
+
+    /// A result set smaller than `pageSize` (single page) still yields every row.
+    func testSinglePageResult() throws {
+        let count = 4  // < pageSize
+        let table = try self.makeTable(rows: count)
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                for try await item in paged {
+                    decoded.append(item)
+                }
+                XCTAssertEqual(decoded.map(\.ck), Array(Int32(0)..<Int32(count)))
+            },
+            30.0
+        )
+    }
+
+    /// A row count that is an exact multiple of `pageSize` yields every row — the last page is full, so
+    /// this covers the boundary where the server may report a further (empty) page.
+    func testRowCountExactMultipleOfPageSize() throws {
+        let count = Int(Self.pageSize) * 2
+        let table = try self.makeTable(rows: count)
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                for try await item in paged {
+                    decoded.append(item)
+                }
+                XCTAssertEqual(decoded.map(\.ck), Array(Int32(0)..<Int32(count)))
+            },
+            30.0
+        )
+    }
+
+    /// Stopping the iteration part-way through a page ends it cleanly, having yielded exactly the rows
+    /// consumed so far. (The assertion is on what the consumer sees; how far the producer had paged ahead
+    /// is not observable here.)
+    func testStoppingIterationEarly() throws {
+        let table = try self.makeTable(rows: 25)
+        let consumed = 12  // stops inside the second page
+
+        runAsyncAndWaitFor(
+            {
+                let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
+                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                var decoded: [Item] = []
+                for try await item in paged {
+                    decoded.append(item)
+                    if decoded.count == consumed { break }
+                }
+                XCTAssertEqual(decoded.map(\.ck), Array(Int32(0)..<Int32(consumed)))
+            },
+            30.0
+        )
+    }
+}


### PR DESCRIPTION
### Motivation:

`Session` can decode a whole result set into `[T]` (`query<T: Decodable>`) or page through a large one as raw `Rows` (`query(...pageSize:)`), but not both — so callers paging a large result set decode each row by hand. Resolves #31.

### Modifications:

- Add an async `query<T: Decodable & SendableMetatype>(...pageSize:)` returning `AsyncThrowingMapSequence<PaginatedRows, T>` — a `.map` over the existing `PaginatedRows`  `AsyncSequence` that decodes each row via the same `makeDecoder` as the buffered decoding query (inheriting encryption-context handling), one row at a time, without materializing `[T]`.
- Cancel the `PaginatedRows` producer task on stream termination, so early exit (decode error, `break`, `prefix`) stops paging rather than fetching remaining pages.
- Integration tests: order/contents vs the buffered query, mid-stream decode failure, empty / single-page / exact-multiple boundaries, early break, and encrypted-column decrypt.

### Result:

Callers page a large result set and receive decoded values directly:

    let users: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, User> =
        try await session.query("select ...", pageSize: 100)
    for try await user in users { ... }

### Known limitations:

- No aggregate "decrypted rows" debug log for paged decoding (no total without draining the stream); per-column decrypt logging and metrics still fire.
- `PaginatedRows`' page stream has no consumer backpressure (buffers unbounded), so the producer can page ahead of a slow consumer — pre-existing; a demand-driven producer is a possible follow-up.
