### PR TITLE
Redact Encrypted<T> plaintext from string and reflection forms

### DIFF
--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -172,6 +172,19 @@ extension CassandraClient {
 // Only Sendable when T is Sendable
 extension CassandraClient.Encrypted: Sendable where T: Sendable {}
 
+// Redact the wrapped plaintext from every string form. Without this, default reflection
+// renders `value` verbatim, leaking encryption-designated plaintext through any interpolation
+// of an `Encrypted<T>`, a `Statement.Value.encryptedXxx` case, or a `Statement` — e.g. bound-value
+// logs, `Statement.description`. Either string conformance covers both `String(describing:)` and
+// `String(reflecting:)` (each falls back to the other); both are stated so neither can drift.
+// `CustomReflectable` additionally redacts `dump(_:)` / `Mirror`, which walk stored properties and
+// ignore the string conformances.
+extension CassandraClient.Encrypted: CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String { "<redacted>" }
+    public var debugDescription: String { "<redacted>" }
+    public var customMirror: Mirror { Mirror(self, children: ["value": "<redacted>"]) }
+}
+
 // MARK: - KeysHolder
 
 extension CassandraClient {

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -571,6 +571,86 @@ final class EncryptorTests: XCTestCase {
         }
     }
 
+    // MARK: - Plaintext redaction in string forms
+
+    /// Test plaintext that must never appear in any string form of an encrypted value.
+    private static let secret = "123-45-6789"
+
+    /// `Encrypted<T>` renders as `<redacted>` — never its wrapped plaintext — through every string form.
+    func testEncryptedWrapperRedactsPlaintext() {
+        let wrapped = CassandraClient.Encrypted(Self.secret)
+        // `==` in XCTAssertTrue, not XCTAssertEqual — the latter echoes the actual value (plaintext) on failure.
+        for rendered in ["\(wrapped)", String(describing: wrapped), String(reflecting: wrapped)] {
+            XCTAssertTrue(rendered == "<redacted>", "wrapper string form should be <redacted>")
+            XCTAssertFalse(rendered.contains(Self.secret), "wrapper leaked plaintext")
+        }
+    }
+
+    /// A `Statement.Value.encryptedXxx` case redacts its wrapped plaintext through both string forms.
+    /// Redaction here relies on default enum reflection delegating to `Encrypted`'s `CustomStringConvertible`
+    /// — there is no hand-written `Value.description`. Covering every encrypted payload type guards against a
+    /// future `Value.description` (or per-type conformance) that pattern-matches a case and interpolates
+    /// `.value`, which would silently reintroduce the leak.
+    func testStatementValueRedactsPlaintext() {
+        let uuid = Foundation.UUID()
+        // (static label, value case, a plaintext substring that must not appear in the rendered form)
+        let cases: [(label: String, value: CassandraClient.Statement.Value, plaintext: String)] = [
+            ("encryptedString", .encryptedString(.init(Self.secret), context: nil), Self.secret),
+            ("encryptedBytes", .encryptedBytes(.init([0xDE, 0xAD, 0xBE, 0xEF]), context: nil), "222"),  // 0xDE == 222
+            ("encryptedInt32", .encryptedInt32(.init(1_234_567), context: nil), "1234567"),
+            ("encryptedInt64", .encryptedInt64(.init(9_876_543_210), context: nil), "9876543210"),
+            ("encryptedDouble", .encryptedDouble(.init(3.14159), context: nil), "3.14159"),
+            ("encryptedUUID", .encryptedUUID(.init(uuid), context: nil), uuid.uuidString),
+            (
+                "encryptedDate", .encryptedDate(.init(Date(timeIntervalSince1970: 1_700_000_000)), context: nil),
+                "2023-11-14"
+            ),
+        ]
+        for (label, value, plaintext) in cases {
+            // Both string forms — `String(reflecting:)` is the debug form some sinks use.
+            // Messages use only the static label — a regression must not echo the plaintext to CI.
+            for rendered in ["\(value)", String(reflecting: value)] {
+                XCTAssertTrue(rendered.contains("<redacted>"), "\(label) should render <redacted>")
+                XCTAssertFalse(rendered.contains(plaintext), "\(label) leaked plaintext")
+            }
+        }
+    }
+
+    /// `dump(_:)` / `Mirror` walk stored properties and ignore `CustomStringConvertible`, so redaction there
+    /// relies on `CustomReflectable`. Guards the operator-debugging path (e.g. `dump(statement.parameters)`).
+    func testEncryptedWrapperRedactsUnderDumpAndMirror() {
+        let wrapped = CassandraClient.Encrypted(Self.secret)
+
+        var dumped = ""
+        dump(wrapped, to: &dumped)
+        XCTAssertFalse(dumped.contains(Self.secret), "dump leaked plaintext")
+
+        let mirrored = Mirror(reflecting: wrapped).children
+            .map { "\($0.value)" }
+            .joined(separator: ",")
+        XCTAssertFalse(mirrored.contains(Self.secret), "Mirror leaked plaintext")
+
+        // Same via the enum case, the shape that flows through Statement.parameters.
+        var dumpedValue = ""
+        dump(CassandraClient.Statement.Value.encryptedString(.init(Self.secret), context: nil), to: &dumpedValue)
+        XCTAssertFalse(dumpedValue.contains(Self.secret), "dump of Value leaked plaintext")
+    }
+
+    /// `Statement.description` — the public, ungated sink — redacts encrypted plaintext even though the
+    /// statement's `parameters` array retains the original `Encrypted` wrapper after binding.
+    func testStatementDescriptionRedactsPlaintext() throws {
+        let (encryptor, _) = try makeEncryptor()
+        let statement = try CassandraClient.Statement(
+            query: "INSERT INTO users (ssn) VALUES (?)",
+            parameters: [.encryptedString(.init(Self.secret), context: testContext())],
+            options: .init(),
+            _encryptor: encryptor
+        )
+        let rendered = statement.description
+        XCTAssertTrue(rendered.contains("<redacted>"))
+        XCTAssertFalse(rendered.contains(Self.secret))
+    }
+
     // MARK: - Metrics dimensions
 
     /// Encrypt, decrypt, and decrypt-failure metrics carry both the keyName and column dimensions.

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -586,36 +586,6 @@ final class EncryptorTests: XCTestCase {
         }
     }
 
-    /// A `Statement.Value.encryptedXxx` case redacts its wrapped plaintext through both string forms.
-    /// Redaction here relies on default enum reflection delegating to `Encrypted`'s `CustomStringConvertible`
-    /// — there is no hand-written `Value.description`. Covering every encrypted payload type guards against a
-    /// future `Value.description` (or per-type conformance) that pattern-matches a case and interpolates
-    /// `.value`, which would silently reintroduce the leak.
-    func testStatementValueRedactsPlaintext() {
-        let uuid = Foundation.UUID()
-        // (static label, value case, a plaintext substring that must not appear in the rendered form)
-        let cases: [(label: String, value: CassandraClient.Statement.Value, plaintext: String)] = [
-            ("encryptedString", .encryptedString(.init(Self.secret), context: nil), Self.secret),
-            ("encryptedBytes", .encryptedBytes(.init([0xDE, 0xAD, 0xBE, 0xEF]), context: nil), "222"),  // 0xDE == 222
-            ("encryptedInt32", .encryptedInt32(.init(1_234_567), context: nil), "1234567"),
-            ("encryptedInt64", .encryptedInt64(.init(9_876_543_210), context: nil), "9876543210"),
-            ("encryptedDouble", .encryptedDouble(.init(3.14159), context: nil), "3.14159"),
-            ("encryptedUUID", .encryptedUUID(.init(uuid), context: nil), uuid.uuidString),
-            (
-                "encryptedDate", .encryptedDate(.init(Date(timeIntervalSince1970: 1_700_000_000)), context: nil),
-                "2023-11-14"
-            ),
-        ]
-        for (label, value, plaintext) in cases {
-            // Both string forms — `String(reflecting:)` is the debug form some sinks use.
-            // Messages use only the static label — a regression must not echo the plaintext to CI.
-            for rendered in ["\(value)", String(reflecting: value)] {
-                XCTAssertTrue(rendered.contains("<redacted>"), "\(label) should render <redacted>")
-                XCTAssertFalse(rendered.contains(plaintext), "\(label) leaked plaintext")
-            }
-        }
-    }
-
     /// `dump(_:)` / `Mirror` walk stored properties and ignore `CustomStringConvertible`, so redaction there
     /// relies on `CustomReflectable`. Guards the operator-debugging path (e.g. `dump(statement.parameters)`).
     func testEncryptedWrapperRedactsUnderDumpAndMirror() {

--- a/Tests/CassandraClientTests/RequestLoggingTests.swift
+++ b/Tests/CassandraClientTests/RequestLoggingTests.swift
@@ -167,4 +167,16 @@ final class RequestLoggingTests: XCTestCase {
         XCTAssertTrue(formatted.hasSuffix("…"))
         XCTAssertLessThanOrEqual(formatted.count, CassandraClient.Configuration.maxLoggedValueLength + 1)
     }
+
+    /// Encrypted bound values are redacted in the formatted string — plaintext must never reach the log.
+    func testBoundValuesRedactEncryptedPlaintext() {
+        let secret = "123-45-6789"
+        let formatted = CassandraClient.RequestLog.formatValues([
+            .string("public"),
+            .encryptedString(.init(secret), context: nil),
+        ])
+        XCTAssertTrue(formatted.contains("<redacted>"))
+        XCTAssertFalse(formatted.contains(secret))
+        XCTAssertTrue(formatted.contains("public"), "Non-encrypted values should still be logged")
+    }
 }


### PR DESCRIPTION
### Motivation:

`Encrypted<T>` and the `Statement.Value.encryptedXxx` cases had no custom string form, so Swift's default reflection rendered the wrapped plaintext verbatim. Interpolating a `Statement`, its parameters, or an `Encrypted<T>` — including the public, ungated `Statement.description` and bound-value request logs — could emit
encryption-marked plaintext in cleartext.

### Modifications:

Conform `Encrypted<T>` to `CustomStringConvertible`, `CustomDebugStringConvertible`, and `CustomReflectable`, all rendering `<redacted>`. Either string conformance covers `String(describing:)` and `String(reflecting:)`; `CustomReflectable` covers `dump(_:)`/`Mirror`. Every affected sink renders the wrapper via reflection, so one set of conformances closes all of them. Adds tests for the wrapper, all seven encrypted `Statement.Value` cases, `Statement.description`, the bound-value formatter, and `dump`/`Mirror`.

### Result:

Encrypted plaintext renders as `<redacted>` across all string and reflection forms. No behavior change to encryption, decryption, or binding.
