### PR TITLE
Restrict OpaquePagingStateToken to in-process use

### DIFF
--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -48,8 +48,6 @@ extension Data {
     }
 }
 
-public protocol PagingStateToken: ContiguousBytes {}
-
 extension CassandraClient {
     /// Resulting row(s) of a Cassandra query. Data are returned all at once.
     public final class Rows: Sequence, Sendable {
@@ -222,7 +220,11 @@ extension CassandraClient {
 
     /// A reusable page token that can be used by `Statement` to resume querying
     /// at a specific position.
-    public struct OpaquePagingStateToken: PagingStateToken, Sendable {
+    ///
+    /// - Important: This type has no public initializer, so a token can only be vended by
+    /// ``CassandraClient/Rows/opaquePagingStateToken()``. Adding one would let a caller pass
+    /// arbitrary bytes to `Statement.setPagingStateToken(_:)`.
+    public struct OpaquePagingStateToken: ContiguousBytes, Sendable {
         let token: [UInt8]
 
         public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -111,7 +111,8 @@ extension CassandraClient {
 
         /// Returns a reusable paging token.
         ///
-        /// - Warning: This token is not suitable or safe for sharing externally.
+        /// The token is usable only within the process that produced it: the library provides
+        /// no API for reading its bytes.
         public func opaquePagingStateToken() throws -> OpaquePagingStateToken {
             try OpaquePagingStateToken(token: self.rawPagingStateToken())
         }
@@ -219,15 +220,16 @@ extension CassandraClient {
     }
 
     /// A reusable page token that can be used by `Statement` to resume querying
-    /// at a specific position.
+    /// at a specific position. Two tokens can be compared for equality.
     ///
-    /// - Important: This type has no public initializer, so a token can only be vended by
-    /// ``CassandraClient/Rows/opaquePagingStateToken()``. Adding one would let a caller pass
-    /// arbitrary bytes to `Statement.setPagingStateToken(_:)`.
-    public struct OpaquePagingStateToken: ContiguousBytes, Sendable {
+    /// - Important: This type has no public initializer and provides no API for reading its
+    ///   bytes, so a token can only be vended by ``CassandraClient/Rows/opaquePagingStateToken()``
+    ///   and cannot be serialized through this library. Adding a public initializer or a public
+    ///   bytes accessor would let a caller move a paging state across a trust boundary.
+    public struct OpaquePagingStateToken: Equatable, Sendable {
         let token: [UInt8]
 
-        public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
             try self.token.withUnsafeBytes(body)
         }
     }

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -296,13 +296,9 @@ extension CassandraClient {
 
         /// Sets the starting page of the returned paginated results.
         ///
-        /// The paging state token can be obtained by the `pagingStateToken()`
-        /// function on `Rows`.
-        ///
-        /// - Warning: The paging state should not be exposed to or come from
-        /// untrusted environments. The paging state could be spoofed and
-        /// potentially used to gain access to other data.
-        public func setPagingStateToken(_ pagingStateToken: PagingStateToken) throws {
+        /// The paging state token can be obtained by
+        /// ``CassandraClient/Rows/opaquePagingStateToken()``.
+        public func setPagingStateToken(_ pagingStateToken: OpaquePagingStateToken) throws {
             try checkResult {
                 pagingStateToken.withUnsafeBytes {
                     let buffer = $0.bindMemory(to: CChar.self)

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -351,7 +351,11 @@ final class Tests: XCTestCase {
 
         let page = try initialPages.nextPage().wait()
         let pageToken = try page.opaquePagingStateToken()
-        let row = try initialPages.nextPage().wait().first!
+        // Tokens from the same result are equal; a later page's token is not.
+        XCTAssertEqual(pageToken, try page.opaquePagingStateToken())
+        let nextPage = try initialPages.nextPage().wait()
+        XCTAssertNotEqual(pageToken, try nextPage.opaquePagingStateToken())
+        let row = nextPage.first!
 
         let statement = try CassandraClient.Statement(query: "select id, data from \(tableName);")
         try! statement.setPagingStateToken(pageToken)


### PR DESCRIPTION
 ### Motivation:

 `Statement.setPagingStateToken(_:)` accepted any `PagingStateToken`, a public  protocol whose only requirement was `ContiguousBytes`. A consumer could conform a type over bytes from an untrusted source — an HTTP cursor handed to a client and accepted back — and have them forwarded to the driver as a paging state. A paging state encodes a server-side resume position which, per the driver's own warning, could be spoofed and potentially used to gain access to other data. The token is opaque and the driver stores it verbatim, so the library cannot validate it.
`Rows.opaquePagingStateToken()` already documented that the token is not safe to share externally. The reverse direction was open too: the token exposed its bytes publicly, which is what made serializing one out possible.

  ### Modifications:

Narrowed `setPagingStateToken(_:)` to the concrete `OpaquePagingStateToken`, which has no public initializer and can only be obtained from `Rows.opaquePagingStateToken()`, and removed the now-unreferenced `PagingStateToken` protocol.
Made `withUnsafeBytes` internal and dropped the public `ContiguousBytes`  conformance so a token's bytes are no longer part of the public API. Added `Equatable`, the only legitimate use of that accessor; `Hashable` is deliberately omitted, since the supported pattern keys by a consumer-chosen identifier and stores the token as a value.
Extended `testPagingToken` to assert that tokens from one result compare equal and tokens from different pages do not.

  ### Result:

 A token can only be obtained from a result, compared, and handed back to a statement in the same process.
 Source-breaking in two ways:
 - A consumer that passed its own `PagingStateToken` conformer, or named that protocol as a type, no longer compiles.
  - A consumer that read a token's bytes, or passed a token to a `ContiguousBytes`-taking API, no longer compiles. This is the wider of the two.

There is no replacement for resuming a query outside the process that produced it,  because a token cannot be reconstructed from bytes. Consumers that persisted a cursor externally must keep the token in memory instead.

  ### Known limitations:

  - Reflection still reaches the stored bytes, so the guarantee is that no supported API reads them, not that they are unreachable.