### PR TITLE
Pin the TLS client minimum protocol version to TLS 1.2

### DIFF
--- a/Sources/CDataStaxDriver/custom/src/ssl/ssl_openssl_impl.cpp
+++ b/Sources/CDataStaxDriver/custom/src/ssl/ssl_openssl_impl.cpp
@@ -556,6 +556,9 @@ OpenSslContext::OpenSslContext()
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
   // Limit to TLS 1.2 for now. TLS 1.3 has broken the handshake code.
   SSL_CTX_set_max_proto_version(ssl_ctx_, TLS1_2_VERSION);
+  // edit: BoringSSL already defaults the client floor to TLS 1.2. Pin it so the
+  // floor stays at TLS 1.2 if that default changes.
+  SSL_CTX_set_min_proto_version(ssl_ctx_, TLS1_2_VERSION);
 #endif
 #if DEBUG_SSL
   SSL_CTX_set_info_callback(ssl_ctx_, ssl_info_callback);


### PR DESCRIPTION
 ### Motivation
The TLS client context sets a maximum protocol version but no minimum, so the floor comes from the TLS library's default rather than from the driver. That default is currently TLS 1.2 (BoringSSL, vendored by swift-nio-ssl), but nothing here states it.

  ### Modifications
 Add `SSL_CTX_set_min_proto_version(ssl_ctx_, TLS1_2_VERSION)` to the `OpenSslContext` constructor, inside the existing OpenSSL >= 1.1.0 guard alongside the max-version cap.

  ### Result
 The TLS 1.2 floor is explicit. No behavior change: the negotiated range was already exactly TLS 1.2 and remains so.

  ### Known limitations
- TLS 1.3 remains blocked by the existing max-version cap; that is a separate change.
- No test: the change is a no-op against the vendored BoringSSL, so an assertion on the floor would pass with or without it.