### PR TITLE
Add withModelType: query and execute overloads

### DIFF
--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -253,6 +253,39 @@ public final class CassandraClient: CassandraSession, Sendable {
         )
     }
 
+    /// Execute a ``PreparedStatement`` and decode each row into `model` using the default ``CassandraSession``.
+    ///
+    /// This is equivalent to the sibling `execute(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `cassandraClient.execute(prepared: statement, withModelType: Model.self)`.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - eventLoop: The `EventLoop` to use, or create a new one.
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///   - model: The type to decode each row into.
+    ///
+    /// - Returns: The decoded rows.
+    @preconcurrency
+    public func execute<T: Decodable & Sendable>(
+        prepared: PreparedStatement,
+        parameters: sending [Statement.Value] = [],
+        options: Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none,
+        withModelType model: T.Type
+    ) -> EventLoopFuture<[T]> {
+        self.defaultSession.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger
+        )
+    }
+
     /// Execute a batch of statements.
     ///
     /// - Parameters:
@@ -392,6 +425,36 @@ public final class CassandraClient: CassandraSession, Sendable {
         parameters: [Statement.Value] = [],
         options: Statement.Options = .init(),
         logger: Logger? = .none
+    ) async throws -> [T] {
+        try await self.defaultSession.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            logger: logger
+        )
+    }
+
+    /// Execute a ``PreparedStatement`` and decode each row into `model` using the default ``CassandraSession``.
+    ///
+    /// This is equivalent to the sibling `execute(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `try await cassandraClient.execute(prepared: statement, withModelType: Model.self)`.
+    ///
+    /// - Parameters:
+    ///   - prepared: The ``PreparedStatement`` to execute.
+    ///   - parameters: The values to bind to the statement's `?` placeholders.
+    ///   - options: Statement options (consistency, timeout, encryption context).
+    ///   - logger: If `nil`, the client's default `Logger` is used.
+    ///   - model: The type to decode each row into.
+    ///
+    /// - Returns: The decoded rows.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func execute<T: Decodable>(
+        prepared: PreparedStatement,
+        parameters: [Statement.Value] = [],
+        options: Statement.Options = .init(),
+        logger: Logger? = .none,
+        withModelType model: T.Type
     ) async throws -> [T] {
         try await self.defaultSession.execute(
             prepared: prepared,

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -556,6 +556,31 @@ extension CassandraSession {
             return result
         }
     }
+
+    /// Execute a prepared statement, decoding each row into `model`.
+    ///
+    /// This is equivalent to the sibling `execute(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `session.execute(prepared: statement, withModelType: Model.self)`.
+    ///
+    /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    @preconcurrency
+    public func execute<T: Decodable & Sendable>(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: sending [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none,
+        withModelType model: T.Type
+    ) -> EventLoopFuture<[T]> {
+        self.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            on: eventLoop,
+            logger: logger
+        )
+    }
 }
 
 final class CassFuture<T>: Sendable {
@@ -1742,6 +1767,27 @@ extension CassandraSession {
         }
         self.logDecryptedRows(count: result.count, options: effectiveOptions, logger: logger)
         return result
+    }
+
+    /// Execute a prepared statement, decoding each row into `model`.
+    ///
+    /// This is equivalent to the sibling `execute(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `try await session.execute(prepared: statement, withModelType: Model.self)`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func execute<T: Decodable>(
+        prepared: CassandraClient.PreparedStatement,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        withModelType model: T.Type
+    ) async throws -> [T] {
+        try await self.execute(
+            prepared: prepared,
+            parameters: parameters,
+            options: options,
+            logger: logger
+        )
     }
 }
 

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -372,6 +372,25 @@ extension CassandraSession {
             }
     }
 
+    /// Query small data-sets that fit into memory, decoding each row into `model`.
+    ///
+    /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `session.query("select ...", withModelType: Model.self)`.
+    ///
+    /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
+    @preconcurrency
+    public func query<T: Decodable & Sendable>(
+        _ query: String,
+        parameters: sending [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        on eventLoop: EventLoop? = .none,
+        logger: Logger? = .none,
+        withModelType model: T.Type
+    ) -> EventLoopFuture<[T]> {
+        self.query(query, parameters: parameters, options: options, on: eventLoop, logger: logger)
+    }
+
     /// Query large data-sets where using an interator helps control memory usage.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
@@ -1572,6 +1591,22 @@ extension CassandraSession {
         return result
     }
 
+    /// Query small data-sets that fit into memory, decoding each row into `model`.
+    ///
+    /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `try await session.query("select ...", withModelType: Model.self)`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func query<T: Decodable>(
+        _ query: String,
+        parameters: [CassandraClient.Statement.Value] = [],
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        withModelType model: T.Type
+    ) async throws -> [T] {
+        try await self.query(query, parameters: parameters, options: options, logger: logger)
+    }
+
     /// Query large data-sets where using an interator helps control memory usage.
     ///
     /// - Important:
@@ -1635,6 +1670,30 @@ extension CassandraSession {
         return paginatedRows.map { row in
             try T(from: self.makeDecoder(row: row, options: options))
         }
+    }
+
+    /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`,
+    /// decoding each row into `model` as the sequence is iterated.
+    ///
+    /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
+    /// but spells out the decoded type explicitly at the call site, e.g.
+    /// `try await session.query("select ...", pageSize: 100, withModelType: Model.self)`.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public func query<T: Decodable & Sendable>(
+        _ query: String,
+        parameters: sending [CassandraClient.Statement.Value] = [],
+        pageSize: Int32,
+        options: CassandraClient.Statement.Options = .init(),
+        logger: Logger? = .none,
+        withModelType model: T.Type
+    ) async throws -> AsyncThrowingMapSequence<CassandraClient.PaginatedRows, T> {
+        try await self.query(
+            query,
+            parameters: parameters,
+            pageSize: pageSize,
+            options: options,
+            logger: logger
+        )
     }
 
     /// Prepare a CQL query for repeated execution.

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -1918,6 +1918,82 @@ final class Tests: XCTestCase {
             XCTAssertEqual(result[0].column(1)?.string, "alice")
         }
     }
+
+    func testQueryDecodingWithModelType() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run("create table \(tableName) (id int primary key, name text);").wait()
+        try self.cassandraClient.run("insert into \(tableName) (id, name) values (1, 'alice');").wait()
+
+        // No type annotation on `result`: the `withModelType:` argument is the only thing binding `T`.
+        let result = try self.cassandraClient.query(
+            "select id, name from \(tableName) where id = 1;",
+            withModelType: Person.self
+        ).wait()
+        XCTAssertEqual(result, [Person(id: 1, name: "alice")])
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testQueryDecodingWithModelTypeAsync() throws {
+        runAsyncAndWaitFor {
+            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+            try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
+            try await self.cassandraClient.run("insert into \(tableName) (id, name) values (1, 'alice');")
+
+            let result = try await self.cassandraClient.query(
+                "select id, name from \(tableName) where id = 1;",
+                withModelType: Person.self
+            )
+            XCTAssertEqual(result, [Person(id: 1, name: "alice")])
+        }
+    }
+
+    func testPreparedStatementDecodingWithModelType() throws {
+        let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+        defer { XCTAssertNoThrow(try session.shutdown()) }
+
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try session.run("create table \(tableName) (id int primary key, name text);").wait()
+
+        let insertStmt = try session.prepare("insert into \(tableName) (id, name) values (?, ?)").wait()
+        _ = try session.execute(prepared: insertStmt, parameters: [.int32(1), .string("alice")]).wait()
+
+        let selectStmt = try session.prepare("select id, name from \(tableName) where id = ?").wait()
+        // No type annotation on `result`: the `withModelType:` argument is the only thing binding `T`.
+        let result = try session.execute(
+            prepared: selectStmt,
+            parameters: [.int32(1)],
+            withModelType: Person.self
+        ).wait()
+        XCTAssertEqual(result, [Person(id: 1, name: "alice")])
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPreparedStatementDecodingWithModelTypeAsync() throws {
+        runAsyncAndWaitFor {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+
+            let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+            try await session.run("create table \(tableName) (id int primary key, name text);")
+
+            let insertStmt = try await session.prepare("insert into \(tableName) (id, name) values (?, ?)")
+            _ = try await session.execute(prepared: insertStmt, parameters: [.int32(1), .string("alice")])
+
+            let selectStmt = try await session.prepare("select id, name from \(tableName) where id = ?")
+            let result = try await session.execute(
+                prepared: selectStmt,
+                parameters: [.int32(1)],
+                withModelType: Person.self
+            )
+            XCTAssertEqual(result, [Person(id: 1, name: "alice")])
+        }
+    }
+}
+
+/// Row fixture shared by the `withModelType:` decoding tests.
+private struct Person: Codable, Equatable {
+    let id: Int32
+    let name: String
 }
 
 extension XCTestCase {

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -715,6 +715,144 @@ final class EncryptionIntegrationTests: XCTestCase {
         XCTAssertEqual(results[0].secret.value, secretValue)
     }
 
+    /// async/await counterpart of `testColumnRegistrationWithPreparedStatementWithModelType`. The async
+    /// `execute(prepared:...withModelType:)` overload delegates to a separate inference method with its own
+    /// copy of the `encryptionTable` defaulting, so it needs its own coverage of both routes.
+    func testColumnRegistrationWithPreparedStatementWithModelTypeAsync() async throws {
+        let tableName = "test_colreg_prep_mt_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try await session.run("create table \(tableName) (user_id text primary key, secret blob)")
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        self.recreateClient()
+
+        let userId = "user-prep-mt"
+        let secretValue = "prepared-secret"
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string(userId))
+        )
+
+        let insertStmt = try await self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        )
+        _ = try await self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: baseContext.forColumn("secret")),
+            ]
+        )
+
+        // Read the same row twice, sourcing `encryptionTable` a different way each pass:
+        // `false` sets it on the read options; `true` resolves it from the prepared statement.
+        for viaPreparedStatement in [false, true] {
+            let selectStmt = try await self.cassandraClient.prepare(
+                "select user_id, secret from \(tableName) where user_id = ?",
+                encryptionTable: viaPreparedStatement ? tableName : nil
+            )
+            var readOptions = CassandraClient.Statement.Options()
+            if !viaPreparedStatement {
+                readOptions.encryptionTable = tableName
+            }
+
+            // No type annotation on `results`: the `withModelType:` argument is the only thing binding `T`.
+            let results = try await self.cassandraClient.execute(
+                prepared: selectStmt,
+                parameters: [.string(userId)],
+                options: readOptions,
+                withModelType: UserWithSecret.self
+            )
+
+            XCTAssertEqual(results.count, 1, "viaPreparedStatement=\(viaPreparedStatement)")
+            XCTAssertEqual(results[0].user_id, userId, "viaPreparedStatement=\(viaPreparedStatement)")
+            XCTAssertEqual(results[0].secret.value, secretValue, "viaPreparedStatement=\(viaPreparedStatement)")
+        }
+    }
+
+    /// The `withModelType:` execute overload must decrypt an encrypted column on read regardless of how
+    /// `encryptionTable` reaches the decoder. Exercises both routes: the table set on the read `options`
+    /// (a plain pass-through, like `parameters` and `logger`), and the table resolved at execute time from
+    /// `prepared.encryptionTable` (the defaulting branch specific to `execute(prepared:)`). A refactor that
+    /// dropped either would fail here while passing every plaintext `withModelType:` test.
+    func testColumnRegistrationWithPreparedStatementWithModelType() throws {
+        let tableName = "test_colreg_prep_mt_elf_\(DispatchTime.now().uptimeNanoseconds)"
+        let keyspace = self.configuration.keyspace!
+
+        do {
+            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            defer { XCTAssertNoThrow(try session.shutdown()) }
+            try session.run("create table \(tableName) (user_id text primary key, secret blob)").wait()
+        }
+
+        let schema = try CassandraClient.EncryptionSchema(
+            keyspace: keyspace,
+            table: tableName,
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: ["secret"]
+        )
+        self.configuration.registerEncryptionSchema(schema)
+
+        self.recreateClient()
+
+        let userId = "user-prep-mt-elf"
+        let secretValue = "prepared-secret"
+        let baseContext = CassandraClient.EncryptionContext.Base(
+            keyspace: keyspace,
+            table: tableName,
+            primaryKey: .init(from: .string(userId))
+        )
+
+        let insertStmt = try self.cassandraClient.prepare(
+            "insert into \(tableName) (user_id, secret) values (?, ?)"
+        ).wait()
+        _ = try self.cassandraClient.execute(
+            prepared: insertStmt,
+            parameters: [
+                .string(userId),
+                .encryptedString(CassandraClient.Encrypted(secretValue), context: baseContext.forColumn("secret")),
+            ]
+        ).wait()
+
+        // Read the same row twice, sourcing `encryptionTable` a different way each pass:
+        // `false` sets it on the read options; `true` resolves it from the prepared statement.
+        for viaPreparedStatement in [false, true] {
+            let selectStmt = try self.cassandraClient.prepare(
+                "select user_id, secret from \(tableName) where user_id = ?",
+                encryptionTable: viaPreparedStatement ? tableName : nil
+            ).wait()
+            var readOptions = CassandraClient.Statement.Options()
+            if !viaPreparedStatement {
+                readOptions.encryptionTable = tableName
+            }
+
+            // No type annotation on `results`: the `withModelType:` argument is the only thing binding `T`.
+            let results = try self.cassandraClient.execute(
+                prepared: selectStmt,
+                parameters: [.string(userId)],
+                options: readOptions,
+                withModelType: UserWithSecret.self
+            ).wait()
+
+            XCTAssertEqual(results.count, 1, "viaPreparedStatement=\(viaPreparedStatement)")
+            XCTAssertEqual(results[0].user_id, userId, "viaPreparedStatement=\(viaPreparedStatement)")
+            XCTAssertEqual(results[0].secret.value, secretValue, "viaPreparedStatement=\(viaPreparedStatement)")
+        }
+    }
+
     /// Both encryptionContextBuilder and encryptionTable are set — builder wins.
     func testColumnRegistrationBuilderTakesPrecedence() throws {
         let tableName = "test_colreg_prec_\(DispatchTime.now().uptimeNanoseconds)"

--- a/Tests/CassandraClientTests/PaginatedDecodingIntegrationTests.swift
+++ b/Tests/CassandraClientTests/PaginatedDecodingIntegrationTests.swift
@@ -150,6 +150,41 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         )
     }
 
+    /// The `withModelType:` paginated overload yields the same decoded values, in the same order, as its
+    /// inference sibling. Here the element type is bound only by `withModelType:`, not a return-type
+    /// annotation on `paged`.
+    func testYieldsEveryRowInOrderWithModelType() throws {
+        let count = 25  // > pageSize: 3 pages
+        let table = try self.makeTable(rows: count)
+
+        runAsyncAndWaitFor(
+            {
+                let paged = try await self.cassandraClient.query(
+                    self.selectAll(table),
+                    pageSize: Self.pageSize,
+                    withModelType: Item.self
+                )
+                var decoded: [Item] = []
+                for try await item in paged {
+                    decoded.append(item)
+                }
+
+                let buffered = try await self.cassandraClient.query(
+                    self.selectAll(table),
+                    withModelType: Item.self
+                )
+                XCTAssertEqual(decoded.count, count, "every row should be yielded")
+                XCTAssertEqual(decoded, buffered, "paged decoding should match the buffered decoding query")
+                XCTAssertEqual(
+                    decoded.map(\.ck),
+                    Array(Int32(0)..<Int32(count)),
+                    "rows should arrive in clustering order"
+                )
+            },
+            30.0
+        )
+    }
+
     /// A row that cannot be decoded fails the iteration at that element: the rows before it — more than
     /// a full page of them — are still yielded, so rows are decoded one at a time as the sequence
     /// advances rather than up front.


### PR DESCRIPTION
### Motivation

The decoding `query(...)` and `execute(prepared:...)` methods pick the decoded type only from the call's return-type context — a variable annotation or a cast. Nothing at the call site names the type, which is less discoverable and inconsistent with Swift APIs like `JSONDecoder.decode(_:from:)`. Resolves #20.

### Modifications

Add sibling overloads that take the decoded type as an explicit `withModelType: T.Type` parameter:

- `query(...)` — the sync `EventLoopFuture`, async buffered, and async paginated variants.
- `execute(prepared:...)` — the sync `EventLoopFuture` and async variants, on both `CassandraSession` and the top-level `CassandraClient`.

Each overload forwards to its existing inference-based sibling and is distinguished only by the `withModelType:` argument label, so existing call sites are unchanged. Adds decoding tests for the new overloads, including encrypted-column reads on the prepared-statement paths.

### Result

The decoded type can be stated at the call site:

```swift
let people = try await session.query("select id, name from users", withModelType: Person.self)
```

The existing annotation style keeps working.

Co-authored-by: hardik-devops <job.hardikmaru@gmail.com>
