### PR TITLE
Verify certificate chain and peer identity when SSL is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ TLS is off by default. To turn it on, set `ssl` on the configuration and give it
 
 ### If you are upgrading
 
-As of 0.13.0 the client verifies both the certificate chain and the server's identity, so a configuration that worked before can start failing two ways. A certificate that doesn't name the address the client connects to fails with `sslIdentityMismatch`, "Peer certificate subject name does not match". `trustedCertificates` left unset fails with `sslInvalidPeerCert` and an X509 reason such as "unable to get local issuer certificate". Also, `verifyFlag`'s `.default` case has been removed; use `.peerCert` for the previous behavior.
+As of 0.13.0 the client verifies both the certificate chain and the server's identity, so a configuration that worked before can start failing two ways. A certificate that doesn't name the address the client connects to fails with `sslIdentityMismatch`, "Peer certificate subject name does not match". `trustedCertificates` left unset fails with `sslInvalidPeerCert` and an X509 reason such as "unable to get local issuer certificate". Also, `verifyFlag`'s `.default` case has been removed; use `.peerCert` for the previous behavior. A configuration file setting `ssl.verifyFlag` to `"default"` now throws when it is read, rather than being accepted.
 
 ### What is verified
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,41 @@ session.query("select * from table ...").map { rows: Rows in
 }
 ```
 
+## TLS
+
+TLS is off by default. To turn it on, set `ssl` on the configuration and give it the PEM-encoded certificates to trust:
+
+```swift
+  var configuration = CassandraClient.Configuration(...)
+  var ssl = CassandraClient.Configuration.SSL()
+  ssl.trustedCertificates = [certificate]
+  configuration.ssl = ssl
+```
+
+### If you are upgrading
+
+As of 0.13.0 the client verifies both the certificate chain and the server's identity, so a configuration that worked before can start failing two ways. A certificate that doesn't name the address the client connects to fails with `sslIdentityMismatch`, "Peer certificate subject name does not match". `trustedCertificates` left unset fails with `sslInvalidPeerCert` and an X509 reason such as "unable to get local issuer certificate". Also, `verifyFlag`'s `.default` case has been removed; use `.peerCert` for the previous behavior.
+
+### What is verified
+
+For every option except `none`, certificates are checked against `trustedCertificates` only. The driver never falls back to the system trust store, so leaving it unset makes verification fail.
+
+By default (`peerIdentity`) the client also checks that the certificate belongs to the node it connected to, by matching that node's IP address against an `iPAddress` subject alternative name. For the node reached through a contact point, that is the contact point's resolved address. For nodes discovered from the cluster, it is their `system.peers` `rpc_address`, which need not be a configured contact point.
+
+To match hostnames instead, set `peerIdentityDNS` and turn on `hostnameResolution`, which is what lets the driver work out a hostname per node. Note that `ssl` is a struct, so it has to be assigned back to the configuration after being changed:
+
+```swift
+  ssl.verifyFlag = .peerIdentityDNS
+  configuration.ssl = ssl
+  configuration.hostnameResolution = true
+```
+
+Setting `peerIdentityDNS` without `hostnameResolution` throws when the cluster is built, rather than failing later on every connection.
+
+Hostname matching uses the name reverse DNS returns for each node's address, not the hostname configured as a contact point. The driver resolves contact points to addresses before it connects, so the string you configured is never the one matched, and each node's certificate has to carry the name its address reverse-resolves to. A node with no PTR record resolves to its own numeric address, which then fails the subject match and reports the same "Peer certificate subject name does not match" as a certificate naming the wrong address. Check what reverse DNS returns for each node before changing any certificates.
+
+`peerCert` checks the certificate is valid but not which host it belongs to, and accepts a certificate issued for any host. `none` accepts any certificate at all. The client logs a warning when it connects with either.
+
 ## DataStax Driver and libuv
 
 The library depends on [the DataStax driver](https://github.com/datastax/cpp-driver) and 

--- a/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
+++ b/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
@@ -197,8 +197,8 @@ extension CassandraClient.Configuration.SSL {
     /// - `enabled` (bool, optional, default: false): Whether SSL is enabled. If `false`, the initializer
     ///   returns `nil`.
     /// - `trustedCertificates` (string array, optional): PEM encoded certificates used to verify the peer.
-    /// - `verifyFlag` (string, optional, default: "default"): Verification performed on the peer's
-    ///   certificate, one of "default", "none", "peerCert", "peerIdentity" or "peerIdentityDNS".
+    /// - `verifyFlag` (string, optional, default: "peerIdentity"): Verification performed on the peer's
+    ///   certificate, one of "none", "peerCert", "peerIdentity" or "peerIdentityDNS".
     /// - `cert` (string, optional): PEM encoded client certificate chain.
     /// - `privateKey` (string, optional, secret): PEM encoded client private key.
     /// - `privateKeyPassword` (string, secret): Password for `privateKey`. Required when `privateKey` is set.

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -242,6 +242,14 @@ extension CassandraClient {
                 try cluster.setCredentials(username: username, password: password)
             }
             if let ssl = self.ssl {
+                // The driver matches DNS identity against a hostname it only resolves when hostname
+                // resolution is on; without it peers reached by IP carry no hostname and every
+                // handshake fails the subject match.
+                if ssl.verifyFlag == .peerIdentityDNS, self.hostnameResolution != true {
+                    throw CassandraClient.Error.badParams(
+                        "SSL verifyFlag .peerIdentityDNS requires hostnameResolution to be true"
+                    )
+                }
                 try cluster.setSSL(try ssl.makeSSLContext())
             }
             if let value = self.numIOThreads {
@@ -315,13 +323,33 @@ extension CassandraClient {
             return cluster
         }
 
+        /// A warning to log when SSL is enabled but the peer's identity is not verified, otherwise
+        /// `nil`. The driver raises its own anti-pattern warning for this, but only for the
+        /// no-verification case and only from a startup message a non-DSE cluster never triggers.
+        internal var insecureSSLWarning: String? {
+            guard let ssl = self.ssl else { return nil }
+            switch ssl.verifyFlag {
+            case .none:
+                return
+                    "SSL is enabled with verifyFlag .none: the peer's certificate is not checked at "
+                    + "all, leaving the connection open to interception"
+            case .peerCert:
+                return
+                    "SSL is enabled with verifyFlag .peerCert: the peer's identity is not verified, "
+                    + "so any certificate chaining to trustedCertificates is accepted for any host"
+            case .peerIdentity, .peerIdentityDNS:
+                return nil
+            }
+        }
+
         public var description: String {
             """
             [\(Configuration.self):
             port: \(self.port),
             username: \(self.username ?? "none"),
             password: *****,
-            authenticator: \(self.authenticator == nil ? "none" : "custom")]
+            authenticator: \(self.authenticator == nil ? "none" : "custom"),
+            ssl: \(self.ssl.map { "enabled, verify \($0.verifyFlag)" } ?? "disabled")]
             """
         }
     }
@@ -492,28 +520,70 @@ internal final class Cluster {
 extension CassandraClient.Configuration {
     public struct SSL: Sendable {
         public var trustedCertificates: [String]?
-        public var verifyFlag: VerifyFlag = .default
+        public var verifyFlag: VerifyFlag = .peerIdentity
         public var cert: String?
         public var privateKey: (key: String, password: String)?
 
         /// Verification performed on the peer's certificate.
-        public enum VerifyFlag: String, Sendable {
-            /// Use DataStax driver's default, which is .peerCert
-            case `default`
-
+        ///
+        /// The driver checks chain validity and peer identity independently, so the identity cases
+        /// request both. ``VerifyFlag/peerCert`` accepts any certificate that chains to
+        /// ``trustedCertificates`` whatever its subject, which does not protect against a
+        /// network-position attacker holding another certificate from the same issuer;
+        /// ``VerifyFlag/none`` checks nothing at all.
+        ///
+        /// Every case except ``VerifyFlag/none`` validates the chain against ``trustedCertificates``
+        /// alone. The driver loads no system trust anchors, so leaving that property `nil` fails
+        /// verification rather than falling back to the platform's certificate store.
+        public enum VerifyFlag: String, Sendable, Equatable, CaseIterable {
             /// No verification is performed
             case none
-            /// Certificate is present and valid
+            /// Certificate is present and valid. The peer's identity is not checked.
             case peerCert
-            /// IP address matches the certificate's common name or one of its subject alternative names.
-            /// This implies the certificate is also present.
+            /// Certificate is present and valid, and the IP address the driver connected to matches
+            /// an `iPAddress` subject alternative name on the certificate. That address is the
+            /// resolved contact point for the node the driver reaches directly, and the
+            /// `system.peers` `rpc_address` for each node discovered from the cluster, so a peer's
+            /// certificate has to name its `rpc_address` even when that is not a configured contact
+            /// point. Matching consumes no hostname, so
+            /// ``CassandraClient/Configuration/hostnameResolution`` only adds a reverse lookup per
+            /// connection here.
             case peerIdentity
-            /// Hostname matches the certificate's common name or one of its subject alternative names.
-            /// This implies the certificate is also present. Hostname resolution must also be enabled.
+            /// Certificate is present and valid, and the peer's hostname matches a `dNSName` subject
+            /// alternative name on the certificate, or its common name when the certificate carries
+            /// no subject alternative names at all. Requires
+            /// ``CassandraClient/Configuration/hostnameResolution`` to be `true`, because the driver
+            /// reaches peers it discovers from the cluster by IP address and resolves their hostname
+            /// only when that is enabled.
+            ///
+            /// That reverse lookup does not require a PTR record. An address without one resolves to
+            /// its own numeric form, which then fails the subject match and is reported as a
+            /// certificate mismatch rather than a missing PTR record.
             case peerIdentityDNS
         }
 
         public init() {}
+
+        /// The driver verify flags for ``verifyFlag``. The driver reads these as a bitmask and runs
+        /// `SSL_get_verify_result` only when `CASS_SSL_VERIFY_PEER_CERT` is set, so the identity
+        /// cases set it alongside the subject-match bit; setting a subject-match bit alone would
+        /// match the subject without validating the chain.
+        internal var cassVerifyFlags: Int32 {
+            switch self.verifyFlag {
+            case .none:
+                return Int32(CASS_SSL_VERIFY_NONE.rawValue)
+            case .peerCert:
+                return Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue)
+            case .peerIdentity:
+                return Int32(
+                    CASS_SSL_VERIFY_PEER_CERT.rawValue | CASS_SSL_VERIFY_PEER_IDENTITY.rawValue
+                )
+            case .peerIdentityDNS:
+                return Int32(
+                    CASS_SSL_VERIFY_PEER_CERT.rawValue | CASS_SSL_VERIFY_PEER_IDENTITY_DNS.rawValue
+                )
+            }
+        }
 
         func makeSSLContext() throws -> SSLContext {
             let sslContext = SSLContext()
@@ -524,18 +594,7 @@ extension CassandraClient.Configuration {
                 }
             }
 
-            switch self.verifyFlag {
-            case .none:
-                sslContext.setVerifyFlags(CASS_SSL_VERIFY_NONE)
-            case .peerCert:
-                sslContext.setVerifyFlags(CASS_SSL_VERIFY_PEER_CERT)
-            case .peerIdentity:
-                sslContext.setVerifyFlags(CASS_SSL_VERIFY_PEER_IDENTITY)
-            case .peerIdentityDNS:
-                sslContext.setVerifyFlags(CASS_SSL_VERIFY_PEER_IDENTITY_DNS)
-            case .default:
-                ()  // use DataStax driver's default
-            }
+            sslContext.setVerifyFlags(self.cassVerifyFlags)
 
             if let cert = self.cert {
                 try sslContext.setCert(cert)
@@ -552,6 +611,9 @@ extension CassandraClient.Configuration {
 internal final class SSLContext {
     let rawPointer: OpaquePointer
 
+    /// The verify flags last applied through ``setVerifyFlags(_:)``.
+    private(set) var verifyFlags: Int32 = Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue)
+
     init() {
         self.rawPointer = cass_ssl_new()
     }
@@ -565,9 +627,11 @@ internal final class SSLContext {
         try self.checkResult { cass_ssl_add_trusted_cert(self.rawPointer, cert) }
     }
 
-    /// Sets verification performed on the peer's certificate.
-    func setVerifyFlags(_ flags: CassSslVerifyFlags_) {
-        cass_ssl_set_verify_flags(self.rawPointer, Int32(flags.rawValue))
+    /// Sets verification performed on the peer's certificate. `flags` is a bitwise OR of
+    /// `CassSslVerifyFlags` values. The C API offers no readback, so the mask is retained here.
+    func setVerifyFlags(_ flags: Int32) {
+        self.verifyFlags = flags
+        cass_ssl_set_verify_flags(self.rawPointer, flags)
     }
 
     /// Sets client-side certificate chain. This is used to authenticate the client on the server-side.

--- a/Sources/CassandraClient/Docs.docc/index.md
+++ b/Sources/CassandraClient/Docs.docc/index.md
@@ -115,3 +115,38 @@ Or using free-form transformations on the row:
     }
   }
 ```
+
+## TLS
+
+TLS is off by default. To turn it on, set `ssl` on the configuration and give it the PEM-encoded certificates to trust:
+
+```swift
+  var configuration = CassandraClient.Configuration(...)
+  var ssl = CassandraClient.Configuration.SSL()
+  ssl.trustedCertificates = [certificate]
+  configuration.ssl = ssl
+```
+
+### If you are upgrading
+
+As of 0.13.0 the client verifies both the certificate chain and the server's identity, so a configuration that worked before can start failing two ways. A certificate that doesn't name the address the client connects to fails with `sslIdentityMismatch`, "Peer certificate subject name does not match". `trustedCertificates` left unset fails with `sslInvalidPeerCert` and an X509 reason such as "unable to get local issuer certificate". Also, `verifyFlag`'s `.default` case has been removed; use `.peerCert` for the previous behavior.
+
+### What is verified
+
+For every option except `none`, certificates are checked against `trustedCertificates` only. The driver never falls back to the system trust store, so leaving it unset makes verification fail.
+
+By default (`peerIdentity`) the client also checks that the certificate belongs to the node it connected to, by matching that node's IP address against an `iPAddress` subject alternative name. For the node reached through a contact point, that is the contact point's resolved address. For nodes discovered from the cluster, it is their `system.peers` `rpc_address`, which need not be a configured contact point.
+
+To match hostnames instead, set `peerIdentityDNS` and turn on `hostnameResolution`, which is what lets the driver work out a hostname per node. Note that `ssl` is a struct, so it has to be assigned back to the configuration after being changed:
+
+```swift
+  ssl.verifyFlag = .peerIdentityDNS
+  configuration.ssl = ssl
+  configuration.hostnameResolution = true
+```
+
+Setting `peerIdentityDNS` without `hostnameResolution` throws when the cluster is built, rather than failing later on every connection.
+
+Hostname matching uses the name reverse DNS returns for each node's address, not the hostname configured as a contact point. The driver resolves contact points to addresses before it connects, so the string you configured is never the one matched, and each node's certificate has to carry the name its address reverse-resolves to. A node with no PTR record resolves to its own numeric address, which then fails the subject match and reports the same "Peer certificate subject name does not match" as a certificate naming the wrong address. Check what reverse DNS returns for each node before changing any certificates.
+
+`peerCert` checks the certificate is valid but not which host it belongs to, and accepts a certificate issued for any host. `none` accepts any certificate at all. The client logs a warning when it connects with either.

--- a/Sources/CassandraClient/Docs.docc/index.md
+++ b/Sources/CassandraClient/Docs.docc/index.md
@@ -129,7 +129,7 @@ TLS is off by default. To turn it on, set `ssl` on the configuration and give it
 
 ### If you are upgrading
 
-As of 0.13.0 the client verifies both the certificate chain and the server's identity, so a configuration that worked before can start failing two ways. A certificate that doesn't name the address the client connects to fails with `sslIdentityMismatch`, "Peer certificate subject name does not match". `trustedCertificates` left unset fails with `sslInvalidPeerCert` and an X509 reason such as "unable to get local issuer certificate". Also, `verifyFlag`'s `.default` case has been removed; use `.peerCert` for the previous behavior.
+As of 0.13.0 the client verifies both the certificate chain and the server's identity, so a configuration that worked before can start failing two ways. A certificate that doesn't name the address the client connects to fails with `sslIdentityMismatch`, "Peer certificate subject name does not match". `trustedCertificates` left unset fails with `sslInvalidPeerCert` and an X509 reason such as "unable to get local issuer certificate". Also, `verifyFlag`'s `.default` case has been removed; use `.peerCert` for the previous behavior. A configuration file setting `ssl.verifyFlag` to `"default"` now throws when it is read, rather than being accepted.
 
 ### What is verified
 

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1437,6 +1437,9 @@ extension CassandraClient {
 
         private func connect(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Void> {
             logger.debug("connecting to: \(self.configuration)")
+            if let warning = self.configuration.insecureSSLWarning {
+                logger.warning("\(warning)")
+            }
             let startedAt = DispatchTime.now()
             // Instrument the whole chain so a `makeCluster` failure (SSL / contact-point / credentials) is
             // logged too, not just a driver-connect failure.
@@ -2114,6 +2117,9 @@ extension CassandraClient.Session {
     private func connect(logger: Logger) -> Task<Void, Swift.Error> {
         Task {
             logger.debug("connecting to: \(self.configuration)")
+            if let warning = self.configuration.insecureSSLWarning {
+                logger.warning("\(warning)")
+            }
             let startedAt = DispatchTime.now()
             // Instrument makeCluster + connect together so cluster-build failures are logged too.
             return try await CassandraClient.RequestLog.instrumented(

--- a/Tests/CassandraClientTests/SSLConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SSLConfigurationTests.swift
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2022-2025 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CDataStaxDriver
+import NIO
+import XCTest
+
+@testable import CassandraClient
+
+/// Unit tests for the SSL verify-flag mapping and the configuration checks around it. No cluster
+/// required — the flags are asserted as the bitmask handed to the driver, and building a cluster
+/// opens no connections.
+final class SSLConfigurationTests: XCTestCase {
+    private static let peerCert = Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue)
+    private static let peerIdentity = Int32(CASS_SSL_VERIFY_PEER_IDENTITY.rawValue)
+    private static let peerIdentityDNS = Int32(CASS_SSL_VERIFY_PEER_IDENTITY_DNS.rawValue)
+
+    private func makeConfiguration() -> CassandraClient.Configuration {
+        CassandraClient.Configuration(
+            contactPointsProvider: { callback in callback(.success(["127.0.0.1"])) },
+            port: 9042,
+            protocolVersion: .v3
+        )
+    }
+
+    // MARK: - Default
+
+    /// The default verifies the peer's identity, so a certificate that merely chains to a trusted
+    /// issuer is not accepted for an address it does not name.
+    func testDefaultVerifiesPeerIdentity() {
+        XCTAssertEqual(CassandraClient.Configuration.SSL().verifyFlag, .peerIdentity)
+    }
+
+    // MARK: - Flag mapping
+
+    /// `.none` disables verification entirely, which the driver spells as an empty mask.
+    func testNoneMapsToEmptyMask() {
+        XCTAssertEqual(self.flags(for: .none), Int32(CASS_SSL_VERIFY_NONE.rawValue))
+    }
+
+    /// `.peerCert` validates the chain and nothing else.
+    func testPeerCertMapsToChainValidationOnly() {
+        XCTAssertEqual(self.flags(for: .peerCert), Self.peerCert)
+    }
+
+    /// `.peerIdentity` requests the IP subject match *and* chain validation. The driver gates
+    /// `SSL_get_verify_result` on the peer-cert bit, so omitting it would match the subject of a
+    /// certificate whose chain was never validated.
+    func testPeerIdentityAlsoRequestsChainValidation() {
+        let flags = self.flags(for: .peerIdentity)
+        XCTAssertEqual(flags, Self.peerCert | Self.peerIdentity)
+    }
+
+    /// `.peerIdentityDNS` requests the hostname subject match *and* chain validation, for the same
+    /// reason as ``testPeerIdentityAlsoRequestsChainValidation``.
+    func testPeerIdentityDNSAlsoRequestsChainValidation() {
+        let flags = self.flags(for: .peerIdentityDNS)
+        XCTAssertEqual(flags, Self.peerCert | Self.peerIdentityDNS)
+    }
+
+    /// The mask actually reaches the context the driver is handed. Asserting ``cassVerifyFlags`` alone
+    /// would stay green if `makeSSLContext()` stopped applying it.
+    func testMakeSSLContextAppliesTheMask() throws {
+        for verifyFlag in CassandraClient.Configuration.SSL.VerifyFlag.allCases {
+            let sslContext = try self.makeSSL(verifyFlag: verifyFlag).makeSSLContext()
+            XCTAssertEqual(
+                sslContext.verifyFlags,
+                self.flags(for: verifyFlag),
+                "verifyFlag: \(verifyFlag)"
+            )
+        }
+    }
+
+    // MARK: - Hostname resolution requirement
+
+    /// `.peerIdentityDNS` without hostname resolution is rejected up front rather than failing every
+    /// handshake against an unresolved hostname.
+    func testPeerIdentityDNSRequiresHostnameResolution() {
+        for hostnameResolution in [nil, false] as [Bool?] {
+            var configuration = self.makeConfiguration()
+            configuration.ssl = self.makeSSL(verifyFlag: .peerIdentityDNS)
+            configuration.hostnameResolution = hostnameResolution
+
+            XCTAssertThrowsError(try self.makeCluster(configuration)) { error in
+                XCTAssertEqual(
+                    error as? CassandraClient.Error,
+                    .badParams(
+                        "SSL verifyFlag .peerIdentityDNS requires hostnameResolution to be true"
+                    ),
+                    "hostnameResolution: \(String(describing: hostnameResolution))"
+                )
+            }
+        }
+    }
+
+    /// With hostname resolution enabled the driver has a hostname to match, so the pairing is allowed.
+    func testPeerIdentityDNSWithHostnameResolutionIsAccepted() {
+        var configuration = self.makeConfiguration()
+        configuration.ssl = self.makeSSL(verifyFlag: .peerIdentityDNS)
+        configuration.hostnameResolution = true
+
+        XCTAssertNoThrow(try self.makeCluster(configuration))
+    }
+
+    /// The requirement is specific to DNS matching; the other options resolve no hostname and so are
+    /// accepted whether hostname resolution is unset or explicitly off.
+    func testOtherVerifyFlagsDoNotRequireHostnameResolution() {
+        for verifyFlag in CassandraClient.Configuration.SSL.VerifyFlag.allCases where verifyFlag != .peerIdentityDNS {
+            for hostnameResolution in [nil, false] as [Bool?] {
+                var configuration = self.makeConfiguration()
+                configuration.ssl = self.makeSSL(verifyFlag: verifyFlag)
+                configuration.hostnameResolution = hostnameResolution
+
+                XCTAssertNoThrow(
+                    try self.makeCluster(configuration),
+                    "verifyFlag: \(verifyFlag), "
+                        + "hostnameResolution: \(String(describing: hostnameResolution))"
+                )
+            }
+        }
+    }
+
+    /// A configuration with no SSL at all is unaffected by the requirement.
+    func testNoSSLIsUnaffected() {
+        var configuration = self.makeConfiguration()
+        configuration.hostnameResolution = false
+
+        XCTAssertNoThrow(try self.makeCluster(configuration))
+    }
+
+    // MARK: - Insecure-configuration warning
+
+    /// Exactly the options that verify no identity are warned about. Asserted as a partition over
+    /// `allCases` rather than two hardcoded lists, so a new case is covered without being named here.
+    func testWarningCoversExactlyTheFlagsThatVerifyNoIdentity() {
+        let expectedToWarn: [CassandraClient.Configuration.SSL.VerifyFlag] = [.none, .peerCert]
+
+        for verifyFlag in CassandraClient.Configuration.SSL.VerifyFlag.allCases {
+            var configuration = self.makeConfiguration()
+            configuration.ssl = self.makeSSL(verifyFlag: verifyFlag)
+
+            if expectedToWarn.contains(verifyFlag) {
+                XCTAssertNotNil(configuration.insecureSSLWarning, "verifyFlag: \(verifyFlag)")
+            } else {
+                XCTAssertNil(configuration.insecureSSLWarning, "verifyFlag: \(verifyFlag)")
+            }
+        }
+    }
+
+    /// A configuration without SSL is not warned about.
+    func testNoSSLIsNotWarnedAbout() {
+        XCTAssertNil(self.makeConfiguration().insecureSSLWarning)
+    }
+
+    // MARK: - Description
+
+    /// SSL disabled and SSL enabled without verification are distinguishable in the connect log.
+    /// Both once rendered as `none`, which is the one line meant to diagnose this.
+    func testDescriptionDistinguishesDisabledFromUnverified() {
+        var unverified = self.makeConfiguration()
+        unverified.ssl = self.makeSSL(verifyFlag: .none)
+
+        XCTAssertNotEqual(unverified.description, self.makeConfiguration().description)
+        XCTAssertTrue(self.makeConfiguration().description.contains("ssl: disabled"))
+    }
+
+    /// The verify mode reaches the description, so a handshake that starts failing after an upgrade
+    /// can be diagnosed from the existing connect log.
+    func testDescriptionCarriesTheVerifyMode() {
+        var configuration = self.makeConfiguration()
+        configuration.ssl = self.makeSSL(verifyFlag: .peerIdentityDNS)
+
+        XCTAssertTrue(configuration.description.contains("peerIdentityDNS"))
+    }
+
+    // MARK: - Helpers
+
+    private func flags(for verifyFlag: CassandraClient.Configuration.SSL.VerifyFlag) -> Int32 {
+        self.makeSSL(verifyFlag: verifyFlag).cassVerifyFlags
+    }
+
+    private func makeSSL(
+        verifyFlag: CassandraClient.Configuration.SSL.VerifyFlag
+    ) -> CassandraClient.Configuration.SSL {
+        var ssl = CassandraClient.Configuration.SSL()
+        ssl.verifyFlag = verifyFlag
+        return ssl
+    }
+
+    private func makeCluster(_ configuration: CassandraClient.Configuration) throws -> Cluster {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? eventLoopGroup.syncShutdownGracefully() }
+        return try configuration.makeCluster(on: eventLoopGroup.next()).wait()
+    }
+}

--- a/Tests/CassandraClientTests/SwiftConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SwiftConfigurationTests.swift
@@ -375,7 +375,7 @@ struct SwiftConfigurationTests {
         let config = try self.makeConfiguration(adding: ["ssl.enabled": true])
         let ssl = try #require(config.ssl)
         #expect(ssl.trustedCertificates == nil)
-        #expect(ssl.verifyFlag == .default)
+        #expect(ssl.verifyFlag == .peerIdentity)
         #expect(ssl.cert == nil)
         #expect(ssl.privateKey == nil)
     }


### PR DESCRIPTION
### Motivation

TLS verification asks two independent questions: is the certificate from a trusted issuer, and does it belong to the host we dialed. The driver takes these as separate bits in one mask, but `Configuration.SSL` modeled them as a pick-one enum and set one bit per case, so no value checked both. The default checked the chain and not identity, letting an attacker on the network path present any certificate from the configured issuer and read the credentials sent over it. `.peerIdentity` checked identity and not the chain, so a self-signed certificate with the right address
passed.

The new default matches the IP rather than the hostname because the driver reaches discovered peers by IP and gets their hostname from a reverse lookup it never forward-confirms, so hostname matching would rest on a PTR record an attacker can answer.

### Modifications

- `verifyFlag` defaults to `.peerIdentity`; both identity cases now also set the  chain bit.
- Removed `.default`, a no-op that read as safe but meant "no identity check". Use  `.peerCert` instead.
- `.peerIdentityDNS` without `hostnameResolution` now throws when the cluster is built.
- Both connect paths warn on `.none` and `.peerCert`, and `Configuration.description`  shows the verify mode.
- Unit tests for the mapping, the applied mask, the `hostnameResolution` rule, the warning, and the description.

### Result

Identity is verified by default. Breaking for SSL users two ways:

- Certificates without an `iPAddress` subject alternative name for the dialed address fail with `sslIdentityMismatch`. For discovered peers that is their `system.peers rpc_address`, not necessarily a configured contact point.
- `.peerIdentity` with `trustedCertificates` nil now fails chain validation. That needs trust anchors, not certificate changes; the driver loads no system trust store.

Naming `.default` is a compile error.
