### PR TITLE
Add swift-configuration support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -191,6 +191,15 @@ let package = Package(
     cxxLanguageStandard: .cxx17
 )
 
+#if compiler(>=6.2)
+package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0", traits: [])
+)
+for target in package.targets where ["CassandraClient", "CassandraClientTests"].contains(target.name) {
+    target.dependencies.append(.product(name: "Configuration", package: "swift-configuration"))
+}
+#endif
+
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
 for target in package.targets {
     switch target.type {

--- a/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
+++ b/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
@@ -1,0 +1,312 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+import Configuration
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension CassandraClient.Configuration {
+    /// Initializes ``CassandraClient/Configuration`` from a `ConfigReader`.
+    ///
+    /// Unless noted otherwise, each key maps onto the property of the same name, an absent key leaves that
+    /// property at its default, and every value is read once here — later provider updates do not affect the
+    /// returned configuration. `contactPoints` is the only exception.
+    ///
+    /// ## Configuration keys:
+    /// - `contactPoints` (string array, required): Initial contact points of the Cassandra cluster. Must hold
+    ///   at least one entry, none of them blank. Unlike every other key, this one is re-read from
+    ///   `configReader` on each cluster creation rather than captured, so a reloading provider's new seeds
+    ///   apply to subsequent connections. A re-read that fails validation fails that connection.
+    /// - `port` (int, optional, default: 9042): Port the cluster listens on, 1 through 65535.
+    /// - `protocolVersion` (int, optional, default: 4): Native protocol version, 1 through 5.
+    /// - `username` (string, optional): Username for plain text authentication. Unused when ``authenticator`` is set in code.
+    /// - `password` (string, optional, secret): Password for plain text authentication. Unused when ``authenticator`` is set in code.
+    /// - `keyspace` (string, optional): Keyspace the session connects to.
+    /// - `numIOThreads` (int, optional): Number of driver IO threads.
+    /// - `connectTimeoutMillis` (int, optional): Connection timeout in milliseconds.
+    /// - `requestTimeoutMillis` (int, optional): Request timeout in milliseconds.
+    /// - `resolveTimeoutMillis` (int, optional): Host resolution timeout in milliseconds.
+    /// - `slowQueryThresholdMillis` (int, optional): Latency at or above which a successful query is logged.
+    /// - `logBoundValues` (bool, optional): Include bound parameter values in request logs.
+    /// - `coreConnectionsPerHost` (int, optional): Number of connections kept open per host.
+    /// - `tcpNodelay` (bool, optional): Whether to set tcp no delay on the socket.
+    /// - `tcpKeepalive` (bool, optional): Whether to enable TCP keepalive.
+    /// - `tcpKeepaliveDelaySeconds` (int, optional): Delay before the first keepalive probe, in seconds.
+    /// - `connectionHeartbeatIntervalSeconds` (int, optional): Connection heartbeat interval, in seconds.
+    /// - `connectionIdleTimeoutSeconds` (int, optional): Connection idle timeout, in seconds.
+    /// - `schema` (bool, optional): Whether the driver maintains schema metadata.
+    /// - `hostnameResolution` (bool, optional): Whether to perform reverse DNS lookups on cluster hosts.
+    /// - `randomizedContactPoints` (bool, optional): Whether to shuffle the resolved contact points.
+    /// - `compact` (bool, optional): Whether to connect in compact mode.
+    /// - `consistency` (string, optional): Consistency level, one of the cases from ``CassandraClient/Consistency``.
+    /// - `serialConsistency` (string, optional): Serial consistency level for LWT operations, one of the cases from ``CassandraClient/SerialConsistency``.
+    /// - `prepareStrategy` (string, optional): When to prepare statements, one of the cases from ``CassandraClient/Configuration/PrepareStrategy``.
+    /// - `metricsEnabled` (bool, optional): Whether driver metrics are emitted.
+    /// - `metricsPollIntervalMillis` (int, optional): Metrics poller cadence in milliseconds. `0` leaves ``metricsEnabled`` on but stops the poller.
+    /// - `metricsSessionName` (string, optional): Value of the `session` dimension on emitted metrics.
+    /// - `ssl` (scoped, optional): SSL configuration read by ``CassandraClient/Configuration/SSL/init(configReader:)``.
+    ///   Only applied if `ssl.enabled` is `true`.
+    /// - `loadBalancingStrategy` (scoped, optional): Load balancing strategy read by
+    ///   ``CassandraClient/Configuration/LoadBalancingStrategy/init(configReader:)``. Only applied if
+    ///   `loadBalancingStrategy.strategy` is present.
+    /// - `speculativeExecutionPolicy` (scoped, optional): Speculative execution policy, one of the cases from ``CassandraClient/Configuration/SpeculativeExecutionPolicy``.
+    ///
+    /// The ``authenticator``, ``encryptor`` and ``encryptionSchemas`` properties cannot be expressed in
+    /// configuration and must be set in code. Setting ``authenticator`` takes precedence over the `username` and `password` read here.
+    ///
+    /// - Throws: If a value is out of range or is not one of the accepted values for its key, or a required key is missing. `contactPoints` is
+    ///   validated here too, but because it is re-read it can also fail later, via the callback passed to ``contactPointsProvider``.
+    public init(configReader: ConfigReader) throws {
+        // Read once here so a malformed list is a configuration error at init rather than a connect-time
+        // failure. The value is deliberately discarded: the provider below re-reads on every cluster
+        // creation so that a reloading provider's new seeds take effect without a process restart.
+        _ = try Self.contactPoints(from: configReader)
+
+        let rawPort = configReader.int(forKey: "port", default: 9042)
+        guard let port = Int32(exactly: rawPort), (1...65535).contains(port) else {
+            throw CassandraClient.ConfigurationError(
+                message: "'port' must be between 1 and 65535, got \(rawPort)"
+            )
+        }
+
+        let rawProtocolVersion = configReader.int(forKey: "protocolVersion", default: 4)
+        guard let protocolVersion = Int32(exactly: rawProtocolVersion).flatMap(ProtocolVersion.init(rawValue:)) else {
+            let valids = ProtocolVersion.allCases.map(\.rawValue.description).joined(separator: ", ")
+            throw CassandraClient.ConfigurationError(
+                message: "'protocolVersion' \(rawProtocolVersion) is invalid. Valid values: \(valids)"
+            )
+        }
+
+        self.init(
+            contactPointsProvider: { callback in
+                // A re-read that no longer validates fails the connection rather than falling back to the
+                // seeds from init: silently connecting with stale seeds is far harder to diagnose.
+                callback(Result { try Self.contactPoints(from: configReader) })
+            },
+            port: port,
+            protocolVersion: protocolVersion
+        )
+
+        self.username = configReader.string(forKey: "username")
+        self.password = configReader.string(forKey: "password", isSecret: true)
+        self.keyspace = configReader.string(forKey: "keyspace")
+
+        self.numIOThreads = try configReader.uint32(forKey: "numIOThreads")
+        self.connectTimeoutMillis = try configReader.uint32(forKey: "connectTimeoutMillis")
+        self.requestTimeoutMillis = try configReader.uint32(forKey: "requestTimeoutMillis")
+        self.resolveTimeoutMillis = try configReader.uint32(forKey: "resolveTimeoutMillis")
+
+        self.slowQueryThresholdMillis = try configReader.uint32(forKey: "slowQueryThresholdMillis")
+        if let value = configReader.bool(forKey: "logBoundValues") {
+            self.logBoundValues = value
+        }
+
+        self.coreConnectionsPerHost = try configReader.uint32(forKey: "coreConnectionsPerHost")
+        self.tcpNodelay = configReader.bool(forKey: "tcpNodelay")
+        self.tcpKeepalive = configReader.bool(forKey: "tcpKeepalive")
+        if let value = try configReader.uint32(forKey: "tcpKeepaliveDelaySeconds") {
+            self.tcpKeepaliveDelaySeconds = value
+        }
+        self.connectionHeartbeatInterval = try configReader.uint32(forKey: "connectionHeartbeatInterval")
+        self.connectionIdleTimeout = try configReader.uint32(forKey: "connectionIdleTimeout")
+
+        self.schema = configReader.bool(forKey: "schema")
+        self.hostnameResolution = configReader.bool(forKey: "hostnameResolution")
+        self.randomizedContactPoints = configReader.bool(forKey: "randomizedContactPoints")
+        self.compact = configReader.bool(forKey: "compact")
+
+        self.consistency = configReader.string(forKey: "consistency")
+        self.serialConsistency = configReader.string(forKey: "serialConsistency")
+        self.prepareStrategy = configReader.string(forKey: "prepareStrategy")
+
+        if let value = configReader.bool(forKey: "metricsEnabled") {
+            self.metricsEnabled = value
+        }
+        if let value = try configReader.uint32(forKey: "metricsPollIntervalMillis") {
+            self.metricsPollIntervalMillis = value
+        }
+        self.metricsSessionName = configReader.string(forKey: "metricsSessionName")
+
+        if let ssl = try SSL(configReader: configReader.scoped(to: "ssl")) {
+            self.ssl = ssl
+        }
+        if let strategy = try LoadBalancingStrategy(
+            configReader: configReader.scoped(to: "loadBalancingStrategy")
+        ) {
+            self.loadBalancingStrategy = strategy
+        }
+        if let policy = try SpeculativeExecutionPolicy(
+            configReader: configReader.scoped(to: "speculativeExecutionPolicy")
+        ) {
+            self.speculativeExecutionPolicy = policy
+        }
+    }
+
+    /// Reads and validates `contactPoints`.
+    ///
+    /// - Throws: If the list is empty or holds a blank entry, or the key is missing.
+    private static func contactPoints(from configReader: ConfigReader) throws -> ContactPoints {
+        let contactPoints = try configReader.requiredStringArray(forKey: "contactPoints")
+        guard !contactPoints.isEmpty else {
+            throw CassandraClient.ConfigurationError(message: "'contactPoints' must not be empty")
+        }
+        // A blank contact point is how the driver is told to *clear* its contact points, so it would
+        // silently discard the rest of the list rather than fail.
+        if let index = contactPoints.firstIndex(where: { $0.allSatisfy(\.isWhitespace) }) {
+            throw CassandraClient.ConfigurationError(
+                message: "'contactPoints' entry at index \(index) must not be blank"
+            )
+        }
+        return contactPoints
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension CassandraClient.Configuration.SSL {
+    /// Initializes SSL configuration from a `ConfigReader`.
+    ///
+    /// ## Configuration keys:
+    /// - `enabled` (bool, optional, default: false): Whether SSL is enabled. If `false`, the initializer
+    ///   returns `nil`.
+    /// - `trustedCertificates` (string array, optional): PEM encoded certificates used to verify the peer.
+    /// - `verifyFlag` (string, optional, default: "default"): Verification performed on the peer's
+    ///   certificate, one of "default", "none", "peerCert", "peerIdentity" or "peerIdentityDNS".
+    /// - `cert` (string, optional): PEM encoded client certificate chain.
+    /// - `privateKey` (string, optional, secret): PEM encoded client private key.
+    /// - `privateKeyPassword` (string, secret): Password for `privateKey`. Required when `privateKey` is set.
+    ///
+    /// - Throws: If `verifyFlag` is not one of the accepted values, or `privateKey` is set without `privateKeyPassword`.
+    public init?(configReader: ConfigReader) throws {
+        guard configReader.bool(forKey: "enabled", default: false) else {
+            return nil
+        }
+        self.init()
+
+        self.trustedCertificates = configReader.stringArray(forKey: "trustedCertificates")
+        if let verifyFlag = configReader.string(forKey: "verifyFlag", as: VerifyFlag.self) {
+            self.verifyFlag = verifyFlag
+        }
+
+        self.cert = configReader.string(forKey: "cert")
+        if let privateKey = configReader.string(forKey: "privateKey", isSecret: true) {
+            let password = try configReader.requiredString(forKey: "privateKeyPassword", isSecret: true)
+            self.privateKey = (key: privateKey, password: password)
+        }
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension CassandraClient.Configuration.LoadBalancingStrategy {
+    /// Initializes a load balancing strategy from a `ConfigReader`.
+    ///
+    /// ## Configuration keys:
+    /// - `strategy` (string, optional): The strategy to use, either "roundRobin" or "dataCenterAware". If
+    ///   absent, the initializer returns `nil`.
+    /// - `localDataCenter` (string, optional): Local data center name. Only supported by the "dataCenterAware" strategy.
+    ///
+    /// - Throws: If `strategy` is not one of the accepted values, or `localDataCenter` is set for the "roundRobin" strategy.
+    public init?(configReader: ConfigReader) throws {
+        guard let strategy = configReader.string(forKey: "strategy") else {
+            return nil
+        }
+        let localDataCenter = configReader.string(forKey: "localDataCenter")
+        switch strategy {
+        case "roundRobin":
+            guard localDataCenter == nil else {
+                throw CassandraClient.ConfigurationError(
+                    message:
+                        "'loadBalancingStrategy.localDataCenter' is not supported by the roundRobin strategy"
+                )
+            }
+            self = .roundRobin()
+        case "dataCenterAware":
+            self = .dataCenterAware(.init(localDataCenter: localDataCenter))
+        default:
+            throw CassandraClient.ConfigurationError(
+                message: "'loadBalancingStrategy.strategy' is not a valid strategy: \(strategy)"
+            )
+        }
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension CassandraClient.Configuration.SpeculativeExecutionPolicy {
+    /// Initializes a speculative execution policy from a `ConfigReader`.
+    ///
+    /// ## Configuration keys:
+    /// - `policy` (string, optional): The policy to use, either "constant" or "disabled". If absent, the
+    ///   initializer returns `nil`.
+    /// - `delayMillis` (int): Delay before each speculative execution, in milliseconds. Required when
+    ///   `policy` is "constant".
+    /// - `maxExecutions` (int): Maximum number of speculative executions. Required when `policy` is
+    ///   "constant". `0` permits no speculative executions.
+    ///
+    /// - Throws: If `policy` is not one of the accepted values or `delayMillis` / `maxExecutions` is negative or out of range, or a key required by "constant" is missing.
+    public init?(configReader: ConfigReader) throws {
+        guard let policy = configReader.string(forKey: "policy") else {
+            return nil
+        }
+        switch policy {
+        case "constant":
+            let delayInMillseconds = try configReader.requiredInt(forKey: "delayMillis")
+            guard delayInMillseconds >= 0 else {
+                throw CassandraClient.ConfigurationError(
+                    message:
+                        "'speculativeExecutionPolicy.delayMillis' must not be negative, got \(delayInMillseconds)"
+                )
+            }
+            let maxExecutions = try configReader.requiredInt32(forKey: "maxExecutions")
+            guard maxExecutions >= 0 else {
+                throw CassandraClient.ConfigurationError(
+                    message: "'speculativeExecutionPolicy.maxExecutions' must not be negative, got \(maxExecutions)"
+                )
+            }
+            self = .constant(delayInMillseconds: Int64(delayInMillseconds), maxExecutions: maxExecutions)
+        case "disabled":
+            self = .disabled
+        default:
+            throw CassandraClient.ConfigurationError(
+                message: "'speculativeExecutionPolicy.policy' is not a valid policy: \(policy)"
+            )
+        }
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension ConfigReader {
+    fileprivate func uint32(forKey key: ConfigKey) throws -> UInt32? {
+        guard let value = self.int(forKey: key) else {
+            return nil
+        }
+        return try Self.narrow(value, to: UInt32.self, forKey: key)
+    }
+
+    fileprivate func requiredInt32(forKey key: ConfigKey) throws -> Int32 {
+        try Self.narrow(self.requiredInt(forKey: key), to: Int32.self, forKey: key)
+    }
+
+    private static func narrow<Value: FixedWidthInteger>(
+        _ value: Int,
+        to: Value.Type,
+        forKey key: ConfigKey
+    ) throws -> Value {
+        guard let narrowed = Value(exactly: value) else {
+            throw CassandraClient.ConfigurationError(
+                message: "'\(key)' must be between \(Value.min) and \(Value.max), got \(value)"
+            )
+        }
+        return narrowed
+    }
+}
+#endif

--- a/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
+++ b/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
@@ -29,7 +29,7 @@ extension CassandraClient.Configuration {
     ///   `configReader` on each cluster creation rather than captured, so a reloading provider's new seeds
     ///   apply to subsequent connections. A re-read that fails validation fails that connection.
     /// - `port` (int, optional, default: 9042): Port the cluster listens on, 1 through 65535.
-    /// - `protocolVersion` (int, optional, default: 4): Native protocol version, 1 through 5.
+    /// - `protocolVersion` (int, optional, default: 4): Native protocol version, either 3 or 4.
     /// - `username` (string, optional): Username for plain text authentication. Unused when ``authenticator`` is set in code.
     /// - `password` (string, optional, secret): Password for plain text authentication. Unused when ``authenticator`` is set in code.
     /// - `keyspace` (string, optional): Keyspace the session connects to.
@@ -80,9 +80,14 @@ extension CassandraClient.Configuration {
             )
         }
 
+        // The driver accepts only these two: 1 and 2 are below its lowest supported version and 5 is
+        // beta-only, so all three would fail at cluster creation.
+        let supportedProtocolVersions: [ProtocolVersion] = [.v3, .v4]
         let rawProtocolVersion = configReader.int(forKey: "protocolVersion", default: 4)
-        guard let protocolVersion = Int32(exactly: rawProtocolVersion).flatMap(ProtocolVersion.init(rawValue:)) else {
-            let valids = ProtocolVersion.allCases.map(\.rawValue.description).joined(separator: ", ")
+        guard let protocolVersion = Int32(exactly: rawProtocolVersion).flatMap(ProtocolVersion.init(rawValue:)),
+            supportedProtocolVersions.contains(protocolVersion)
+        else {
+            let valids = supportedProtocolVersions.map(\.rawValue.description).joined(separator: ", ")
             throw CassandraClient.ConfigurationError(
                 message: "'protocolVersion' \(rawProtocolVersion) is invalid. Valid values: \(valids)"
             )
@@ -126,9 +131,9 @@ extension CassandraClient.Configuration {
         self.randomizedContactPoints = configReader.bool(forKey: "randomizedContactPoints")
         self.compact = configReader.bool(forKey: "compact")
 
-        self.consistency = configReader.string(forKey: "consistency")
-        self.serialConsistency = configReader.string(forKey: "serialConsistency")
-        self.prepareStrategy = configReader.string(forKey: "prepareStrategy")
+        self.consistency = try configReader.string(forKey: "consistency")
+        self.serialConsistency = try configReader.string(forKey: "serialConsistency")
+        self.prepareStrategy = try configReader.string(forKey: "prepareStrategy")
 
         if let value = configReader.bool(forKey: "metricsEnabled") {
             self.metricsEnabled = value
@@ -194,7 +199,7 @@ extension CassandraClient.Configuration.SSL {
         self.init()
 
         self.trustedCertificates = configReader.stringArray(forKey: "trustedCertificates")
-        if let verifyFlag = configReader.string(forKey: "verifyFlag", as: VerifyFlag.self) {
+        if let verifyFlag = try configReader.string(forKey: "verifyFlag", asOrThrow: VerifyFlag.self) {
             self.verifyFlag = verifyFlag
         }
 
@@ -307,6 +312,22 @@ extension ConfigReader {
             )
         }
         return narrowed
+    }
+
+    fileprivate func string<T: RawRepresentable>(
+        forKey key: ConfigKey,
+        asOrThrow: T.Type = T.self
+    ) throws -> T? where T.RawValue == String {
+        guard let string = self.string(forKey: key) else {
+            return nil  // Value doesn't exist, fine
+        }
+        // Value does exist, must be valid
+        guard let value = T(rawValue: string) else {
+            throw CassandraClient.ConfigurationError(
+                message: "'\(key)' is not a valid \(T.self): \(string)"
+            )
+        }
+        return value
     }
 }
 #endif

--- a/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
+++ b/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
@@ -14,6 +14,7 @@
 
 #if compiler(>=6.2)
 import Configuration
+import Logging
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension CassandraClient.Configuration {
@@ -56,7 +57,8 @@ extension CassandraClient.Configuration {
     /// - `metricsPollIntervalMillis` (int, optional): Metrics poller cadence in milliseconds. `0` leaves ``metricsEnabled`` on but stops the poller.
     /// - `metricsSessionName` (string, optional): Value of the `session` dimension on emitted metrics.
     /// - `ssl` (scoped, optional): SSL configuration read by ``CassandraClient/Configuration/SSL/init(configReader:)``.
-    ///   Only applied if `ssl.enabled` is `true`.
+    ///   Only applied if `ssl.enabled` is `true`. If it is not, but other `ssl` keys are set, those keys are
+    ///   ignored and a warning is logged to `logger`.
     /// - `loadBalancingStrategy` (scoped, optional): Load balancing strategy read by
     ///   ``CassandraClient/Configuration/LoadBalancingStrategy/init(configReader:)``. Only applied if
     ///   `loadBalancingStrategy.strategy` is present.
@@ -67,7 +69,11 @@ extension CassandraClient.Configuration {
     ///
     /// - Throws: If a value is out of range or is not one of the accepted values for its key, or a required key is missing. `contactPoints` is
     ///   validated here too, but because it is re-read it can also fail later, via the callback passed to ``contactPointsProvider``.
-    public init(configReader: ConfigReader) throws {
+    ///
+    /// - Parameters:
+    ///   - configReader: The reader to read configuration from.
+    ///   - logger: Logger for configuration warnings, such as SSL properties set while SSL is disabled
+    public init(configReader: ConfigReader, logger: Logger) throws {
         // Read once here so a malformed list is a configuration error at init rather than a connect-time
         // failure. The value is deliberately discarded: the provider below re-reads on every cluster
         // creation so that a reloading provider's new seeds take effect without a process restart.
@@ -143,8 +149,14 @@ extension CassandraClient.Configuration {
         }
         self.metricsSessionName = configReader.string(forKey: "metricsSessionName")
 
-        if let ssl = try SSL(configReader: configReader.scoped(to: "ssl")) {
+        let sslConfigReader = configReader.scoped(to: "ssl")
+        if let ssl = try SSL(configReader: sslConfigReader) {
             self.ssl = ssl
+        } else {
+            SSL.warnAboutIgnoredKeys(
+                configReader: sslConfigReader,
+                logger: logger
+            )
         }
         if let strategy = try LoadBalancingStrategy(
             configReader: configReader.scoped(to: "loadBalancingStrategy")
@@ -208,6 +220,39 @@ extension CassandraClient.Configuration.SSL {
             let password = try configReader.requiredString(forKey: "privateKeyPassword", isSecret: true)
             self.privateKey = (key: privateKey, password: password)
         }
+    }
+
+    /// Warns about SSL keys that are set but ignored because SSL is not enabled.
+    ///
+    /// Configuring certificates and then connecting in plain text is potentially a mistake, so we should make the user aware
+    internal static func warnAboutIgnoredKeys(configReader: ConfigReader, logger: Logger) {
+        var ignoredKeys: [String] = []
+        if configReader.stringArray(forKey: "trustedCertificates") != nil {
+            ignoredKeys.append("trustedCertificates")
+        }
+        if configReader.string(forKey: "verifyFlag") != nil {
+            ignoredKeys.append("verifyFlag")
+        }
+        if configReader.string(forKey: "cert") != nil {
+            ignoredKeys.append("cert")
+        }
+        if configReader.string(forKey: "privateKey", isSecret: true) != nil {
+            ignoredKeys.append("privateKey")
+        }
+        if configReader.string(forKey: "privateKeyPassword", isSecret: true) != nil {
+            ignoredKeys.append("privateKeyPassword")
+        }
+        guard !ignoredKeys.isEmpty else {
+            return
+        }
+        logger.warning(
+            "SSL properties are set but 'ssl.enabled' is not true, so they are ignored.",
+            metadata: [
+                CassandraClient.ConfigurationLogKey.ignoredKeys: .string(
+                    ignoredKeys.map { "ssl.\($0)" }.joined(separator: ", ")
+                )
+            ]
+        )
     }
 }
 

--- a/Sources/CassandraClient/Configuration.swift
+++ b/Sources/CassandraClient/Configuration.swift
@@ -162,12 +162,12 @@ extension CassandraClient {
             case disabled
         }
 
-        public enum PrepareStrategy: Sendable, Hashable {
+        public enum PrepareStrategy: String, Sendable, Hashable {
             case allHosts
             case upOrAddHost
         }
 
-        public enum ProtocolVersion: Int32, Sendable {
+        public enum ProtocolVersion: Int32, Sendable, CaseIterable {
             case v1 = 1
             case v2 = 2
             case v3 = 3
@@ -497,7 +497,7 @@ extension CassandraClient.Configuration {
         public var privateKey: (key: String, password: String)?
 
         /// Verification performed on the peer's certificate.
-        public enum VerifyFlag: Sendable {
+        public enum VerifyFlag: String, Sendable {
             /// Use DataStax driver's default, which is .peerCert
             case `default`
 

--- a/Sources/CassandraClient/Consistency.swift
+++ b/Sources/CassandraClient/Consistency.swift
@@ -16,7 +16,7 @@ internal import CDataStaxDriver
 
 extension CassandraClient {
     /// Consistency levels
-    public enum Consistency: Sendable, Hashable {
+    public enum Consistency: String, Sendable, Hashable {
         case any
         case one
         case two
@@ -58,7 +58,7 @@ extension CassandraClient {
     }
 
     /// Serial consistency levels
-    public enum SerialConsistency: Sendable, Hashable {
+    public enum SerialConsistency: String, Sendable, Hashable {
         case serial
         case localSerial
 

--- a/Sources/CassandraClient/Docs.docc/index.md
+++ b/Sources/CassandraClient/Docs.docc/index.md
@@ -6,14 +6,14 @@ A Cassandra client in Swift.
 
 `CassandraClient` is a Cassandra client in Swift. The client is based on [Datastax Cassandra C++ Driver](https://github.com/datastax/cpp-driver) wrapping it with Swift friendly APIs and data structures.
 
-`CassandraClient` API currently exposes [SwiftNIO](https://github.com/apple/swift-nio) based futures to simplify integration with SwiftNIO based servers. Swift concurrency based API is also available in Swift 5.5 and newer.
+`CassandraClient` API currently exposes [SwiftNIO](https://github.com/apple/swift-nio) based futures to simplify integration with SwiftNIO based servers. Swift concurrency based API is also available.
 
 ## Getting started
 
 ### Creating a client instance
 
 ```swift
-  let configuration = CassandraClient.Configuration(...)
+  let configuration = CassandraClient.Configuration(...) // Or use CassandraClient.Configuration(configReader:)
   let cassandraClient = CassandraClient(configuration: configuration)
 ```
 

--- a/Sources/CassandraClient/LogConstants.swift
+++ b/Sources/CassandraClient/LogConstants.swift
@@ -25,6 +25,11 @@ extension CassandraClient {
         static let boundValues = "request.boundValues"
     }
 
+    /// Structured-log metadata key names for configuration diagnostics.
+    internal enum ConfigurationLogKey {
+        static let ignoredKeys = "configuration.ignoredKeys"
+    }
+
     /// Structured-log metadata key names for encryption. Values are unchanged from their original
     /// definition (shipped keys — consumers may filter on them), just relocated here (by-kind).
     internal enum EncryptionLogKey {

--- a/Tests/CassandraClientTests/SwiftConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SwiftConfigurationTests.swift
@@ -14,6 +14,7 @@
 
 #if compiler(>=6.2)
 import Configuration
+import Logging
 import NIOConcurrencyHelpers
 import Testing
 
@@ -24,7 +25,10 @@ struct SwiftConfigurationTests {
     private func makeConfiguration(
         _ values: [AbsoluteConfigKey: ConfigValue]
     ) throws -> CassandraClient.Configuration {
-        try CassandraClient.Configuration(configReader: ConfigReader(provider: InMemoryProvider(values: values)))
+        try CassandraClient.Configuration(
+            configReader: ConfigReader(provider: InMemoryProvider(values: values)),
+            logger: .init(label: "test")
+        )
     }
 
     /// A configuration with only the required keys set, for tests that add one key at a time.
@@ -37,6 +41,23 @@ struct SwiftConfigurationTests {
         ]
         all.merge(values) { _, new in new }
         return try self.makeConfiguration(all)
+    }
+
+    /// As ``makeConfiguration(adding:)``, but captures what the initializer logs.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private func makeConfigurationCapturingLogs(
+        adding values: [AbsoluteConfigKey: ConfigValue]
+    ) throws -> (CassandraClient.Configuration, TestLogCapture) {
+        var all: [AbsoluteConfigKey: ConfigValue] = [
+            "contactPoints": .init(.stringArray(["localhost"]), isSecret: false)
+        ]
+        all.merge(values) { _, new in new }
+        let (logger, capture) = makeCapturingLogger()
+        let configuration = try CassandraClient.Configuration(
+            configReader: ConfigReader(provider: InMemoryProvider(values: all)),
+            logger: logger
+        )
+        return (configuration, capture)
     }
 
     /// Resolves the contact points the configuration was built with. The provider synthesised from
@@ -203,7 +224,10 @@ struct SwiftConfigurationTests {
         let provider = MutableInMemoryProvider(
             initialValues: ["contactPoints": .init(.stringArray(["seed-one"]), isSecret: false)]
         )
-        let config = try CassandraClient.Configuration(configReader: ConfigReader(provider: provider))
+        let config = try CassandraClient.Configuration(
+            configReader: ConfigReader(provider: provider),
+            logger: .init(label: "test")
+        )
         #expect(try self.contactPoints(of: config) == ["seed-one"])
 
         provider.setValue(
@@ -219,7 +243,10 @@ struct SwiftConfigurationTests {
         let provider = MutableInMemoryProvider(
             initialValues: ["contactPoints": .init(.stringArray(["seed-one"]), isSecret: false)]
         )
-        let config = try CassandraClient.Configuration(configReader: ConfigReader(provider: provider))
+        let config = try CassandraClient.Configuration(
+            configReader: ConfigReader(provider: provider),
+            logger: .init(label: "test")
+        )
         #expect(try self.contactPoints(of: config) == ["seed-one"])
 
         // Reloaded into an invalid state: the connection must fail rather than reuse "seed-one".
@@ -359,6 +386,38 @@ struct SwiftConfigurationTests {
         #expect(throws: (any Error).self) {
             try self.makeConfiguration(adding: ["ssl.enabled": true, "ssl.privateKey": "client-key"])
         }
+    }
+
+    @Test(arguments: [nil, false] as [Bool?])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sslPropertiesSetWhileDisabledWarns(enabled: Bool?) throws {
+        var values: [AbsoluteConfigKey: ConfigValue] = [
+            "ssl.trustedCertificates": .init(.stringArray(["cert-one"]), isSecret: false),
+            "ssl.verifyFlag": "peerIdentityDNS",
+            "ssl.cert": "client-cert",
+            "ssl.privateKey": .init(.string("client-key"), isSecret: true),
+            "ssl.privateKeyPassword": .init(.string("key-password"), isSecret: true),
+        ]
+        if let enabled {
+            values["ssl.enabled"] = .init(.bool(enabled), isSecret: false)
+        }
+        let (config, logs) = try self.makeConfigurationCapturingLogs(adding: values)
+
+        #expect(config.ssl == nil)
+        let warning = try #require(logs.all.first { $0.level == .warning })
+        #expect(logs.all.filter { $0.level == .warning }.count == 1)
+        #expect(
+            warning.metadata[CassandraClient.ConfigurationLogKey.ignoredKeys]?.description
+                == "ssl.trustedCertificates, ssl.verifyFlag, ssl.cert, ssl.privateKey, ssl.privateKeyPassword"
+        )
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sslDisabledWithNoSSLPropertiesDoesNotWarn() throws {
+        let (config, logs) = try self.makeConfigurationCapturingLogs(adding: ["ssl.enabled": false])
+        #expect(config.ssl == nil)
+        #expect(logs.all.filter { $0.level >= .warning }.isEmpty)
     }
 
     // MARK: - Load balancing

--- a/Tests/CassandraClientTests/SwiftConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SwiftConfigurationTests.swift
@@ -56,7 +56,7 @@ struct SwiftConfigurationTests {
         let config = try self.makeConfiguration([
             "contactPoints": .init(.stringArray(["localhost", "192.168.1.1"]), isSecret: false),
             "port": 9043,
-            "protocolVersion": 5,
+            "protocolVersion": 3,
             "username": "cassandra",
             "password": "secret",
             "keyspace": "test",
@@ -106,7 +106,7 @@ struct SwiftConfigurationTests {
 
         #expect(try self.contactPoints(of: config) == ["localhost", "192.168.1.1"])
         #expect(config.port == 9043)
-        #expect(config.protocolVersion == .v5)
+        #expect(config.protocolVersion == .v3)
         #expect(config.username == "cassandra")
         #expect(config.password == "secret")
         #expect(config.keyspace == "test")
@@ -274,11 +274,62 @@ struct SwiftConfigurationTests {
         }
     }
 
+    @Test(arguments: [1, 2, 5])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func protocolVersionTheDriverDoesNotSupportThrows(version: Int) {
+        // These are all ProtocolVersion cases, but the driver rejects them, so they are caught here
+        // rather than at connect time.
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["protocolVersion": .init(.int(version), isSecret: false)])
+        }
+    }
+
+    @Test(arguments: [3, 4])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func supportedProtocolVersionsAreAccepted(version: Int) throws {
+        let config = try self.makeConfiguration(
+            adding: ["protocolVersion": .init(.int(version), isSecret: false)]
+        )
+        #expect(config.protocolVersion.rawValue == Int32(version))
+    }
+
     @Test
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func outOfRangeUInt32Throws() {
         #expect(throws: CassandraClient.ConfigurationError.self) {
             try self.makeConfiguration(adding: ["connectTimeoutMillis": -1])
+        }
+    }
+
+    // MARK: - Enumerated string values
+
+    @Test(
+        arguments: [
+            "consistency",
+            "serialConsistency",
+            "prepareStrategy",
+            "ssl.verifyFlag",
+        ] as [AbsoluteConfigKey]
+    )
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func unrecognizedEnumeratedValueThrows(key: AbsoluteConfigKey) throws {
+        let error = #expect(throws: CassandraClient.ConfigurationError.self) {
+            // 'ssl.enabled' so that the SSL scope, and with it 'ssl.verifyFlag', is read at all.
+            try self.makeConfiguration(adding: ["ssl.enabled": true, key: "notAValidValue"])
+        }
+        // The offending key is named, so which of several enumerated keys was wrong is unambiguous.
+        // Scoped keys are reported relative to their scope, hence the last component only.
+        let message = try #require(error).message
+        #expect(message.contains(try #require(key.components.last)))
+        #expect(message.contains("notAValidValue"))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func serialConsistencyRejectsANonSerialLevel() {
+        // "quorum" is a valid 'consistency' but not a valid 'serialConsistency'.
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["serialConsistency": "quorum"])
         }
     }
 

--- a/Tests/CassandraClientTests/SwiftConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SwiftConfigurationTests.swift
@@ -1,0 +1,387 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+import Configuration
+import NIOConcurrencyHelpers
+import Testing
+
+@testable import CassandraClient
+
+struct SwiftConfigurationTests {
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private func makeConfiguration(
+        _ values: [AbsoluteConfigKey: ConfigValue]
+    ) throws -> CassandraClient.Configuration {
+        try CassandraClient.Configuration(configReader: ConfigReader(provider: InMemoryProvider(values: values)))
+    }
+
+    /// A configuration with only the required keys set, for tests that add one key at a time.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private func makeConfiguration(
+        adding values: [AbsoluteConfigKey: ConfigValue]
+    ) throws -> CassandraClient.Configuration {
+        var all: [AbsoluteConfigKey: ConfigValue] = [
+            "contactPoints": .init(.stringArray(["localhost"]), isSecret: false)
+        ]
+        all.merge(values) { _, new in new }
+        return try self.makeConfiguration(all)
+    }
+
+    /// Resolves the contact points the configuration was built with. The provider synthesised from
+    /// configuration is synchronous, so the result is available as soon as it returns.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private func contactPoints(of configuration: CassandraClient.Configuration) throws -> [String] {
+        let result = NIOLockedValueBox<Result<CassandraClient.Configuration.ContactPoints, Swift.Error>?>(nil)
+        configuration.contactPointsProvider { outcome in
+            result.withLockedValue { $0 = outcome }
+        }
+        return try #require(result.withLockedValue { $0 }).get()
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func allPropertiesAreSetFromConfig() throws {
+        let config = try self.makeConfiguration([
+            "contactPoints": .init(.stringArray(["localhost", "192.168.1.1"]), isSecret: false),
+            "port": 9043,
+            "protocolVersion": 5,
+            "username": "cassandra",
+            "password": "secret",
+            "keyspace": "test",
+
+            "numIOThreads": 4,
+            "connectTimeoutMillis": 5000,
+            "requestTimeoutMillis": 30000,
+            "resolveTimeoutMillis": 2000,
+
+            "slowQueryThresholdMillis": 250,
+            "logBoundValues": true,
+
+            "coreConnectionsPerHost": 2,
+            "tcpNodelay": true,
+            "tcpKeepalive": true,
+            "tcpKeepaliveDelaySeconds": 30,
+            "connectionHeartbeatInterval": 45,
+            "connectionIdleTimeout": 120,
+
+            "schema": true,
+            "hostnameResolution": true,
+            "randomizedContactPoints": true,
+            "compact": true,
+
+            "consistency": "localQuorum",
+            "serialConsistency": "localSerial",
+            "prepareStrategy": "allHosts",
+
+            "metricsEnabled": true,
+            "metricsPollIntervalMillis": 5000,
+            "metricsSessionName": "primary",
+
+            "ssl.enabled": true,
+            "ssl.trustedCertificates": .init(.stringArray(["cert-one", "cert-two"]), isSecret: false),
+            "ssl.verifyFlag": "peerIdentityDNS",
+            "ssl.cert": "client-cert",
+            "ssl.privateKey": "client-key",
+            "ssl.privateKeyPassword": "key-password",
+
+            "loadBalancingStrategy.strategy": "dataCenterAware",
+            "loadBalancingStrategy.localDataCenter": "dc1",
+
+            "speculativeExecutionPolicy.policy": "constant",
+            "speculativeExecutionPolicy.delayMillis": 100,
+            "speculativeExecutionPolicy.maxExecutions": 3,
+        ])
+
+        #expect(try self.contactPoints(of: config) == ["localhost", "192.168.1.1"])
+        #expect(config.port == 9043)
+        #expect(config.protocolVersion == .v5)
+        #expect(config.username == "cassandra")
+        #expect(config.password == "secret")
+        #expect(config.keyspace == "test")
+
+        #expect(config.numIOThreads == 4)
+        #expect(config.connectTimeoutMillis == 5000)
+        #expect(config.requestTimeoutMillis == 30000)
+        #expect(config.resolveTimeoutMillis == 2000)
+
+        #expect(config.slowQueryThresholdMillis == 250)
+        #expect(config.logBoundValues)
+
+        #expect(config.coreConnectionsPerHost == 2)
+        #expect(config.tcpNodelay == true)
+        #expect(config.tcpKeepalive == true)
+        #expect(config.tcpKeepaliveDelaySeconds == 30)
+        #expect(config.connectionHeartbeatInterval == 45)
+        #expect(config.connectionIdleTimeout == 120)
+
+        #expect(config.schema == true)
+        #expect(config.hostnameResolution == true)
+        #expect(config.randomizedContactPoints == true)
+        #expect(config.compact == true)
+
+        #expect(config.consistency == .localQuorum)
+        #expect(config.serialConsistency == .localSerial)
+        #expect(config.prepareStrategy == .allHosts)
+
+        #expect(config.metricsEnabled)
+        #expect(config.metricsPollIntervalMillis == 5000)
+        #expect(config.metricsSessionName == "primary")
+
+        let ssl = try #require(config.ssl)
+        #expect(ssl.trustedCertificates == ["cert-one", "cert-two"])
+        #expect(ssl.verifyFlag == .peerIdentityDNS)
+        #expect(ssl.cert == "client-cert")
+        #expect(ssl.privateKey?.key == "client-key")
+        #expect(ssl.privateKey?.password == "key-password")
+
+        #expect(config.loadBalancingStrategy == .dataCenterAware(.init(localDataCenter: "dc1")))
+        #expect(config.speculativeExecutionPolicy == .constant(delayInMillseconds: 100, maxExecutions: 3))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func defaultsAreUsedWhenOnlyContactPointsAreSet() throws {
+        let config = try self.makeConfiguration(adding: [:])
+
+        #expect(try self.contactPoints(of: config) == ["localhost"])
+        #expect(config.port == 9042)
+        #expect(config.protocolVersion == .v4)
+        #expect(config.username == nil)
+        #expect(config.password == nil)
+        #expect(config.keyspace == nil)
+
+        #expect(config.numIOThreads == nil)
+        #expect(config.connectTimeoutMillis == nil)
+        #expect(config.requestTimeoutMillis == nil)
+        #expect(config.resolveTimeoutMillis == nil)
+
+        #expect(config.slowQueryThresholdMillis == nil)
+        #expect(!config.logBoundValues)
+
+        #expect(config.coreConnectionsPerHost == nil)
+        #expect(config.tcpNodelay == nil)
+        #expect(config.tcpKeepalive == nil)
+        #expect(config.tcpKeepaliveDelaySeconds == 0)
+        #expect(config.connectionHeartbeatInterval == nil)
+        #expect(config.connectionIdleTimeout == nil)
+
+        #expect(config.schema == nil)
+        #expect(config.hostnameResolution == nil)
+        #expect(config.randomizedContactPoints == nil)
+        #expect(config.compact == nil)
+
+        #expect(config.consistency == nil)
+        #expect(config.serialConsistency == nil)
+        #expect(config.prepareStrategy == nil)
+
+        #expect(!config.metricsEnabled)
+        #expect(config.metricsPollIntervalMillis == 10000)
+        #expect(config.metricsSessionName == nil)
+
+        #expect(config.ssl == nil)
+        #expect(config.loadBalancingStrategy == nil)
+        #expect(config.speculativeExecutionPolicy == nil)
+    }
+
+    // MARK: - Contact points
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func contactPointsAreRereadOnEachClusterCreation() throws {
+        let provider = MutableInMemoryProvider(
+            initialValues: ["contactPoints": .init(.stringArray(["seed-one"]), isSecret: false)]
+        )
+        let config = try CassandraClient.Configuration(configReader: ConfigReader(provider: provider))
+        #expect(try self.contactPoints(of: config) == ["seed-one"])
+
+        provider.setValue(
+            ConfigValue(.stringArray(["seed-two", "seed-three"]), isSecret: false),
+            forKey: "contactPoints"
+        )
+        #expect(try self.contactPoints(of: config) == ["seed-two", "seed-three"])
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func contactPointsRereadFailureIsSurfacedToTheCallback() throws {
+        let provider = MutableInMemoryProvider(
+            initialValues: ["contactPoints": .init(.stringArray(["seed-one"]), isSecret: false)]
+        )
+        let config = try CassandraClient.Configuration(configReader: ConfigReader(provider: provider))
+        #expect(try self.contactPoints(of: config) == ["seed-one"])
+
+        // Reloaded into an invalid state: the connection must fail rather than reuse "seed-one".
+        provider.setValue(ConfigValue(.stringArray([]), isSecret: false), forKey: "contactPoints")
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.contactPoints(of: config)
+        }
+    }
+
+    @Test(
+        arguments: [
+            nil,
+            .init(.stringArray([]), isSecret: false),
+            .init(.stringArray([""]), isSecret: false),
+            .init(.stringArray(["localhost", " "]), isSecret: false),
+            .init(.stringArray(["\t"]), isSecret: false),
+        ] as [ConfigValue?]
+    )
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidContactPointsAreRejected(contactPoints: ConfigValue?) {
+        var values: [AbsoluteConfigKey: ConfigValue] = [:]
+        if let contactPoints {
+            values["contactPoints"] = contactPoints
+        }
+        #expect(throws: (any Error).self) {
+            try self.makeConfiguration(values)
+        }
+    }
+
+    // MARK: - Port and protocol version
+
+    @Test(arguments: [1, 65535])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func portBoundsAreAccepted(port: Int) throws {
+        let config = try self.makeConfiguration(adding: ["port": .init(.int(port), isSecret: false)])
+        #expect(config.port == Int32(port))
+    }
+
+    @Test(arguments: [0, -1, 65536, Int.max])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func outOfRangePortThrows(port: Int) {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["port": .init(.int(port), isSecret: false)])
+        }
+    }
+
+    @Test(arguments: [0, -1, 6, Int.max])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidProtocolVersionThrows(version: Int) {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["protocolVersion": .init(.int(version), isSecret: false)])
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func outOfRangeUInt32Throws() {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["connectTimeoutMillis": -1])
+        }
+    }
+
+    // MARK: - SSL
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sslIsIgnoredWhenNotEnabled() throws {
+        let config = try self.makeConfiguration(adding: ["ssl.cert": "client-cert"])
+        #expect(config.ssl == nil)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sslDefaults() throws {
+        let config = try self.makeConfiguration(adding: ["ssl.enabled": true])
+        let ssl = try #require(config.ssl)
+        #expect(ssl.trustedCertificates == nil)
+        #expect(ssl.verifyFlag == .default)
+        #expect(ssl.cert == nil)
+        #expect(ssl.privateKey == nil)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func sslPrivateKeyWithoutPasswordThrows() {
+        #expect(throws: (any Error).self) {
+            try self.makeConfiguration(adding: ["ssl.enabled": true, "ssl.privateKey": "client-key"])
+        }
+    }
+
+    // MARK: - Load balancing
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func loadBalancingRoundRobinWithLocalDataCenterThrows() {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(
+                adding: [
+                    "loadBalancingStrategy.strategy": "roundRobin",
+                    "loadBalancingStrategy.localDataCenter": "dc1",
+                ]
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func loadBalancingDataCenterAwareWithoutLocalDataCenter() throws {
+        let config = try self.makeConfiguration(adding: ["loadBalancingStrategy.strategy": "dataCenterAware"])
+        #expect(config.loadBalancingStrategy == .dataCenterAware(.init()))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidLoadBalancingStrategyThrows() {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["loadBalancingStrategy.strategy": "closestHost"])
+        }
+    }
+
+    // MARK: - Speculative execution
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func speculativeExecutionConstantMissingKeysThrows() {
+        #expect(throws: (any Error).self) {
+            try self.makeConfiguration(adding: ["speculativeExecutionPolicy.policy": "constant"])
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func speculativeExecutionConstantZeroIsAccepted() throws {
+        let config = try self.makeConfiguration(
+            adding: [
+                "speculativeExecutionPolicy.policy": "constant",
+                "speculativeExecutionPolicy.delayMillis": 0,
+                "speculativeExecutionPolicy.maxExecutions": 0,
+            ]
+        )
+        #expect(config.speculativeExecutionPolicy == .constant(delayInMillseconds: 0, maxExecutions: 0))
+    }
+
+    @Test(arguments: [(-1, 3), (100, -1), (-1, -1)])
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func negativeSpeculativeExecutionValuesThrow(delay: Int, maxExecutions: Int) {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(
+                adding: [
+                    "speculativeExecutionPolicy.policy": "constant",
+                    "speculativeExecutionPolicy.delayMillis": .init(.int(delay), isSecret: false),
+                    "speculativeExecutionPolicy.maxExecutions": .init(.int(maxExecutions), isSecret: false),
+                ]
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidSpeculativeExecutionPolicyThrows() {
+        #expect(throws: CassandraClient.ConfigurationError.self) {
+            try self.makeConfiguration(adding: ["speculativeExecutionPolicy.policy": "exponential"])
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Make it possible to configure Cassandra client using Swift configuration. I've followed the patterns used in async-http-client. Almost all of the configs are optional and default to the existing defaults.

None of the config is reloading, except for contact points provider.