### PR TITLE
Make Statement.setPagingSize public and validate the page size

### DIFF
--- a/Sources/CassandraClient/CassandraClient.swift
+++ b/Sources/CassandraClient/CassandraClient.swift
@@ -139,7 +139,8 @@ public final class CassandraClient: CassandraSession, Sendable {
 
     /// Execute a ``Statement`` using the default ``CassandraSession`` on the given `EventLoop` or create a new one.
     ///
-    /// **All** rows are returned.
+    /// **All** rows are returned, unless the statement sets a page size with
+    /// ``Statement/setPagingSize(_:)``, which limits the result to a single page.
     ///
     /// - Parameters:
     ///   - statement: The ``Statement`` to execute.
@@ -163,7 +164,8 @@ public final class CassandraClient: CassandraSession, Sendable {
     ///
     /// - Parameters:
     ///   - statement: The ``Statement`` to execute.
-    ///   - pageSize: The maximum number of rows returned per page.
+    ///   - pageSize: The maximum number of rows returned per page. Must be positive; a
+    ///     non-positive size fails the call with ``CassandraClient/Error/badParams(_:)``.
     ///   - eventLoop: The `EventLoop` to use, or create a new one.
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
@@ -477,7 +479,8 @@ public final class CassandraClient: CassandraSession, Sendable {
 extension CassandraClient {
     /// Execute a ``Statement`` using the default ``CassandraSession``.
     ///
-    /// **All** rows are returned.
+    /// **All** rows are returned, unless the statement sets a page size with
+    /// ``Statement/setPagingSize(_:)``, which limits the result to a single page.
     ///
     /// - Parameters:
     ///   - statement: The ``Statement`` to execute.
@@ -495,7 +498,8 @@ extension CassandraClient {
     ///
     /// - Parameters:
     ///   - statement: The ``Statement`` to execute.
-    ///   - pageSize: The maximum number of rows returned per page.
+    ///   - pageSize: The maximum number of rows returned per page. Must be positive; a
+    ///     non-positive size fails the call with ``CassandraClient/Error/badParams(_:)``.
     ///   - logger: If `nil`, the client's default `Logger` is used.
     ///
     /// - Returns: The ``PaginatedRows``.

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -1067,7 +1067,7 @@ extension CassandraClient {
             let eventLoop = eventLoop ?? self.eventLoopGroup.next()
 
             do {
-                try statement.setPagingSize(pageSize)
+                try statement.setPagingSize(Int(pageSize))
             } catch {
                 if let cassError = error as? CassandraClient.Error {
                     CassandraClient.RequestLog.logFailure(
@@ -1902,7 +1902,7 @@ extension CassandraClient.Session {
         logger: Logger? = .none
     ) async throws -> CassandraClient.PaginatedRows {
         do {
-            try statement.setPagingSize(pageSize)
+            try statement.setPagingSize(Int(pageSize))
         } catch {
             if let cassError = error as? CassandraClient.Error {
                 CassandraClient.RequestLog.logFailure(

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -40,7 +40,8 @@ import NIOCore  // for async-await bridge
 
     /// Execute a prepared statement.
     ///
-    /// **All** rows are returned.
+    /// **All** rows are returned, unless the statement sets a page size with
+    /// ``CassandraClient/Statement/setPagingSize(_:)``, which limits the result to a single page.
     ///
     /// - Parameters:
     ///   - statement: The ``CassandraClient/Statement`` to execute.
@@ -61,7 +62,8 @@ import NIOCore  // for async-await bridge
     ///
     /// - Parameters:
     ///   - statement: The ``CassandraClient/Statement`` to execute.
-    ///   - pageSize: The maximum number of rows returned per page.
+    ///   - pageSize: The maximum number of rows returned per page. Must be positive; a
+    ///     non-positive size fails the call with ``CassandraClient/Error/badParams(_:)``.
     ///   - eventLoop: The `EventLoop` to use. Optional.
     ///   - logger: The `Logger` to use. Optional.
     ///
@@ -114,7 +116,8 @@ import NIOCore  // for async-await bridge
 
     /// Execute a prepared statement.
     ///
-    /// **All** rows are returned.
+    /// **All** rows are returned, unless the statement sets a page size with
+    /// ``CassandraClient/Statement/setPagingSize(_:)``, which limits the result to a single page.
     ///
     /// - Parameters:
     ///   - statement: The ``CassandraClient/Statement`` to execute.
@@ -134,7 +137,8 @@ import NIOCore  // for async-await bridge
     ///
     /// - Parameters:
     ///   - statement: The ``CassandraClient/Statement`` to execute.
-    ///   - pageSize: The maximum number of rows returned per page.
+    ///   - pageSize: The maximum number of rows returned per page. Must be positive; a
+    ///     non-positive size fails the call with ``CassandraClient/Error/badParams(_:)``.
     ///   - logger: The `Logger` to use. Optional.
     ///
     /// - Returns: The resulting ``CassandraClient/PaginatedRows``.
@@ -253,7 +257,8 @@ extension CassandraSession {
 
     /// Execute a prepared statement.
     ///
-    /// **All** rows are returned.
+    /// **All** rows are returned, unless the statement sets a page size with
+    /// ``CassandraClient/Statement/setPagingSize(_:)``, which limits the result to a single page.
     ///
     /// - Parameters:
     ///   - statement: The ``CassandraClient/Statement`` to execute.
@@ -429,6 +434,8 @@ extension CassandraSession {
     }
 
     /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`.
+    ///
+    /// A non-positive `pageSize` fails the call with ``CassandraClient/Error/badParams(_:)``.
     ///
     /// If `eventLoop` is `nil`, a new one will get created through the `EventLoopGroup` provided during initialization.
     public func query(
@@ -1657,6 +1664,8 @@ extension CassandraSession {
     }
 
     /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`.
+    ///
+    /// A non-positive `pageSize` fails the call with ``CassandraClient/Error/badParams(_:)``.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func query(
         _ query: String,
@@ -1677,6 +1686,8 @@ extension CassandraSession {
     /// Query large data-sets where the number of rows fetched at a time is limited by `pageSize`,
     /// decoding each row into `T` as the sequence is iterated, rather than materializing the whole
     /// decoded result set as an array.
+    ///
+    /// A non-positive `pageSize` fails the call with ``CassandraClient/Error/badParams(_:)``.
     ///
     /// - Note: Unlike the raw ``query(_:parameters:pageSize:options:logger:)`` sequence, decoded values
     ///   are independent Swift values and remain valid after the sequence is advanced.
@@ -1706,6 +1717,8 @@ extension CassandraSession {
     /// This is equivalent to the sibling `query(...)` overload that infers `T` purely from the return type,
     /// but spells out the decoded type explicitly at the call site, e.g.
     /// `try await session.query("select ...", pageSize: 100, withModelType: Model.self)`.
+    ///
+    /// A non-positive `pageSize` fails the call with ``CassandraClient/Error/badParams(_:)``.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func query<T: Decodable & Sendable>(
         _ query: String,

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -295,7 +295,8 @@ extension CassandraClient {
             return cass_statement_bind_collection(self.rawPointer, index, collection)
         }
 
-        func setPagingSize(_ pagingSize: Int32) throws {
+        /// Sets the paging size of the returned paginated results.
+        public func setPagingSize(_ pagingSize: Int32) throws {
             try checkResult { cass_statement_set_paging_size(self.rawPointer, pagingSize) }
         }
 

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -295,9 +295,26 @@ extension CassandraClient {
             return cass_statement_bind_collection(self.rawPointer, index, collection)
         }
 
-        /// Sets the paging size of the returned paginated results.
+        /// Sets the maximum number of rows the server returns per page for this statement.
+        ///
+        /// This bounds the `execute` variants that take a `Statement` and no `pageSize`, which
+        /// otherwise return every row: the result becomes a single page, and pairing this with
+        /// ``setPagingStateToken(_:)`` walks the rest by hand. The `execute` variants that do take a
+        /// `pageSize` set it from that argument, overwriting whatever is set here. The `query`
+        /// variants build their own statement, so this never reaches them.
+        ///
+        /// - Parameter pagingSize: Rows per page. Must be in `1...Int32.max`; a non-positive size
+        ///   disables paging in the driver rather than limiting the page, and is rejected here.
+        ///
+        /// - Note: The `EventLoopFuture` `execute` takes the statement as `sending`, so a hand-rolled
+        ///   loop needs a new `Statement` for each page.
         public func setPagingSize(_ pagingSize: Int) throws {
-            try checkResult { cass_statement_set_paging_size(self.rawPointer, Int32(clamping: pagingSize)) }
+            guard let size = Int32(exactly: pagingSize), size > 0 else {
+                throw CassandraClient.Error.badParams(
+                    "Paging size must be between 1 and \(Int32.max), got \(pagingSize)"
+                )
+            }
+            try checkResult { cass_statement_set_paging_size(self.rawPointer, size) }
         }
 
         /// Sets the starting page of the returned paginated results.

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -296,8 +296,8 @@ extension CassandraClient {
         }
 
         /// Sets the paging size of the returned paginated results.
-        public func setPagingSize(_ pagingSize: Int32) throws {
-            try checkResult { cass_statement_set_paging_size(self.rawPointer, pagingSize) }
+        public func setPagingSize(_ pagingSize: Int) throws {
+            try checkResult { cass_statement_set_paging_size(self.rawPointer, Int32(clamping: pagingSize)) }
         }
 
         /// Sets the starting page of the returned paginated results.

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -427,7 +427,7 @@ final class Tests: XCTestCase {
         XCTAssertLessThanOrEqual(
             secondIDs.count,
             pageSize,
-            "the resumed page should be bounded the same way"
+            "the resumed page should not exceed the page size"
         )
         XCTAssertFalse(secondIDs.isEmpty, "the resumed page should not be empty")
         XCTAssertTrue(

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -371,6 +371,71 @@ final class Tests: XCTestCase {
         XCTAssertEqual(id1.int32, id2.int32)
     }
 
+    /// A page size set on the statement itself bounds the result of a plain (non-paginated) execute,
+    /// which is what lets a caller drive paging by hand: read a page, keep its token, resume from it.
+    func testPagingSizeOnStatement() throws {
+        let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
+        try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
+            .wait()
+
+        let options = CassandraClient.Statement.Options(consistency: .localQuorum)
+        let count = 50
+        let pageSize = 10
+        var futures = [EventLoopFuture<Void>]()
+        for index in 0..<count {
+            futures.append(
+                self.cassandraClient.run(
+                    "insert into \(tableName) (id, data) values (?, ?);",
+                    parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
+                    options: options
+                )
+            )
+        }
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
+
+        let query = "select id, data from \(tableName);"
+
+        // Control: the same execute on a statement with no page size returns every row.
+        let unboundedStatement = try CassandraClient.Statement(query: query)
+        let allRows = try self.cassandraClient.execute(statement: unboundedStatement, on: nil).wait()
+        XCTAssertEqual(allRows.count, count, "a statement with no page size should return every row")
+
+        let firstStatement = try CassandraClient.Statement(query: query)
+        try firstStatement.setPagingSize(pageSize)
+        let firstPage = try self.cassandraClient.execute(statement: firstStatement, on: nil).wait()
+        let firstIDs = firstPage.compactMap { $0.column(0)?.int32 }
+        // Cassandra may return a short page, so the bound is what matters, not an exact count.
+        XCTAssertLessThanOrEqual(
+            firstIDs.count,
+            pageSize,
+            "the page size set on the statement should bound the page"
+        )
+        XCTAssertFalse(firstIDs.isEmpty, "the page should not be empty")
+
+        // Stop here if the page was not bounded: the result then has no paging state, and reading its
+        // token would throw over the assertion failure above rather than reporting it.
+        guard !firstIDs.isEmpty, firstIDs.count < count else { return }
+
+        // Resuming from the first page's token with the same page size yields the following page.
+        let secondStatement = try CassandraClient.Statement(query: query)
+        try secondStatement.setPagingSize(pageSize)
+        try secondStatement.setPagingStateToken(try firstPage.opaquePagingStateToken())
+        let secondPage = try self.cassandraClient.execute(statement: secondStatement, on: nil).wait()
+        let secondIDs = secondPage.compactMap { $0.column(0)?.int32 }
+        XCTAssertLessThanOrEqual(
+            secondIDs.count,
+            pageSize,
+            "the resumed page should be bounded the same way"
+        )
+        XCTAssertFalse(secondIDs.isEmpty, "the resumed page should not be empty")
+        XCTAssertTrue(
+            Set(firstIDs).isDisjoint(with: Set(secondIDs)),
+            "the resumed page should not repeat rows from the first page"
+        )
+    }
+
     /// Exhaustion edge (EventLoopFuture API): once every page has been consumed,
     /// `hasMorePages` reads `false` and a further `nextPage()` fails with
     /// `CassandraClient.Error.rowsExhausted`.

--- a/Tests/CassandraClientTests/StatementPagingSizeTests.swift
+++ b/Tests/CassandraClientTests/StatementPagingSizeTests.swift
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CassandraClient
+import NIO
+import XCTest
+
+/// Unit tests for ``CassandraClient/Statement/setPagingSize(_:)``. Statement configuration needs no
+/// cluster, and neither does a rejected page size on the paginated entry points — the page size is
+/// applied before the request reaches a connection — so the accepted range is pinned here rather
+/// than in the integration suite.
+///
+/// - Note: Imported without `@testable` (unlike the rest of the suite) so that the file stops
+///   compiling if `setPagingSize` loses its `public` access level.
+final class StatementPagingSizeTests: XCTestCase {
+    private func makeStatement() throws -> CassandraClient.Statement {
+        try CassandraClient.Statement(query: "select id from test;")
+    }
+
+    /// A client that is never expected to reach a node: these calls fail on the page size first.
+    private func makeClient() -> CassandraClient {
+        CassandraClient(
+            configuration: CassandraClient.Configuration(
+                contactPointsProvider: { callback in callback(.success(["127.0.0.1"])) },
+                port: 9042,
+                protocolVersion: .v3
+            )
+        )
+    }
+
+    /// `Error.badParams` carries its message in the payload, so equality would pin the wording;
+    /// `shortDescription` identifies the case without doing that.
+    private func assertBadParams(
+        _ error: Swift.Error,
+        _ subject: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            (error as? CassandraClient.Error)?.shortDescription,
+            "Bad parameters",
+            "\(subject) should be rejected as a bad parameter, got \(error)",
+            file: file,
+            line: line
+        )
+    }
+
+    func testAcceptsPositiveSizes() throws {
+        let statement = try self.makeStatement()
+        for size in [1, 10, 5000, Int(Int32.max)] {
+            XCTAssertNoThrow(try statement.setPagingSize(size), "page size \(size) should be accepted")
+        }
+    }
+
+    /// The driver treats a non-positive page size as "paging disabled" instead of clamping it, so the
+    /// wrapper rejects it rather than returning an unpaginated result from a paginated call.
+    func testRejectsNonPositiveSizes() throws {
+        let statement = try self.makeStatement()
+        for size in [0, -1, Int(Int32.min)] {
+            XCTAssertThrowsError(try statement.setPagingSize(size)) { error in
+                self.assertBadParams(error, "page size \(size)")
+            }
+        }
+    }
+
+    /// The driver's page size is a C `int`, so sizes above `Int32.max` throw instead of trapping on
+    /// the narrowing conversion. Only meaningful where `Int` is wider than `Int32`.
+    func testRejectsSizesAboveInt32Max() throws {
+        try XCTSkipUnless(Int.bitWidth > 32, "Int is no wider than Int32 on this platform")
+        let statement = try self.makeStatement()
+        for size in [Int(Int32.max) + 1, Int.max] {
+            XCTAssertThrowsError(try statement.setPagingSize(size)) { error in
+                self.assertBadParams(error, "page size \(size)")
+            }
+        }
+    }
+
+    /// The public `pageSize:` entry points share this validation, so a size the driver would ignore
+    /// fails the call rather than returning every row from a paginated one.
+    func testPaginatedQueryRejectsNonPositivePageSize() throws {
+        let client = self.makeClient()
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        XCTAssertThrowsError(
+            try client.query("select id from test;", pageSize: Int32(0)).wait()
+        ) { error in
+            self.assertBadParams(error, "pageSize 0 on the EventLoopFuture query")
+        }
+    }
+
+    /// The async paginated path applies the page size in separate code from the `EventLoopFuture`
+    /// path, so it gets its own assertion.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func testPaginatedAsyncQueryRejectsNonPositivePageSize() async throws {
+        let client = self.makeClient()
+
+        do {
+            let rows: CassandraClient.PaginatedRows = try await client.query(
+                "select id from test;",
+                pageSize: Int32(-1)
+            )
+            XCTFail("expected a bad parameter error, got \(rows)")
+        } catch {
+            self.assertBadParams(error, "pageSize -1 on the async query")
+        }
+
+        try await client.shutdownAsync()
+    }
+
+    /// ``CassandraClient/Statement/setPagingSize(_:)`` documents that the `pageSize`-taking variants
+    /// overwrite a size already set on the statement. Applying a rejected size to a statement that
+    /// carries a valid one pins that: the call fails, so the argument was applied unconditionally
+    /// rather than deferring to what the statement already held.
+    func testPaginatedExecuteOverwritesTheStatementPagingSize() throws {
+        let client = self.makeClient()
+        defer { XCTAssertNoThrow(try client.shutdown()) }
+
+        let statement = try self.makeStatement()
+        try statement.setPagingSize(10)
+
+        XCTAssertThrowsError(
+            try client.execute(statement: statement, pageSize: Int32(0), on: nil).wait()
+        ) { error in
+            self.assertBadParams(error, "pageSize 0 over a statement already set to 10")
+        }
+    }
+}


### PR DESCRIPTION
### Motivation:

`Statement.setPagingStateToken` is public, but `setPagingSize` was internal, so the page size could only be set through the `execute`/`query` variants that take a `pageSize` — and those build the statement themselves. Bounding the page of a caller-configured statement, which is what driving pagination by hand requires, was not possible. Supersedes #30 and keeps its commits.

### Modifications:

Made `setPagingSize` public, taking `Int` rather than `Int32`. Rejected sizes outside `1...Int32.max` with `badParams`: the driver's page size is a C `int`, so a larger value would trap on the narrowing conversion, and a non-positive one disables paging in the driver rather than limiting the page, returning the whole result set. Documented the constraint on all eight public entry points that take a `pageSize`, and qualified "**All** rows are returned" wherever a caller-supplied statement can now bound it. Added unit tests for the accepted range, both paginated entry points, and the documented overwrite of a size already set on the statement, plus an integration test that pages a statement by hand.

### Result:

A per-statement page size can be set and paired with `setPagingStateToken(_:)` to walk pages by hand, and a page size the driver would ignore is reported instead of silently changing the result shape.

Source-compatible, with one behavior change: the existing `pageSize: Int32` entry points share the validation, so a `pageSize` of `0` or below now fails where it previously returned every row from a paginated call. Unifying those parameters on `Int` is a follow-up.

Co-authored-by: Igor Milyakov <imilyakov@apple.com>
