### PR TITLE
Allow contact points provider to be set separately from ConfigReader

### DIFF
--- a/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
+++ b/Sources/CassandraClient/Configuration+SwiftConfiguration.swift
@@ -24,6 +24,10 @@ extension CassandraClient.Configuration {
     /// property at its default, and every value is read once here — later provider updates do not affect the
     /// returned configuration. `contactPoints` is the only exception.
     ///
+    /// To supply the contact points in code instead — e.g. from service discovery — use
+    /// ``init(configReader:contactPointsProvider:logger:)``, which reads every other key exactly as this
+    /// initializer does.
+    ///
     /// ## Configuration keys:
     /// - `contactPoints` (string array, required): Initial contact points of the Cassandra cluster. Must hold
     ///   at least one entry, none of them blank. Unlike every other key, this one is re-read from
@@ -79,6 +83,68 @@ extension CassandraClient.Configuration {
         // creation so that a reloading provider's new seeds take effect without a process restart.
         _ = try Self.contactPoints(from: configReader)
 
+        let (port, protocolVersion) = try Self.portAndProtocolVersion(from: configReader)
+        self.init(
+            contactPointsProvider: { callback in
+                // A re-read that no longer validates fails the connection rather than falling back to the
+                // seeds from init: silently connecting with stale seeds is far harder to diagnose.
+                callback(Result { try Self.contactPoints(from: configReader) })
+            },
+            port: port,
+            protocolVersion: protocolVersion
+        )
+
+        try self.read(from: configReader, logger: logger)
+    }
+
+    /// Initializes ``CassandraClient/Configuration`` from a `ConfigReader`, with the cluster's contact
+    /// points supplied in code rather than read from configuration.
+    ///
+    /// Use this initializer when the contact points come from somewhere other than configuration — service
+    /// discovery, for example. Every key documented on ``init(configReader:logger:)`` is read in the same way,
+    /// except `contactPoints`, which is ignored here. A warning is logged to `logger` if it is set.
+    ///
+    /// - Throws: If a value is out of range or is not one of the accepted values for its key, or a required
+    ///   key is missing.
+    ///
+    /// - Parameters:
+    ///   - configReader: The reader to read configuration from.
+    ///   - contactPointsProvider: Provides the initial `ContactPoints` of the Cassandra cluster, and is
+    ///     invoked once per cluster creation. This can be a subset since each Cassandra instance is capable
+    ///     of discovering its peers.
+    ///   - logger: Logger for configuration warnings, such as SSL properties set while SSL is disabled
+    public init(
+        configReader: ConfigReader,
+        contactPointsProvider:
+            @escaping @Sendable (@escaping @Sendable (Result<ContactPoints, Swift.Error>) -> Void) ->
+            Void,
+        logger: Logger
+    ) throws {
+        if configReader.stringArray(forKey: "contactPoints") != nil {
+            logger.warning(
+                "'contactPoints' is set but the contact points are supplied in code, so the key is ignored.",
+                metadata: [
+                    CassandraClient.ConfigurationLogKey.ignoredKeys: .string("contactPoints")
+                ]
+            )
+        }
+
+        let (port, protocolVersion) = try Self.portAndProtocolVersion(from: configReader)
+        self.init(
+            contactPointsProvider: contactPointsProvider,
+            port: port,
+            protocolVersion: protocolVersion
+        )
+
+        try self.read(from: configReader, logger: logger)
+    }
+
+    /// Reads and validates `port` and `protocolVersion`, which the designated initializer requires up front.
+    ///
+    /// - Throws: If either value is out of range, or `protocolVersion` is one the driver rejects.
+    private static func portAndProtocolVersion(
+        from configReader: ConfigReader
+    ) throws -> (port: Int32, protocolVersion: ProtocolVersion) {
         let rawPort = configReader.int(forKey: "port", default: 9042)
         guard let port = Int32(exactly: rawPort), (1...65535).contains(port) else {
             throw CassandraClient.ConfigurationError(
@@ -99,16 +165,12 @@ extension CassandraClient.Configuration {
             )
         }
 
-        self.init(
-            contactPointsProvider: { callback in
-                // A re-read that no longer validates fails the connection rather than falling back to the
-                // seeds from init: silently connecting with stale seeds is far harder to diagnose.
-                callback(Result { try Self.contactPoints(from: configReader) })
-            },
-            port: port,
-            protocolVersion: protocolVersion
-        )
+        return (port, protocolVersion)
+    }
 
+    /// Reads every property other than the contact points, `port` and `protocolVersion`, which each
+    /// initializer handles itself.
+    private mutating func read(from configReader: ConfigReader, logger: Logger) throws {
         self.username = configReader.string(forKey: "username")
         self.password = configReader.string(forKey: "password", isSecret: true)
         self.keyspace = configReader.string(forKey: "keyspace")

--- a/Tests/CassandraClientTests/SwiftConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SwiftConfigurationTests.swift
@@ -71,6 +71,53 @@ struct SwiftConfigurationTests {
         return try #require(result.withLockedValue { $0 }).get()
     }
 
+    /// As ``makeConfiguration(_:)``, but with the contact points supplied in code.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private func makeConfiguration(
+        _ values: [AbsoluteConfigKey: ConfigValue],
+        contactPointsProvider:
+            @escaping @Sendable (
+                @escaping @Sendable (Result<CassandraClient.Configuration.ContactPoints, Swift.Error>) -> Void
+            ) -> Void
+    ) throws -> CassandraClient.Configuration {
+        try CassandraClient.Configuration(
+            configReader: ConfigReader(provider: InMemoryProvider(values: values)),
+            contactPointsProvider: contactPointsProvider,
+            logger: .init(label: "test")
+        )
+    }
+
+    /// As ``makeConfiguration(_:contactPointsProvider:)``, but captures what the initializer logs.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private func makeConfigurationCapturingLogs(
+        _ values: [AbsoluteConfigKey: ConfigValue],
+        contactPointsProvider:
+            @escaping @Sendable (
+                @escaping @Sendable (Result<CassandraClient.Configuration.ContactPoints, Swift.Error>) -> Void
+            ) -> Void
+    ) throws -> (CassandraClient.Configuration, TestLogCapture) {
+        let (logger, capture) = makeCapturingLogger()
+        let configuration = try CassandraClient.Configuration(
+            configReader: ConfigReader(provider: InMemoryProvider(values: values)),
+            contactPointsProvider: contactPointsProvider,
+            logger: logger
+        )
+        return (configuration, capture)
+    }
+
+    /// A provider that yields a fixed set of contact points
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    private static func staticProvider(
+        _ contactPoints: CassandraClient.Configuration.ContactPoints
+    )
+        -> @Sendable (@escaping @Sendable (Result<CassandraClient.Configuration.ContactPoints, Swift.Error>) -> Void)
+        -> Void
+    {
+        { callback in callback(.success(contactPoints)) }
+    }
+
+    private struct DiscoveryFailure: Swift.Error {}
+
     @Test
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func allPropertiesAreSetFromConfig() throws {
@@ -274,6 +321,74 @@ struct SwiftConfigurationTests {
         #expect(throws: (any Error).self) {
             try self.makeConfiguration(values)
         }
+    }
+
+    // MARK: - Contact points supplied in code
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func contactPointsProviderSuppliesTheContactPoints() throws {
+        let (config, logs) = try self.makeConfigurationCapturingLogs(
+            [:],
+            contactPointsProvider: Self.staticProvider(["discovered-one", "discovered-two"])
+        )
+        #expect(try self.contactPoints(of: config) == ["discovered-one", "discovered-two"])
+        #expect(logs.all.filter { $0.level >= .warning }.isEmpty)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func contactPointsProviderFailureIsSurfacedToTheCallback() throws {
+        // Discovery failing is the normal transient state for a provider supplied in code, so the error must
+        // reach the caller rather than be swallowed into an empty contact point list.
+        let config = try self.makeConfiguration(
+            [:],
+            contactPointsProvider: { callback in callback(.failure(DiscoveryFailure())) }
+        )
+        #expect(throws: DiscoveryFailure.self) {
+            try self.contactPoints(of: config)
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func otherPropertiesAreStillReadWhenContactPointsAreSuppliedInCode() throws {
+        let config = try self.makeConfiguration(
+            [
+                "port": 9043,
+                "protocolVersion": 3,
+                "keyspace": "test",
+                "consistency": "localQuorum",
+                "ssl.enabled": true,
+                "ssl.verifyFlag": "peerCert",
+                "loadBalancingStrategy.strategy": "dataCenterAware",
+                "loadBalancingStrategy.localDataCenter": "dc1",
+            ],
+            contactPointsProvider: Self.staticProvider(["discovered"])
+        )
+
+        #expect(config.port == 9043)
+        #expect(config.protocolVersion == .v3)
+        #expect(config.keyspace == "test")
+        #expect(config.consistency == .localQuorum)
+        #expect(config.ssl?.verifyFlag == .peerCert)
+        #expect(config.loadBalancingStrategy == .dataCenterAware(.init(localDataCenter: "dc1")))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func configuredContactPointsAreIgnoredAndWarnedAboutWhenSuppliedInCode() throws {
+        let (config, logs) = try self.makeConfigurationCapturingLogs(
+            ["contactPoints": .init(.stringArray(["from-config"]), isSecret: false)],
+            contactPointsProvider: Self.staticProvider(["from-provider"])
+        )
+
+        #expect(try self.contactPoints(of: config) == ["from-provider"])
+        let warning = try #require(logs.all.first { $0.level == .warning })
+        #expect(logs.all.filter { $0.level == .warning }.count == 1)
+        #expect(
+            warning.metadata[CassandraClient.ConfigurationLogKey.ignoredKeys]?.description == "contactPoints"
+        )
     }
 
     // MARK: - Port and protocol version


### PR DESCRIPTION
### Motivation:

The contact points provider will often come from something whic needs to be manually wired in, rather than something which can be represented in config. For example, service discovery

The config reader inits added in #126 do not let users make the config using a ConfigReader but then override the contact points provider, because they require the config to contain the provider

### Modifications:

Create a second init which allows users to specify the contact points provider separately from the ConfigReader
