### PR TITLE
Require encryptedColumns and correct public interface defects ahead of 1.0

### DIFF
--- a/Sources/CassandraClient/Batch.swift
+++ b/Sources/CassandraClient/Batch.swift
@@ -17,7 +17,7 @@ import Foundation
 
 extension CassandraClient {
     /// The type of a batch operation.
-    public struct BatchType: Sendable, Equatable {
+    public struct BatchType: Sendable, Hashable {
         let rawValue: CassBatchType
 
         /// All statements are applied atomically with a write to the batch log.
@@ -29,13 +29,16 @@ extension CassandraClient {
     }
 
     /// A batch of statements to execute in Cassandra.
+    ///
+    /// Not `Sendable`: a `Batch` must not be used concurrently, and `~Copyable` enforces single
+    /// ownership so it cannot be reused after execution.
     public struct Batch: ~Copyable {
         internal let rawPointer: OpaquePointer
         internal let resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)?
 
         internal init(
             configuration: Configuration,
-            resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)? = nil
+            resolver: ((PreparedStatement, [Statement.Value], Statement.Options) throws -> Statement)?
         ) throws {
             self.rawPointer = cass_batch_new(configuration.type.rawValue)
             self.resolver = resolver
@@ -132,6 +135,10 @@ extension CassandraClient {
         }
     }
 }
+
+// `Batch` is intentionally not `Sendable`; see the type's documentation.
+@available(*, unavailable)
+extension CassandraClient.Batch: Sendable {}
 
 private func checkResult(body: () -> CassError) throws {
     let result = body()

--- a/Sources/CassandraClient/Data.swift
+++ b/Sources/CassandraClient/Data.swift
@@ -217,6 +217,12 @@ extension CassandraClient {
         public func isNull() -> Bool {
             cass_value_is_null(self.rawPointer) == cass_true
         }
+
+        /// Whether this column's CQL type is textual, so a `nil` from ``string`` means the stored bytes
+        /// are not valid UTF-8 rather than that the column holds another type.
+        internal var isTextType: Bool {
+            isTextValueType(cassValue: self.rawPointer)
+        }
     }
 
     /// A reusable page token that can be used by `Statement` to resume querying
@@ -226,7 +232,7 @@ extension CassandraClient {
     ///   bytes, so a token can only be vended by ``CassandraClient/Rows/opaquePagingStateToken()``
     ///   and cannot be serialized through this library. Adding a public initializer or a public
     ///   bytes accessor would let a caller move a paging state across a trust boundary.
-    public struct OpaquePagingStateToken: Equatable, Sendable {
+    public struct OpaquePagingStateToken: Sendable, Hashable {
         let token: [UInt8]
 
         func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
@@ -238,12 +244,7 @@ extension CassandraClient {
 // MARK: - Utils
 
 func toString(cassValue: OpaquePointer) -> String? {
-    let valueType = cass_value_type(cassValue)
-    guard
-        valueType == CASS_VALUE_TYPE_ASCII
-            || valueType == CASS_VALUE_TYPE_TEXT
-            || valueType == CASS_VALUE_TYPE_VARCHAR
-    else {
+    guard isTextValueType(cassValue: cassValue) else {
         return nil
     }
     var value: UnsafePointer<CChar>?
@@ -256,6 +257,13 @@ func toString(cassValue: OpaquePointer) -> String? {
     return stringBuffer.withMemoryRebound(to: UInt8.self) {
         String(bytes: $0, encoding: .utf8)
     }
+}
+
+private func isTextValueType(cassValue: OpaquePointer) -> Bool {
+    let valueType = cass_value_type(cassValue)
+    return valueType == CASS_VALUE_TYPE_ASCII
+        || valueType == CASS_VALUE_TYPE_TEXT
+        || valueType == CASS_VALUE_TYPE_VARCHAR
 }
 
 // MARK: - Int8

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -81,6 +81,10 @@ extension CassandraClient {
         /// distinct causes into `nil` — a column the row lacks, a NULL value, a stored type that cannot
         /// convert, and a text column whose bytes are not valid UTF-8 — so probe the untyped accessor
         /// to tell them apart.
+        ///
+        /// The probe repeats the lookup the caller just made. That is deliberate: it runs only once that
+        /// lookup has already returned `nil`, so it never costs the success path, and classifying here
+        /// rather than at each call site keeps every one of them a single `throw`.
         private func columnFailure(_ type: Any.Type, forKey key: Key) -> Swift.DecodingError {
             guard let column: Column = self.row.column(key.stringValue) else {
                 return .columnMissing(forKey: key, codingPath: self.codingPath)

--- a/Sources/CassandraClient/Decoding.swift
+++ b/Sources/CassandraClient/Decoding.swift
@@ -39,11 +39,14 @@ extension CassandraClient {
         }
 
         public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-            throw DecodingError.notSupported("unkeyedContainer not supported")
+            throw DecodingError.unsupportedOperation("unkeyedContainer not supported", codingPath: self.codingPath)
         }
 
         public func singleValueContainer() throws -> SingleValueDecodingContainer {
-            throw DecodingError.notSupported("singleValueContainer not supported")
+            throw DecodingError.unsupportedOperation(
+                "singleValueContainer not supported",
+                codingPath: self.codingPath
+            )
         }
     }
 
@@ -69,108 +72,138 @@ extension CassandraClient {
 
         public func decodeNil(forKey key: Key) throws -> Bool {
             guard let column: Column = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch("\(key.stringValue) not found.")
+                throw DecodingError.columnMissing(forKey: key, codingPath: self.codingPath)
             }
             return column.isNull()
         }
 
+        /// The error for a typed column read that produced `nil`. The typed accessors collapse four
+        /// distinct causes into `nil` — a column the row lacks, a NULL value, a stored type that cannot
+        /// convert, and a text column whose bytes are not valid UTF-8 — so probe the untyped accessor
+        /// to tell them apart.
+        private func columnFailure(_ type: Any.Type, forKey key: Key) -> Swift.DecodingError {
+            guard let column: Column = self.row.column(key.stringValue) else {
+                return .columnMissing(forKey: key, codingPath: self.codingPath)
+            }
+            guard !column.isNull() else {
+                return .columnNull(type, forKey: key, codingPath: self.codingPath)
+            }
+            // A textual column that cannot produce a `String` holds bytes that are not valid UTF-8. The
+            // column type is what the property asked for, so this is corruption, not a mismatch.
+            if type == String.self, column.isTextType {
+                return .malformedPayload(
+                    "value for \(key.stringValue) is not valid UTF-8",
+                    forKey: key,
+                    codingPath: self.codingPath
+                )
+            }
+            return .columnTypeMismatch(type, forKey: key, codingPath: self.codingPath)
+        }
+
         public func decode(_: Bool.Type, forKey key: Key) throws -> Bool {
             guard let value: Bool = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Bool.self, forKey: key)
             }
             return value
         }
 
         public func decode(_: Int.Type, forKey key: Key) throws -> Int {
             guard let value: Int32 = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Int.self, forKey: key)
             }
             return Int(value)  // will always fit since storage is 32
         }
 
         public func decode(_: Int8.Type, forKey key: Key) throws -> Int8 {
             guard let value: Int8 = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Int8.self, forKey: key)
             }
             return value
         }
 
         public func decode(_: Int16.Type, forKey key: Key) throws -> Int16 {
             guard let value: Int16 = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Int16.self, forKey: key)
             }
             return value
         }
 
         public func decode(_: Int32.Type, forKey key: Key) throws -> Int32 {
             guard let value: Int32 = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Int32.self, forKey: key)
             }
             return value
         }
 
         public func decode(_: Int64.Type, forKey key: Key) throws -> Int64 {
             guard let value: Int64 = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Int64.self, forKey: key)
             }
             return value
         }
 
-        public func decode(_: UInt.Type, forKey _: Key) throws -> UInt {
-            throw DecodingError.notSupported("UInt is not supported")
+        public func decode(_: UInt.Type, forKey key: Key) throws -> UInt {
+            throw DecodingError.unsupportedType(
+                UInt.self,
+                forKey: key,
+                codingPath: self.codingPath,
+                "UInt is not supported"
+            )
         }
 
-        public func decode(_: UInt8.Type, forKey _: Key) throws -> UInt8 {
-            throw DecodingError.notSupported("UInt8 is not supported")
+        public func decode(_: UInt8.Type, forKey key: Key) throws -> UInt8 {
+            throw DecodingError.unsupportedType(
+                UInt8.self,
+                forKey: key,
+                codingPath: self.codingPath,
+                "UInt8 is not supported"
+            )
         }
 
-        public func decode(_: UInt16.Type, forKey _: Key) throws -> UInt16 {
-            throw DecodingError.notSupported("UInt16 is not supported")
+        public func decode(_: UInt16.Type, forKey key: Key) throws -> UInt16 {
+            throw DecodingError.unsupportedType(
+                UInt16.self,
+                forKey: key,
+                codingPath: self.codingPath,
+                "UInt16 is not supported"
+            )
         }
 
-        public func decode(_: UInt32.Type, forKey _: Key) throws -> UInt32 {
-            throw DecodingError.notSupported("UInt32 is not supported")
+        public func decode(_: UInt32.Type, forKey key: Key) throws -> UInt32 {
+            throw DecodingError.unsupportedType(
+                UInt32.self,
+                forKey: key,
+                codingPath: self.codingPath,
+                "UInt32 is not supported"
+            )
         }
 
-        public func decode(_: UInt64.Type, forKey _: Key) throws -> UInt64 {
-            throw DecodingError.notSupported("UInt64 is not supported")
+        public func decode(_: UInt64.Type, forKey key: Key) throws -> UInt64 {
+            throw DecodingError.unsupportedType(
+                UInt64.self,
+                forKey: key,
+                codingPath: self.codingPath,
+                "UInt64 is not supported"
+            )
         }
 
         public func decode(_: Float.Type, forKey key: Key) throws -> Float {
             guard let value: Float32 = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Float.self, forKey: key)
             }
             return value
         }
 
         public func decode(_: Double.Type, forKey key: Key) throws -> Double {
             guard let value: Double = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(Double.self, forKey: key)
             }
             return value
         }
 
         public func decode(_: String.Type, forKey key: Key) throws -> String {
             guard let value: String = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch(
-                    "value for \(key.stringValue) not found or of incorrect data type."
-                )
+                throw self.columnFailure(String.self, forKey: key)
             }
             return value
         }
@@ -179,42 +212,74 @@ extension CassandraClient {
         public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
             // Encrypted types — decrypt column and deserialize
             if type == Encrypted<String>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 guard let string = String(data: data, encoding: .utf8) else {
-                    throw DecodingError.typeMismatch("Decrypted data for \(key.stringValue) is not valid UTF-8")
+                    throw DecodingError.malformedPayload(
+                        "Decrypted data for \(key.stringValue) is not valid UTF-8",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 return Encrypted<String>(string) as! T
             } else if type == Encrypted<Int32>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 guard data.count == 4 else {
-                    throw DecodingError.typeMismatch("Expected 4 bytes for Int32, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 4 bytes for Int32, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 guard let value = data.parseInt32BigEndian() else {
-                    throw DecodingError.typeMismatch("Expected 4 bytes for Int32, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 4 bytes for Int32, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 return Encrypted<Int32>(value) as! T
             } else if type == Encrypted<Int64>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 guard data.count == 8 else {
-                    throw DecodingError.typeMismatch("Expected 8 bytes for Int64, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 8 bytes for Int64, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 guard let value = data.parseInt64BigEndian() else {
-                    throw DecodingError.typeMismatch("Expected 8 bytes for Int64, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 8 bytes for Int64, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 return Encrypted<Int64>(value) as! T
             } else if type == Encrypted<Double>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 guard data.count == 8 else {
-                    throw DecodingError.typeMismatch("Expected 8 bytes for Double, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 8 bytes for Double, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 guard let bits = data.parseUInt64BigEndian() else {
-                    throw DecodingError.typeMismatch("Expected 8 bytes for Double, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 8 bytes for Double, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 return Encrypted<Double>(Double(bitPattern: bits)) as! T
             } else if type == Encrypted<Foundation.UUID>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 guard data.count == 16 else {
-                    throw DecodingError.typeMismatch("Expected 16 bytes for UUID, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 16 bytes for UUID, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 let u: uuid_t = (
                     data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
@@ -222,157 +287,234 @@ extension CassandraClient {
                 )
                 return Encrypted<Foundation.UUID>(Foundation.UUID(uuid: u)) as! T
             } else if type == Encrypted<[UInt8]>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 return Encrypted<[UInt8]>(Array(data)) as! T
             } else if type == Encrypted<Foundation.Date>.self {
-                let data = try decryptColumnData(key: key)
+                let data = try decryptColumnData(key: key, as: type)
                 guard data.count == 8 else {
-                    throw DecodingError.typeMismatch("Expected 8 bytes for Date, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 8 bytes for Date, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 guard let millis = data.parseInt64BigEndian() else {
-                    throw DecodingError.typeMismatch("Expected 8 bytes for Date, got \(data.count)")
+                    throw DecodingError.malformedPayload(
+                        "Expected 8 bytes for Date, got \(data.count)",
+                        forKey: key,
+                        codingPath: self.codingPath
+                    )
                 }
                 return Encrypted<Foundation.Date>(Foundation.Date(timeIntervalSince1970: Double(millis) / 1000.0)) as! T
             } else if type == [UInt8].self {
                 guard let value: [UInt8] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == Foundation.Date.self {
                 guard let value: Int64 = row.column(key.stringValue)?.timestamp else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return Foundation.Date(timeIntervalSince1970: Double(value) / 1000) as! T
             } else if type == Foundation.UUID.self {
                 guard let value: Foundation.UUID = row.column(key.stringValue)?.uuid else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == TimeBasedUUID.self {
                 guard let value: TimeBasedUUID = row.column(key.stringValue)?.timeuuid else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Int8].self {
                 guard let value: [Int8] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Int16].self {
                 guard let value: [Int16] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Int32].self {
                 guard let value: [Int32] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Int64].self {
                 guard let value: [Int64] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Float32].self {
                 guard let value: [Float32] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Double].self {
                 guard let value: [Double] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [String].self {
                 guard let value: [String] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else if type == [Foundation.UUID].self {
                 guard let value: [Foundation.UUID] = row.column(key.stringValue) else {
-                    throw DecodingError.typeMismatch(
-                        "value for \(key.stringValue) not found or of incorrect data type."
-                    )
+                    throw self.columnFailure(type, forKey: key)
                 }
                 return value as! T
             } else {
-                throw DecodingError.notSupported("Decoding of \(type) is not supported.")
+                throw DecodingError.unsupportedType(
+                    type,
+                    forKey: key,
+                    codingPath: self.codingPath,
+                    "Decoding of \(type) is not supported."
+                )
             }
         }
 
         public func nestedContainer<NestedKey>(
             keyedBy _: NestedKey.Type,
-            forKey _: Key
+            forKey key: Key
         ) throws
             -> KeyedDecodingContainer<NestedKey>
         {
-            throw DecodingError.notSupported()
+            throw DecodingError.unsupportedOperation(
+                "nested containers are not supported",
+                codingPath: self.codingPath + [key]
+            )
         }
 
-        public func nestedUnkeyedContainer(forKey _: Key) throws -> UnkeyedDecodingContainer {
-            throw DecodingError.notSupported()
+        public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+            throw DecodingError.unsupportedOperation(
+                "nested unkeyed containers are not supported",
+                codingPath: self.codingPath + [key]
+            )
         }
 
-        private func _superDecoder(forKey _: __owned CodingKey) throws -> Decoder {
-            throw DecodingError.notSupported()
+        private func _superDecoder(forKey key: __owned CodingKey) throws -> Decoder {
+            throw DecodingError.unsupportedOperation(
+                "superDecoder is not supported",
+                codingPath: self.codingPath + [key]
+            )
         }
 
         public func superDecoder() throws -> Decoder {
-            throw DecodingError.notSupported()
+            throw DecodingError.unsupportedOperation(
+                "superDecoder is not supported",
+                codingPath: self.codingPath
+            )
         }
 
-        public func superDecoder(forKey _: Key) throws -> Decoder {
-            throw DecodingError.notSupported()
+        public func superDecoder(forKey key: Key) throws -> Decoder {
+            throw DecodingError.unsupportedOperation(
+                "superDecoder is not supported",
+                codingPath: self.codingPath + [key]
+            )
         }
 
-        /// Decrypt column data using encryptor and context from userInfo.
-        private func decryptColumnData(key: Key) throws -> Data {
+        /// Decrypt column data using encryptor and context from userInfo. `type` is the type the
+        /// caller asked for, reported if the column is null.
+        private func decryptColumnData(key: Key, as type: Any.Type) throws -> Data {
             guard #available(macOS 15.0, iOS 18.0, visionOS 2.0, *) else {
-                throw DecodingError.notSupported("Encryption requires macOS 15.0+")
+                throw CassandraClient.Error.encryptionConfigError("Encryption requires macOS 15.0+")
             }
             guard let encryptor = userInfo[.cassandraEncryptor] as? CassandraClient.Encryptor else {
-                throw DecodingError.notSupported(
+                throw CassandraClient.Error.encryptionConfigError(
                     "Encryptor not provided in decoder userInfo. Use RowDecoder(row:encryptor:rowContext:)"
                 )
             }
             guard let rowContext = userInfo[.cassandraRowContext] as? CassandraClient.EncryptionContext.Base else {
-                throw DecodingError.notSupported("EncryptionContext.Base missing from decoder userInfo")
+                throw CassandraClient.Error.encryptionConfigError(
+                    "EncryptionContext.Base missing from decoder userInfo"
+                )
             }
             let context = rowContext.forColumn(key.stringValue)
             guard let column: Column = row.column(key.stringValue) else {
-                throw DecodingError.typeMismatch("value for \(key.stringValue) not found.")
+                throw DecodingError.columnMissing(forKey: key, codingPath: self.codingPath)
             }
             guard let data = try column.decryptedData(encryptor: encryptor, context: context) else {
-                throw DecodingError.typeMismatch("value for \(key.stringValue) is null.")
+                throw DecodingError.columnNull(type, forKey: key, codingPath: self.codingPath)
             }
             return data
         }
     }
 }
 
-private enum DecodingError: Error {
-    case typeMismatch(String)
-    case notSupported(String? = nil)
+extension Swift.DecodingError {
+    /// A column the row does not contain.
+    fileprivate static func columnMissing(
+        forKey key: some CodingKey,
+        codingPath: [CodingKey]
+    ) -> Swift.DecodingError {
+        .keyNotFound(
+            key,
+            Context(
+                codingPath: codingPath,
+                debugDescription: "value for \(key.stringValue) not found."
+            )
+        )
+    }
+
+    /// A column holding NULL, read into a non-Optional property. Optionals never reach here: they
+    /// route through `decodeIfPresent` to `decodeNil(forKey:)`.
+    fileprivate static func columnNull(
+        _ type: Any.Type,
+        forKey key: some CodingKey,
+        codingPath: [CodingKey]
+    ) -> Swift.DecodingError {
+        .valueNotFound(
+            type,
+            Context(
+                codingPath: codingPath + [key],
+                debugDescription: "value for \(key.stringValue) is null; declare the property Optional."
+            )
+        )
+    }
+
+    /// A column present in the row whose stored type cannot produce `type`.
+    fileprivate static func columnTypeMismatch(
+        _ type: Any.Type,
+        forKey key: some CodingKey,
+        codingPath: [CodingKey]
+    ) -> Swift.DecodingError {
+        .typeMismatch(
+            type,
+            Context(
+                codingPath: codingPath + [key],
+                debugDescription: "value for \(key.stringValue) is of incorrect data type."
+            )
+        )
+    }
+
+    /// A type this decoder cannot produce, whatever the row holds.
+    fileprivate static func unsupportedType(
+        _ type: Any.Type,
+        forKey key: some CodingKey,
+        codingPath: [CodingKey],
+        _ description: String
+    ) -> Swift.DecodingError {
+        .typeMismatch(type, Context(codingPath: codingPath + [key], debugDescription: description))
+    }
+
+    /// A container operation this decoder does not implement. A row is flat, so there is no
+    /// requested type to report.
+    fileprivate static func unsupportedOperation(
+        _ description: String,
+        codingPath: [CodingKey]
+    ) -> Swift.DecodingError {
+        .dataCorrupted(Context(codingPath: codingPath, debugDescription: description))
+    }
+
+    /// Stored bytes that do not match the shape the requested type needs.
+    fileprivate static func malformedPayload(
+        _ description: String,
+        forKey key: some CodingKey,
+        codingPath: [CodingKey]
+    ) -> Swift.DecodingError {
+        .dataCorrupted(Context(codingPath: codingPath + [key], debugDescription: description))
+    }
 }

--- a/Sources/CassandraClient/Encryptor.swift
+++ b/Sources/CassandraClient/Encryptor.swift
@@ -26,7 +26,7 @@ extension CassandraClient {
     ///
     /// Renaming keyspace, table, or column after data has been encrypted
     /// will make that data permanently unreadable.
-    public struct EncryptionContext {
+    public struct EncryptionContext: Hashable {
         public let keyspace: String
         public let table: String
         public let column: String
@@ -43,7 +43,7 @@ extension CassandraClient {
         internal var contextString: String { "\(self.keyspace).\(self.table).\(self.column)" }
 
         /// Base context without a column name. Use ``forColumn(_:)`` to produce a full ``EncryptionContext``.
-        public struct Base: Sendable {
+        public struct Base: Sendable, Hashable {
             public let keyspace: String
             public let table: String
             public let primaryKey: PrimaryKey
@@ -78,7 +78,7 @@ extension CassandraClient {
     /// This ensures composite keys are unambiguous — for example,
     /// `PrimaryKey(from: .string("ab"), .string("c"))` produces different bytes
     /// from `PrimaryKey(from: .string("a"), .string("bc"))`.
-    public struct PrimaryKey: Sendable, Equatable {
+    public struct PrimaryKey: Sendable, Hashable {
         internal let data: Data
 
         public init(from components: CassandraClient.KeyComponent...) {
@@ -685,7 +685,7 @@ extension CassandraClient {
     /// Type tag for key columns used in column registration.
     ///
     /// New column types can be added without breaking existing consumers.
-    public struct KeyColumnType: Sendable, Equatable {
+    public struct KeyColumnType: Sendable, Hashable {
         internal let rawValue: String
 
         public static let string = KeyColumnType(rawValue: "string")
@@ -704,9 +704,9 @@ extension CassandraClient {
     ///
     /// Register a schema via ``Configuration/registerEncryptionSchema(_:)`` so the decoder
     /// can build ``EncryptionContext/Base`` per row without an `encryptionContextBuilder` closure.
-    public struct EncryptionSchema: Sendable {
+    public struct EncryptionSchema: Sendable, Hashable {
         /// A column in the table's primary key, used to build the PrimaryKey for DEK derivation.
-        public struct KeyColumn: Sendable {
+        public struct KeyColumn: Sendable, Hashable {
             public let name: String
             public let type: KeyColumnType
 
@@ -720,13 +720,18 @@ extension CassandraClient {
         public let table: String
         public let keyColumns: [KeyColumn]
         /// Names of all encrypted regular columns in the table.
+        ///
+        /// Used only by write-path binding validation; see ``Statement/Options/encryptionTable``
+        /// for what each execution path enforces. Decryption is driven by the declared property
+        /// type on the decoded model, so a schema registered only to build row contexts for reads
+        /// can pass an empty set.
         public let encryptedColumns: Set<String>
 
         public init(
             keyspace: String,
             table: String,
             keyColumns: [KeyColumn],
-            encryptedColumns: Set<String> = []
+            encryptedColumns: Set<String>
         ) throws {
             let keyColumnNames = Set(keyColumns.map(\.name))
             let overlap = keyColumnNames.intersection(encryptedColumns)

--- a/Sources/CassandraClient/Errors.swift
+++ b/Sources/CassandraClient/Errors.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 internal import CDataStaxDriver
+import Foundation
 
 extension CassandraClient {
     /// Possible ``CassandraClient`` errors.
@@ -797,6 +798,11 @@ extension CassandraClient {
     }
 }
 
+extension CassandraClient.Error: LocalizedError {
+    /// Backs `localizedDescription`, which otherwise reports a generic Foundation message.
+    public var errorDescription: String? { self.description }
+}
+
 extension CassandraClient {
     public struct ConfigurationError: Swift.Error, CustomStringConvertible {
         public let message: String
@@ -805,6 +811,11 @@ extension CassandraClient {
             "Configuration error: \(self.message)"
         }
     }
+}
+
+extension CassandraClient.ConfigurationError: LocalizedError {
+    /// Backs `localizedDescription`, which otherwise reports a generic Foundation message.
+    public var errorDescription: String? { self.description }
 }
 
 extension CassandraClient {

--- a/Sources/CassandraClient/Metrics.swift
+++ b/Sources/CassandraClient/Metrics.swift
@@ -15,7 +15,7 @@
 internal import CDataStaxDriver
 
 /// ``CassandraClient`` metrics.
-public struct CassandraMetrics: Sendable, Codable {
+public struct CassandraMetrics: Sendable, Hashable, Codable {
     // MARK: - Requests
 
     /// Minimum in microseconds

--- a/Sources/CassandraClient/Session.swift
+++ b/Sources/CassandraClient/Session.swift
@@ -203,7 +203,7 @@ import NIOCore  // for async-await bridge
     ) async throws
 
     /// Terminate the session and free resources.
-    @available(*, noasync, message: "Can block indefinitely, prefer shutdown()", renamed: "shutdownAsync()")
+    @available(*, noasync, message: "Can block indefinitely, prefer shutdownAsync()", renamed: "shutdownAsync()")
     func shutdown() throws
 
     /// Terminate the session and free resources.
@@ -836,7 +836,7 @@ extension CassandraClient {
             }
         }
 
-        @available(*, noasync, message: "Can block indefinitely, prefer shutdown()", renamed: "shutdownAsync()")
+        @available(*, noasync, message: "Can block indefinitely, prefer shutdownAsync()", renamed: "shutdownAsync()")
         func shutdown() throws {
             enum Action {
                 case alreadyShut

--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -490,9 +490,11 @@ extension CassandraClient {
         }
 
         public struct Options: Sendable, CustomStringConvertible {
-            /// Sets the statement's consistency level. Default is `.localOne`.
+            /// Sets the statement's consistency level. `nil` inherits
+            /// ``CassandraClient/Configuration/consistency``.
             public var consistency: CassandraClient.Consistency?
-            /// Sets the statement's request timeout in milliseconds. Default is `CASS_UINT64_MAX`
+            /// Sets the statement's request timeout in milliseconds. `nil` inherits
+            /// ``CassandraClient/Configuration/requestTimeoutMillis``.
             public var requestTimeout: UInt64?
 
             /// Type-erased backing store for ``encryptionContextBuilder``.
@@ -523,6 +525,14 @@ extension CassandraClient {
             /// - Important: The query must SELECT all primary key columns registered in the schema.
             ///   The decoder reads these columns from each result row to build the ``PrimaryKey`` for key derivation.
             ///   Omitting a key column will cause decryption to fail at runtime.
+            ///
+            /// - Important: What binding validation enforces depends on the execution path.
+            ///   Prepared statement execution maps each parameter to its column via statement metadata
+            ///   and checks both directions: a registered column must receive an encrypted value, and an
+            ///   unregistered one must not. Other execution paths have no parameter column names, so they
+            ///   check only that each encrypted value's ``EncryptionContext`` names a registered column —
+            ///   a plaintext value bound to a registered column is written as-is. Neither path verifies
+            ///   that a value's context names the column it is actually bound to.
             @available(macOS 15.0, iOS 18.0, visionOS 2.0, *)
             public var encryptionTable: String? {
                 get { self._encryptionTable }

--- a/Sources/CassandraClient/TraceConstants.swift
+++ b/Sources/CassandraClient/TraceConstants.swift
@@ -47,8 +47,8 @@ extension CassandraClient {
     internal enum TraceAttributeKey {
         /// Current OTel key (`db.cassandra.consistency_level` is deprecated upstream in favor of this).
         static let consistencyLevel = "cassandra.consistency.level"
-        /// Shared failure classification — the same concept logging emits as `request.errorCategory` and
-        /// metrics tag as `errorCategory`; value is the ``CassandraClient/Error`` category (`category.rawValue`).
+        /// Shared failure classification — the same concept logging emits as `request.errorCategory`;
+        /// value is the ``CassandraClient/Error`` category (`category.rawValue`).
         static let errorCategory = "cassandra.error.category"
     }
 }

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -1013,7 +1013,8 @@ final class EncryptionIntegrationTests: XCTestCase {
         let schema = try CassandraClient.EncryptionSchema(
             keyspace: keyspace,
             table: tableName,
-            keyColumns: [.init(name: "user_id", type: .string)]
+            keyColumns: [.init(name: "user_id", type: .string)],
+            encryptedColumns: []
         )
         self.configuration.registerEncryptionSchema(schema)
 


### PR DESCRIPTION
### Motivation

`EncryptionSchema.init` defaulted `encryptedColumns` to an empty set, which left the write-path binding validation with nothing to enforce: a plaintext value bound to a column meant to be encrypted was written as cleartext with no error.

Several other parts of the public interface misreport themselves — doc comments state defaults the code contradicts, and a `private` error type reaches adopters through every public `Decodable` overload of `query` and `execute`, unnameable and uninspectable. Plain-data value types also lack `Hashable`, which is cheaper to add before 1.0 than after.

### Modifications

Remove the `encryptedColumns` default, and document what binding validation enforces on each execution path, since prepared and non-prepared execution differ.

Replace the private `DecodingError` with `Swift.DecodingError`, so decoding failures are nameable and carry a `codingPath`. The typed column accessors collapse four causes into `nil`, so probe the untyped accessor to separate them: a missing column is `keyNotFound`, a NULL read into a non-Optional property is `valueNotFound`, invalid UTF-8 in a text column is `dataCorrupted`, and an unconvertible stored type is `typeMismatch`. Decoder misconfiguration throws `encryptionConfigError` instead of masquerading as a decoding failure; ciphertext that fails authentication still throws `decryptionError` from the encryptor.

Conform `Error` and `ConfigurationError` to `LocalizedError` so `localizedDescription` reports the message. Add `Hashable` to nine value types; `Encrypted<T>` and `KeyComponent` are held back as reviewer decisions, the first over constant-time comparison of plaintext, the second because its `==` would publish a key-derivation collision as contract.

Require `Batch`'s resolver argument explicitly and declare its non-Sendability the way `Statement` does. Correct doc comments on `Statement.Options`, `CassandraSession.shutdown()` at both declaration sites, `Batch`, and the trace error-category constant.

### Result

Registering an encryption schema now states the columns the validation protects, and the four reasons a column fails to decode are distinguishable.

Source-breaking in two cases: callers that omitted `encryptedColumns` must pass a set, where `[]` preserves the previous behaviour; and any hand-written or retroactive `Hashable` conformance on one of the nine types is now redundant.
