### PR TITLE
Build the test target under the Swift 6 language mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -182,9 +182,6 @@ let package = Package(
                 // The tests bootstrap swift-distributed-tracing's shipped in-memory tracer.
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .product(name: "InMemoryTracing", package: "swift-distributed-tracing"),
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v5)
             ]
         ),
     ],

--- a/Tests/CassandraClientTests/CassandraClientTests.swift
+++ b/Tests/CassandraClientTests/CassandraClientTests.swift
@@ -15,10 +15,14 @@
 import Foundation
 import Logging
 import NIO
+import NIOConcurrencyHelpers
 import XCTest
 
 @testable import CassandraClient
 
+// Each async test binds the client and configuration to locals before handing work to another task, so no
+// test body captures `self` — a test case is not `Sendable`. Both types are. The locals are snapshots taken
+// before the handoff: a test that reassigned either property mid-body would not see the new value there.
 final class Tests: XCTestCase {
     var cassandraClient: CassandraClient!
     var configuration: CassandraClient.Configuration!
@@ -86,8 +90,10 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testAsyncSession() throws {
+        let client = self.cassandraClient!
+        let config = self.configuration!
         runAsyncAndWaitFor {
-            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            let session = client.makeSession(keyspace: config.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
 
             let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
@@ -125,8 +131,9 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testWithAsyncSession() throws {
+        let config = self.configuration!
         runAsyncAndWaitFor {
-            var configuration = self.configuration!
+            var configuration = config
             configuration.keyspace = "test_\(DispatchTime.now().uptimeNanoseconds)"
             let cassandraClient = CassandraClient(configuration: configuration)
             defer { XCTAssertNoThrow(try cassandraClient.shutdown()) }
@@ -192,11 +199,13 @@ final class Tests: XCTestCase {
     // (it stashes the callback instead of completing it), so the connect is guaranteed to
     // still be in flight when `shutdown()` runs, and completes only when we say so.
     func testShutdownDuringInFlightConnectDoesNotResurrectSession() throws {
-        final class CallbackBox: @unchecked Sendable {
-            var callback: ((Result<CassandraClient.Configuration.ContactPoints, Swift.Error>) -> Void)?
-        }
-
-        let box = CallbackBox()
+        // The driver writes the callback from its own thread and the test reads it back, so the box
+        // locks rather than asserting `@unchecked Sendable` over a bare `var`.
+        typealias ContactPointsCallback =
+            @Sendable (
+                Result<CassandraClient.Configuration.ContactPoints, Swift.Error>
+            ) -> Void
+        let box = NIOLockedValueBox<ContactPointsCallback?>(nil)
         let connectStarted = self.expectation(description: "connect started")
 
         // Connect without a keyspace so the connect always succeeds against a running
@@ -205,7 +214,7 @@ final class Tests: XCTestCase {
         var configuration: CassandraClient.Configuration = self.configuration
         configuration.keyspace = nil
         configuration.contactPointsProvider = { callback in
-            box.callback = callback
+            box.withLockedValue { $0 = callback }
             connectStarted.fulfill()
         }
 
@@ -222,7 +231,7 @@ final class Tests: XCTestCase {
         XCTAssertNoThrow(try client.shutdown())
 
         // Now let the (real) connect complete successfully.
-        let callback = try XCTUnwrap(box.callback)
+        let callback = try XCTUnwrap(box.withLockedValue { $0 })
         callback(.success([self.cassandraHost]))
 
         // The in-flight request must fail with `.disconnected` rather than run against —
@@ -272,7 +281,8 @@ final class Tests: XCTestCase {
         )
     }
 
-    func testQueryIterator() {
+    /// A table of `count` rows for the iterator tests, inserted concurrently.
+    private func makeIteratorFixture() -> (table: String, count: Int) {
         let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
         XCTAssertNoThrow(
             try self.cassandraClient.run("create table \(tableName) (id int primary key, data text);")
@@ -297,6 +307,12 @@ final class Tests: XCTestCase {
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
 
+        return (tableName, count)
+    }
+
+    func testQueryIterator() {
+        let (tableName, count) = self.makeIteratorFixture()
+
         let rows = try! self.cassandraClient.query("select id, data from \(tableName);").wait()
         XCTAssertEqual(rows.count, count, "result count should match")
         XCTAssertEqual(rows.columnsCount, 2, "result column count should match")
@@ -305,6 +321,15 @@ final class Tests: XCTestCase {
         for (index, id) in ids.sorted().enumerated() {
             XCTAssertEqual(id, Int32(index))
         }
+    }
+
+    // `PaginatedRows.map` is deprecated but still shipped, and this is its coverage, so the call stays.
+    // Swift has no per-expression suppression, so the enclosing test carries the attribute. It holds only
+    // the paginated-map assertions: deprecating the whole iterator test would also silence any future
+    // deprecation of `run`, `query` or `wait` exercised alongside it.
+    @available(*, deprecated, message: "Covers the deprecated PaginatedRows.map.")
+    func testQueryIteratorPaginatedMap() {
+        let (tableName, count) = self.makeIteratorFixture()
 
         let paginatedIDs = try! self.cassandraClient.query(
             "select id, data from \(tableName);",
@@ -515,9 +540,10 @@ final class Tests: XCTestCase {
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
-                let paginatedRows = try await self.cassandraClient.query(
+                let paginatedRows = try await client.query(
                     "select id, data from \(tableName);",
                     pageSize: Int32(10)
                 )
@@ -575,9 +601,10 @@ final class Tests: XCTestCase {
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
-                let paginatedRows = try await self.cassandraClient.query(
+                let paginatedRows = try await client.query(
                     "select id, data from \(tableName);",
                     pageSize: Int32(100)
                 )
@@ -689,9 +716,10 @@ final class Tests: XCTestCase {
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(futures, on: eventLoopGroup.next()).wait())
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
-                let paginatedRows = try await self.cassandraClient.query(
+                let paginatedRows = try await client.query(
                     "select id, data from \(tableName);",
                     pageSize: Int32(10)
                 )
@@ -766,10 +794,11 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testQueryAsyncIterator() throws {
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.cassandraClient.run(
+                try await client.run(
                     "create table \(tableName) (id int primary key, data text);"
                 )
 
@@ -778,7 +807,7 @@ final class Tests: XCTestCase {
                     let options = CassandraClient.Statement.Options(consistency: .localQuorum)
                     for index in 0..<count {
                         group.addTask {
-                            try await self.cassandraClient.run(
+                            try await client.run(
                                 "insert into \(tableName) (id, data) values (?, ?);",
                                 parameters: [.int32(Int32(index)), .string(UUID().uuidString)],
                                 options: options
@@ -787,7 +816,7 @@ final class Tests: XCTestCase {
                     }
                 }
 
-                let rows = try await self.cassandraClient.query("select id, data from \(tableName);")
+                let rows = try await client.query("select id, data from \(tableName);")
                 XCTAssertEqual(rows.count, count, "result count should match")
                 XCTAssertEqual(rows.columnsCount, 2, "result column count should match")
                 let ids = rows.compactMap { $0.column(0)?.int32 }
@@ -796,7 +825,7 @@ final class Tests: XCTestCase {
                     XCTAssertEqual(id, Int32(index))
                 }
 
-                let paginatedRows = try await self.cassandraClient.query(
+                let paginatedRows = try await client.query(
                     "select id, data from \(tableName);",
                     pageSize: Int32(300)
                 )
@@ -852,10 +881,11 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testQueryAsyncBuffered() throws {
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.cassandraClient.run(
+                try await client.run(
                     "create table \(tableName) (id int primary key, data text);"
                 )
 
@@ -863,7 +893,7 @@ final class Tests: XCTestCase {
                 await withThrowingTaskGroup(of: Void.self) { group in
                     for index in 0..<count {
                         group.addTask {
-                            try await self.cassandraClient.run(
+                            try await client.run(
                                 "insert into \(tableName) (id, data) values (?, ?);",
                                 parameters: [.int32(Int32(index)), .string(UUID().uuidString)]
                             )
@@ -871,7 +901,7 @@ final class Tests: XCTestCase {
                     }
                 }
 
-                let rows = try await self.cassandraClient.query("select id, data from \(tableName);") {
+                let rows = try await client.query("select id, data from \(tableName);") {
                     $0.column(0)?.int32
                 }
                 XCTAssertEqual(rows.count, count, "result count should match")
@@ -1012,8 +1042,10 @@ final class Tests: XCTestCase {
         )
 
         var futures = [EventLoopFuture<Void>]()
-        for model in data {
-            let parameters: [CassandraClient.Statement.Value] = [
+        // Built fresh per row: `run` takes `parameters` as `sending`, and the futures are collected and
+        // awaited together. Local rather than a method, because `Model` is scoped to this test.
+        func insertParameters(for model: Model) -> [CassandraClient.Statement.Value] {
+            [
                 .int8(model.col1),
                 .int16(model.col2),
                 .int32(model.col3),
@@ -1036,6 +1068,9 @@ final class Tests: XCTestCase {
                 .stringArray(model.col20),
                 .uuidArray(model.col21),
             ]
+        }
+
+        for model in data {
             futures.append(
                 self.cassandraClient.run(
                     """
@@ -1044,7 +1079,7 @@ final class Tests: XCTestCase {
                     values
                     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                    parameters: parameters
+                    parameters: insertParameters(for: model)
                 )
             )
         }
@@ -1207,17 +1242,19 @@ final class Tests: XCTestCase {
                 .uuidArray(uuidList),  // list<uuid>
             ]
 
-            XCTAssertNoThrow(
-                try self.cassandraClient.run(
-                    """
-                    insert into \(tableName)
-                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21, col22, col23, col24)
-                    values
-                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    parameters: parameters
-                ).wait()
+            // `parameters` is handed over `sending`, so the call stays out of the `XCTAssertNoThrow`
+            // autoclosure — capturing it there would leave the send provably non-final. `run` does not
+            // throw, so the assertion still covers everything it did.
+            let insert = self.cassandraClient.run(
+                """
+                insert into \(tableName)
+                (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21, col22, col23, col24)
+                values
+                (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                parameters: parameters
             )
+            XCTAssertNoThrow(try insert.wait())
 
             let result = try! self.cassandraClient.query("select * from \(tableName);").wait()
             XCTAssertEqual(Int8(result.count), index + 1, "expected exactly one result")
@@ -1476,29 +1513,31 @@ final class Tests: XCTestCase {
                 .timeuuidUUIDMap(timeuuidUUIDMap),
             ]
 
-            XCTAssertNoThrow(
-                try self.cassandraClient.run(
-                    """
-                    insert into \(tableName)
-                    (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10,
-                     col11, col12, col13, col14, col15, col16, col17, col18, col19,
-                     col20, col21, col22, col23, col24, col25, col26, col27, col28,
-                     col29, col30, col31, col32, col33, col34, col35, col36, col37,
-                     col38, col39, col40, col41, col42, col43, col44, col45, col46,
-                     col47, col48, col49, col50, col51, col52, col53, col54, col55,
-                     col56, col57, col58, col59, col60, col61, col62, col63, col64)
-                    values
-                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                     ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                     ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    parameters: parameters
-                ).wait()
+            // `parameters` is handed over `sending`, so the call stays out of the `XCTAssertNoThrow`
+            // autoclosure — capturing it there would leave the send provably non-final. `run` does not
+            // throw, so the assertion still covers everything it did.
+            let insert = self.cassandraClient.run(
+                """
+                insert into \(tableName)
+                (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10,
+                 col11, col12, col13, col14, col15, col16, col17, col18, col19,
+                 col20, col21, col22, col23, col24, col25, col26, col27, col28,
+                 col29, col30, col31, col32, col33, col34, col35, col36, col37,
+                 col38, col39, col40, col41, col42, col43, col44, col45, col46,
+                 col47, col48, col49, col50, col51, col52, col53, col54, col55,
+                 col56, col57, col58, col59, col60, col61, col62, col63, col64)
+                values
+                (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                parameters: parameters
             )
+            XCTAssertNoThrow(try insert.wait())
 
             let result = try! self.cassandraClient.query(
                 "select * from \(tableName) where col1 = ?;",
@@ -1851,13 +1890,14 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testBatchInsertionAsync() throws {
+        let client = self.cassandraClient!
         runAsyncAndWaitFor {
             let tableName = "test_batch_async_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.cassandraClient.run(
+            try await client.run(
                 "create table \(tableName) (id int primary key, name text);"
             )
 
-            try await self.cassandraClient.batch { batch in
+            try await client.batch { batch in
                 for i: Int32 in 0..<10 {
                     try batch.add(
                         statement: CassandraClient.Statement(
@@ -1868,7 +1908,7 @@ final class Tests: XCTestCase {
                 }
             }
 
-            let result = try await self.cassandraClient.query("select * from \(tableName);")
+            let result = try await client.query("select * from \(tableName);")
             XCTAssertEqual(Array(result).count, 10)
         }
     }
@@ -1898,7 +1938,7 @@ final class Tests: XCTestCase {
         let insertStmt = try self.cassandraClient.prepare(
             "insert into \(tableName) (id, name) values (?, ?)"
         ).wait()
-        try self.cassandraClient.execute(
+        _ = try self.cassandraClient.execute(
             prepared: insertStmt,
             parameters: [.int32(1), .string("alice")]
         ).wait()
@@ -1924,7 +1964,7 @@ final class Tests: XCTestCase {
             "insert into \(tableName) (id, name) values (?, ?)"
         ).wait()
         for i: Int32 in 0..<10 {
-            try self.cassandraClient.execute(
+            _ = try self.cassandraClient.execute(
                 prepared: insertStmt,
                 parameters: [.int32(i), .string("user-\(i)")]
             ).wait()
@@ -1967,22 +2007,23 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testPreparedStatementAsyncRoundtrip() throws {
+        let client = self.cassandraClient!
         runAsyncAndWaitFor {
             let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
+            try await client.run("create table \(tableName) (id int primary key, name text);")
 
-            let insertStmt = try await self.cassandraClient.prepare(
+            let insertStmt = try await client.prepare(
                 "insert into \(tableName) (id, name) values (?, ?)"
             )
-            try await self.cassandraClient.execute(
+            _ = try await client.execute(
                 prepared: insertStmt,
                 parameters: [.int32(1), .string("alice")]
             )
 
-            let selectStmt = try await self.cassandraClient.prepare(
+            let selectStmt = try await client.prepare(
                 "select id, name from \(tableName) where id = ?"
             )
-            let rows = try await self.cassandraClient.execute(
+            let rows = try await client.execute(
                 prepared: selectStmt,
                 parameters: [.int32(1)]
             )
@@ -2008,12 +2049,13 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testQueryDecodingWithModelTypeAsync() throws {
+        let client = self.cassandraClient!
         runAsyncAndWaitFor {
             let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.cassandraClient.run("create table \(tableName) (id int primary key, name text);")
-            try await self.cassandraClient.run("insert into \(tableName) (id, name) values (1, 'alice');")
+            try await client.run("create table \(tableName) (id int primary key, name text);")
+            try await client.run("insert into \(tableName) (id, name) values (1, 'alice');")
 
-            let result = try await self.cassandraClient.query(
+            let result = try await client.query(
                 "select id, name from \(tableName) where id = 1;",
                 withModelType: Person.self
             )
@@ -2043,8 +2085,10 @@ final class Tests: XCTestCase {
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testPreparedStatementDecodingWithModelTypeAsync() throws {
+        let client = self.cassandraClient!
+        let config = self.configuration!
         runAsyncAndWaitFor {
-            let session = self.cassandraClient.makeSession(keyspace: self.configuration.keyspace)
+            let session = client.makeSession(keyspace: config.keyspace)
             defer { XCTAssertNoThrow(try session.shutdown()) }
 
             let tableName = "test_\(DispatchTime.now().uptimeNanoseconds)"

--- a/Tests/CassandraClientTests/CustomAuthenticationIntegrationTests.swift
+++ b/Tests/CassandraClientTests/CustomAuthenticationIntegrationTests.swift
@@ -28,15 +28,18 @@ import XCTest
 /// default `AllowAllAuthenticator` cluster the callbacks never fire, so all but the teardown test are gated
 /// behind `CASSANDRA_REQUIRE_AUTH` and `XCTSkip` when it is unset. The flag is set out-of-band, not probed,
 /// because `testClusterEnforcesAuthentication` is itself the probe.
+///
+/// The environment accessors are `static` so the `contactPointsProvider` closure never captures `self`:
+/// a test case is not `Sendable`, and they read only the process environment.
 final class CustomAuthenticationIntegrationTests: XCTestCase {
-    private var environment: [String: String] { ProcessInfo.processInfo.environment }
-    private var validUsername: String { self.environment["CASSANDRA_USER"] ?? "cassandra" }
-    private var validPassword: String { self.environment["CASSANDRA_PASSWORD"] ?? "cassandra" }
+    private static var environment: [String: String] { ProcessInfo.processInfo.environment }
+    private static var validUsername: String { Self.environment["CASSANDRA_USER"] ?? "cassandra" }
+    private static var validPassword: String { Self.environment["CASSANDRA_PASSWORD"] ?? "cassandra" }
 
     /// Skips a test unless `CASSANDRA_REQUIRE_AUTH` is set to a non-empty value, i.e. the caller asserts the
     /// target cluster enforces `PasswordAuthenticator`. See the type doc for why this is opt-in, not probed.
     private func requireAuthEnforcement() throws {
-        guard let value = self.environment["CASSANDRA_REQUIRE_AUTH"], !value.isEmpty else {
+        guard let value = Self.environment["CASSANDRA_REQUIRE_AUTH"], !value.isEmpty else {
             throw XCTSkip(
                 "set CASSANDRA_REQUIRE_AUTH=1 against an auth-enforcing cluster to run this test"
             )
@@ -49,9 +52,9 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
     private func makeConfiguration() -> CassandraClient.Configuration {
         var configuration = CassandraClient.Configuration(
             contactPointsProvider: { callback in
-                callback(.success([self.environment["CASSANDRA_HOST"] ?? "127.0.0.1"]))
+                callback(.success([Self.environment["CASSANDRA_HOST"] ?? "127.0.0.1"]))
             },
-            port: self.environment["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
+            port: Self.environment["CASSANDRA_CQL_PORT"].flatMap(Int32.init) ?? 9042,
             protocolVersion: .v3
         )
         configuration.connectTimeoutMillis = 10_000
@@ -82,8 +85,8 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
     func testAuthenticatorConnectsAndSucceeds() throws {
         try self.requireAuthEnforcement()
         let authenticator = RecordingPlaintextAuthenticator(
-            username: self.validUsername,
-            password: self.validPassword
+            username: Self.validUsername,
+            password: Self.validPassword
         )
         var configuration = self.makeConfiguration()
         configuration.authenticator = authenticator
@@ -100,7 +103,7 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
         try self.requireAuthEnforcement()
         var configuration = self.makeConfiguration()
         configuration.authenticator = PlaintextAuthenticator(
-            username: self.validUsername,
+            username: Self.validUsername,
             password: "wrong-\(UUID().uuidString)"
         )
         let client = self.makeClient(configuration)
@@ -117,8 +120,8 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
         try self.requireAuthEnforcement()
         var configuration = self.makeConfiguration()
         configuration.authenticator = PlaintextAuthenticator(
-            username: self.validUsername,
-            password: self.validPassword
+            username: Self.validUsername,
+            password: Self.validPassword
         )
         configuration.username = "bogus-\(UUID().uuidString)"
         configuration.password = "bogus-\(UUID().uuidString)"
@@ -135,8 +138,8 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
     func testConcurrentSharedAuthenticator() throws {
         try self.requireAuthEnforcement()
         let authenticator = RecordingPlaintextAuthenticator(
-            username: self.validUsername,
-            password: self.validPassword
+            username: Self.validUsername,
+            password: Self.validPassword
         )
         var configuration = self.makeConfiguration()
         configuration.authenticator = authenticator
@@ -146,9 +149,7 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
 
         let iterations = 50
         let group = DispatchGroup()
-        let lock = NSLock()
-        var errors = [Swift.Error]()
-        var rowCounts = [Int]()
+        let results = NIOLockedValueBox<(rowCounts: [Int], errors: [Swift.Error])>(([], []))
 
         for _ in 0..<iterations {
             group.enter()
@@ -156,18 +157,15 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
                 defer { group.leave() }
                 do {
                     let count = Array(try client.query("select release_version from system.local").wait()).count
-                    lock.lock()
-                    rowCounts.append(count)
-                    lock.unlock()
+                    results.withLockedValue { $0.rowCounts.append(count) }
                 } catch {
-                    lock.lock()
-                    errors.append(error)
-                    lock.unlock()
+                    results.withLockedValue { $0.errors.append(error) }
                 }
             }
         }
         group.wait()
 
+        let (rowCounts, errors) = results.withLockedValue { ($0.rowCounts, $0.errors) }
         XCTAssertEqual(errors.count, 0, "concurrent queries through the shared authenticator: \(errors)")
         XCTAssertEqual(rowCounts.count, iterations)
         XCTAssertTrue(rowCounts.allSatisfy { $0 == 1 }, "every query returns exactly one row")
@@ -218,8 +216,8 @@ final class CustomAuthenticationIntegrationTests: XCTestCase {
 
         func connectQueryAndShutdown() throws {
             let authenticator = DeinitCountingAuthenticator(
-                username: self.validUsername,
-                password: self.validPassword,
+                username: Self.validUsername,
+                password: Self.validPassword,
                 deinitCounter: deinitCounter
             )
             var configuration = self.makeConfiguration()

--- a/Tests/CassandraClientTests/CustomAuthenticationTestSupport.swift
+++ b/Tests/CassandraClientTests/CustomAuthenticationTestSupport.swift
@@ -47,7 +47,7 @@ struct ThrowingAuthenticator: CassandraClient.Authenticator {
 
 /// Byte-reverses each challenge and records challenges and the success token, for the challenge/success
 /// round-trip that no live `PasswordAuthenticator` exchange reaches.
-final class RecordingChallengeAuthenticator: CassandraClient.Authenticator, @unchecked Sendable {
+final class RecordingChallengeAuthenticator: CassandraClient.Authenticator {
     private let state = NIOLockedValueBox<(challenges: [[UInt8]], successToken: [UInt8]?)>(([], nil))
 
     func initialResponse() throws -> [UInt8]? { [] }
@@ -67,7 +67,7 @@ final class RecordingChallengeAuthenticator: CassandraClient.Authenticator, @unc
 
 /// Plaintext credentials plus lock-protected invocation counts. Serves the success-observability test
 /// (`onSuccessFired`) and the shared-instance concurrency test (counts under fan-out).
-final class RecordingPlaintextAuthenticator: CassandraClient.Authenticator, @unchecked Sendable {
+final class RecordingPlaintextAuthenticator: CassandraClient.Authenticator {
     let username: String
     let password: String
     private let counts = NIOLockedValueBox<(initial: Int, success: Int)>((0, 0))
@@ -93,7 +93,7 @@ final class RecordingPlaintextAuthenticator: CassandraClient.Authenticator, @unc
 
 /// Increments an external, box-outliving counter in `deinit`, to witness the driver's data-cleanup
 /// releasing the retained box on session teardown.
-final class DeinitCountingAuthenticator: CassandraClient.Authenticator, @unchecked Sendable {
+final class DeinitCountingAuthenticator: CassandraClient.Authenticator {
     let username: String
     let password: String
     private let deinitCounter: NIOLockedValueBox<Int>

--- a/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
+++ b/Tests/CassandraClientTests/EncryptionIntegrationTests.swift
@@ -384,12 +384,14 @@ final class EncryptionIntegrationTests: XCTestCase {
 
         // Read back using Codable path
         var readOptions = CassandraClient.Statement.Options()
+        // Bound outside the builder: it is `@Sendable`, and a test case is not.
+        let contextKeyspace = self.configuration.keyspace!
         readOptions.encryptionContextBuilder = { row in
             guard let uid: String = row.column("user_id") else {
                 throw CassandraClient.Error.badParams("user_id not found in row")
             }
             return CassandraClient.EncryptionContext.Base(
-                keyspace: self.configuration.keyspace!,
+                keyspace: contextKeyspace,
                 table: tableName,
                 primaryKey: .init(from: .string(uid))
             )

--- a/Tests/CassandraClientTests/EncryptorTests.swift
+++ b/Tests/CassandraClientTests/EncryptorTests.swift
@@ -16,6 +16,7 @@ import CoreMetrics
 import Foundation
 import Logging
 import MetricsTestKit
+import NIOConcurrencyHelpers
 import XCTest
 
 @testable import CassandraClient
@@ -409,8 +410,7 @@ final class EncryptorTests: XCTestCase {
         let iterations = 100
 
         let group = DispatchGroup()
-        var errors = [Error]()
-        let errorLock = NSLock()
+        let errors = NIOLockedValueBox<[Error]>([])
 
         for i in 0..<iterations {
             group.enter()
@@ -426,20 +426,19 @@ final class EncryptorTests: XCTestCase {
                     let encrypted = try encryptor.encrypt(plaintext, context: context)
                     let decrypted = try encryptor.decrypt(encrypted, context: context)
                     if decrypted != plaintext {
-                        errorLock.lock()
-                        errors.append(CassandraClient.Error.decryptionError("Data mismatch on iteration \(i)"))
-                        errorLock.unlock()
+                        errors.withLockedValue {
+                            $0.append(CassandraClient.Error.decryptionError("Data mismatch on iteration \(i)"))
+                        }
                     }
                 } catch {
-                    errorLock.lock()
-                    errors.append(error)
-                    errorLock.unlock()
+                    errors.withLockedValue { $0.append(error) }
                 }
             }
         }
 
         group.wait()
-        XCTAssertEqual(errors.count, 0, "Concurrent errors: \(errors)")
+        let collected = errors.withLockedValue { $0 }
+        XCTAssertEqual(collected.count, 0, "Concurrent errors: \(collected)")
     }
 
     // MARK: - Salt

--- a/Tests/CassandraClientTests/PaginatedDecodingIntegrationTests.swift
+++ b/Tests/CassandraClientTests/PaginatedDecodingIntegrationTests.swift
@@ -27,6 +27,10 @@ import XCTest
 ///
 /// The fixture puts every row in one partition behind a clustering key, so pages come back in `ck` order
 /// and the ordering and mid-stream failure assertions are deterministic.
+///
+/// `selectAll` is `static` and each test binds the client to a local, so the async bodies never capture
+/// `self` — a test case is not `Sendable`. The local is a snapshot taken before the handoff: a test that
+/// reassigned `cassandraClient` mid-body would not see the new value there.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 final class PaginatedDecodingIntegrationTests: XCTestCase {
     private static let partition: Int32 = 1
@@ -84,6 +88,19 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         self.cassandraClient = nil  // FIXME: for tsan
     }
 
+    /// The bound values for one fixture row, built fresh per row: `run` takes `parameters` as `sending`,
+    /// and the futures below are collected and awaited together.
+    private static func insertParameters(
+        index: Int,
+        nullPayloadAt: Int?
+    ) -> [CassandraClient.Statement.Value] {
+        [
+            .int32(Self.partition),
+            .int32(Int32(index)),
+            index == nullPayloadAt ? .null : .string("payload-\(index)"),
+        ]
+    }
+
     /// Create the fixture table and insert `count` rows into one partition with `ck` 0..<count.
     /// `nullPayloadAt` writes a null `payload` at that clustering key.
     private func makeTable(rows count: Int, nullPayloadAt: Int? = nil) throws -> String {
@@ -95,12 +112,10 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let options = CassandraClient.Statement.Options(consistency: .localQuorum)
         var futures = [EventLoopFuture<Void>]()
         for index in 0..<count {
-            let payload: CassandraClient.Statement.Value =
-                index == nullPayloadAt ? .null : .string("payload-\(index)")
             futures.append(
                 self.cassandraClient.run(
                     "insert into \(table) (pk, ck, payload) values (?, ?, ?);",
-                    parameters: [.int32(Self.partition), .int32(Int32(index)), payload],
+                    parameters: Self.insertParameters(index: index, nullPayloadAt: nullPayloadAt),
                     options: options
                 )
             )
@@ -111,7 +126,7 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         return table
     }
 
-    private func selectAll(_ table: String) -> String {
+    private static func selectAll(_ table: String) -> String {
         "select pk, ck, payload from \(table) where pk = \(Self.partition);"
     }
 
@@ -123,16 +138,17 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let count = 25  // > pageSize: 3 pages
         let table = try self.makeTable(rows: count)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 for try await item in paged {
                     decoded.append(item)
                 }
 
-                let buffered: [Item] = try await self.cassandraClient.query(self.selectAll(table))
+                let buffered: [Item] = try await client.query(Self.selectAll(table))
                 XCTAssertEqual(decoded.count, count, "every row should be yielded")
                 XCTAssertEqual(decoded, buffered, "paged decoding should match the buffered decoding query")
                 XCTAssertEqual(
@@ -157,10 +173,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let count = 25  // > pageSize: 3 pages
         let table = try self.makeTable(rows: count)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
-                let paged = try await self.cassandraClient.query(
-                    self.selectAll(table),
+                let paged = try await client.query(
+                    Self.selectAll(table),
                     pageSize: Self.pageSize,
                     withModelType: Item.self
                 )
@@ -169,8 +186,8 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
                     decoded.append(item)
                 }
 
-                let buffered = try await self.cassandraClient.query(
-                    self.selectAll(table),
+                let buffered = try await client.query(
+                    Self.selectAll(table),
                     withModelType: Item.self
                 )
                 XCTAssertEqual(decoded.count, count, "every row should be yielded")
@@ -193,10 +210,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let failingIndex = 15  // second page, so a full page is consumed before the failure
         let table = try self.makeTable(rows: count, nullPayloadAt: failingIndex)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 do {
                     for try await item in paged {
@@ -223,10 +241,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
     func testSurfacesDecodeFailureOnFirstRow() throws {
         let table = try self.makeTable(rows: 25, nullPayloadAt: 0)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 do {
                     for try await item in paged {
@@ -246,10 +265,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
     func testEmptyResult() throws {
         let table = try self.makeTable(rows: 0)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 for try await item in paged {
                     decoded.append(item)
@@ -265,10 +285,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let count = 4  // < pageSize
         let table = try self.makeTable(rows: count)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 for try await item in paged {
                     decoded.append(item)
@@ -285,10 +306,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let count = Int(Self.pageSize) * 2
         let table = try self.makeTable(rows: count)
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 for try await item in paged {
                     decoded.append(item)
@@ -306,10 +328,11 @@ final class PaginatedDecodingIntegrationTests: XCTestCase {
         let table = try self.makeTable(rows: 25)
         let consumed = 12  // stops inside the second page
 
+        let client = self.cassandraClient!
         runAsyncAndWaitFor(
             {
                 let paged: AsyncThrowingMapSequence<CassandraClient.PaginatedRows, Item> =
-                    try await self.cassandraClient.query(self.selectAll(table), pageSize: Self.pageSize)
+                    try await client.query(Self.selectAll(table), pageSize: Self.pageSize)
                 var decoded: [Item] = []
                 for try await item in paged {
                     decoded.append(item)

--- a/Tests/CassandraClientTests/RequestLoggingIntegrationTests.swift
+++ b/Tests/CassandraClientTests/RequestLoggingIntegrationTests.swift
@@ -26,9 +26,12 @@ import XCTest
 /// The async API is used deliberately: the async logging helper emits the record *before* the `await`
 /// returns, so assertions after the call are deterministic (no completion-callback race).
 /// `testConnectFailureLoggedOnce` points at an unroutable host and does not need the cluster.
+///
+/// The helpers below are `static` so the async test bodies never capture `self`: a test case is not
+/// `Sendable`, and none of these need instance state.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 final class RequestLoggingIntegrationTests: XCTestCase {
-    private func makeConfig() -> CassandraClient.Configuration {
+    private static func makeConfig() -> CassandraClient.Configuration {
         let env = ProcessInfo.processInfo.environment
         var config = CassandraClient.Configuration(
             contactPointsProvider: { callback in
@@ -46,10 +49,10 @@ final class RequestLoggingIntegrationTests: XCTestCase {
     }
 
     /// Create a client whose default logger captures, with slow-query logging on ("0" logs all successes).
-    private func makeCapturingClient(
+    private static func makeCapturingClient(
         logBoundValues: Bool = false
     ) -> (CassandraClient, TestLogCapture, String) {
-        var config = self.makeConfig()
+        var config = Self.makeConfig()
         config.slowQueryThresholdMillis = 0
         config.logBoundValues = logBoundValues
         let (logger, capture) = makeCapturingLogger()
@@ -57,7 +60,7 @@ final class RequestLoggingIntegrationTests: XCTestCase {
         return (client, capture, config.keyspace!)
     }
 
-    private func createKeyspaceAndTable(
+    private static func createKeyspaceAndTable(
         _ client: CassandraClient,
         keyspace: String,
         table: String,
@@ -69,17 +72,17 @@ final class RequestLoggingIntegrationTests: XCTestCase {
             )
         }
         let session = client.makeSession(keyspace: keyspace)
-        defer { try? session.shutdown() }
+        defer { XCTAssertNoThrow(try session.shutdown()) }
         try await session.run("create table \(keyspace).\(table) \(schema)")
     }
 
     /// A prepared statement's slow-query record shows the real CQL, not "(prepared)".
     func testPreparedStatementLogsRealCQL() throws {
         runAsyncAndWaitFor {
-            let (client, capture, keyspace) = self.makeCapturingClient()
+            let (client, capture, keyspace) = Self.makeCapturingClient()
             defer { XCTAssertNoThrow(try client.shutdown()) }
             let table = "log_v6b_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.createKeyspaceAndTable(
+            try await Self.createKeyspaceAndTable(
                 client,
                 keyspace: keyspace,
                 table: table,
@@ -87,7 +90,7 @@ final class RequestLoggingIntegrationTests: XCTestCase {
             )
 
             let session = client.makeSession(keyspace: keyspace)
-            defer { try? session.shutdown() }
+            defer { XCTAssertNoThrow(try session.shutdown()) }
             let cql = "insert into \(table) (id, v) values (?, ?)"
             let prepared = try await session.prepare(cql)
             capture.clear()  // ignore setup logs
@@ -104,10 +107,10 @@ final class RequestLoggingIntegrationTests: XCTestCase {
     /// A batch's record carries the "batch" operation label (batch has no single query text).
     func testBatchLogsOperationLabel() throws {
         runAsyncAndWaitFor {
-            let (client, capture, keyspace) = self.makeCapturingClient()
+            let (client, capture, keyspace) = Self.makeCapturingClient()
             defer { XCTAssertNoThrow(try client.shutdown()) }
             let table = "log_v6c_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.createKeyspaceAndTable(
+            try await Self.createKeyspaceAndTable(
                 client,
                 keyspace: keyspace,
                 table: table,
@@ -143,7 +146,7 @@ final class RequestLoggingIntegrationTests: XCTestCase {
             let client = CassandraClient(configuration: config, logger: logger)
             defer { XCTAssertNoThrow(try client.shutdown()) }
             let session = client.makeSession(keyspace: "test")
-            defer { try? session.shutdown() }
+            defer { XCTAssertNoThrow(try session.shutdown()) }
 
             do {
                 try await session.run("select release_version from system.local")
@@ -160,10 +163,10 @@ final class RequestLoggingIntegrationTests: XCTestCase {
     /// A preflight (binding) failure is logged even though it throws before the request is sent.
     func testPreflightFailureLogged() throws {
         runAsyncAndWaitFor {
-            let (client, capture, keyspace) = self.makeCapturingClient()
+            let (client, capture, keyspace) = Self.makeCapturingClient()
             defer { XCTAssertNoThrow(try client.shutdown()) }
             let table = "log_v1c_\(DispatchTime.now().uptimeNanoseconds)"
-            try await self.createKeyspaceAndTable(
+            try await Self.createKeyspaceAndTable(
                 client,
                 keyspace: keyspace,
                 table: table,
@@ -171,7 +174,7 @@ final class RequestLoggingIntegrationTests: XCTestCase {
             )
 
             let session = client.makeSession(keyspace: keyspace)
-            defer { try? session.shutdown() }
+            defer { XCTAssertNoThrow(try session.shutdown()) }
             let prepared = try await session.prepare("insert into \(table) (id, v) values (?, ?)")
             capture.clear()
 
@@ -206,9 +209,9 @@ final class RequestLoggingIntegrationTests: XCTestCase {
 
             // Off (default): the bound value must not leak into any captured record.
             do {
-                let (client, capture, keyspace) = self.makeCapturingClient(logBoundValues: false)
+                let (client, capture, keyspace) = Self.makeCapturingClient(logBoundValues: false)
                 defer { XCTAssertNoThrow(try client.shutdown()) }
-                try await self.createKeyspaceAndTable(
+                try await Self.createKeyspaceAndTable(
                     client,
                     keyspace: keyspace,
                     table: table,
@@ -228,7 +231,7 @@ final class RequestLoggingIntegrationTests: XCTestCase {
 
             // On: the bound value should appear, capped, in the captured records.
             do {
-                let (client, capture, _) = self.makeCapturingClient(logBoundValues: true)
+                let (client, capture, _) = Self.makeCapturingClient(logBoundValues: true)
                 defer { XCTAssertNoThrow(try client.shutdown()) }
                 let marker = "PII_MARKER_ON_\(DispatchTime.now().uptimeNanoseconds)"
                 capture.clear()

--- a/Tests/CassandraClientTests/SSLConfigurationTests.swift
+++ b/Tests/CassandraClientTests/SSLConfigurationTests.swift
@@ -198,9 +198,12 @@ final class SSLConfigurationTests: XCTestCase {
         return ssl
     }
 
-    private func makeCluster(_ configuration: CassandraClient.Configuration) throws -> Cluster {
+    /// Builds the cluster and discards it. `Cluster` is not `Sendable` — the library builds it on the event
+    /// loop for that reason — so the result is dropped there rather than carried back by `wait()`. The tests
+    /// assert on whether building throws; none of them use the cluster.
+    private func makeCluster(_ configuration: CassandraClient.Configuration) throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { try? eventLoopGroup.syncShutdownGracefully() }
-        return try configuration.makeCluster(on: eventLoopGroup.next()).wait()
+        try configuration.makeCluster(on: eventLoopGroup.next()).map { _ in }.wait()
     }
 }

--- a/Tests/CassandraClientTests/StatementPagingSizeTests.swift
+++ b/Tests/CassandraClientTests/StatementPagingSizeTests.swift
@@ -24,7 +24,7 @@ import XCTest
 /// - Note: Imported without `@testable` (unlike the rest of the suite) so that the file stops
 ///   compiling if `setPagingSize` loses its `public` access level.
 final class StatementPagingSizeTests: XCTestCase {
-    private func makeStatement() throws -> CassandraClient.Statement {
+    private static func makeStatement() throws -> CassandraClient.Statement {
         try CassandraClient.Statement(query: "select id from test;")
     }
 
@@ -57,7 +57,7 @@ final class StatementPagingSizeTests: XCTestCase {
     }
 
     func testAcceptsPositiveSizes() throws {
-        let statement = try self.makeStatement()
+        let statement = try Self.makeStatement()
         for size in [1, 10, 5000, Int(Int32.max)] {
             XCTAssertNoThrow(try statement.setPagingSize(size), "page size \(size) should be accepted")
         }
@@ -66,7 +66,7 @@ final class StatementPagingSizeTests: XCTestCase {
     /// The driver treats a non-positive page size as "paging disabled" instead of clamping it, so the
     /// wrapper rejects it rather than returning an unpaginated result from a paginated call.
     func testRejectsNonPositiveSizes() throws {
-        let statement = try self.makeStatement()
+        let statement = try Self.makeStatement()
         for size in [0, -1, Int(Int32.min)] {
             XCTAssertThrowsError(try statement.setPagingSize(size)) { error in
                 self.assertBadParams(error, "page size \(size)")
@@ -78,7 +78,7 @@ final class StatementPagingSizeTests: XCTestCase {
     /// the narrowing conversion. Only meaningful where `Int` is wider than `Int32`.
     func testRejectsSizesAboveInt32Max() throws {
         try XCTSkipUnless(Int.bitWidth > 32, "Int is no wider than Int32 on this platform")
-        let statement = try self.makeStatement()
+        let statement = try Self.makeStatement()
         for size in [Int(Int32.max) + 1, Int.max] {
             XCTAssertThrowsError(try statement.setPagingSize(size)) { error in
                 self.assertBadParams(error, "page size \(size)")
@@ -126,11 +126,16 @@ final class StatementPagingSizeTests: XCTestCase {
         let client = self.makeClient()
         defer { XCTAssertNoThrow(try client.shutdown()) }
 
-        let statement = try self.makeStatement()
+        let statement = try Self.makeStatement()
         try statement.setPagingSize(10)
 
+        // `statement` is handed over `sending`. The call stays out of the `XCTAssertThrowsError`
+        // autoclosure, and `makeStatement` is `static`, so the statement is not in the test case's
+        // region — the error closure below reads `self`. `execute` does not throw; the page-size
+        // failure arrives through the future, which `wait()` still surfaces.
+        let paginated = client.execute(statement: statement, pageSize: Int32(0), on: nil)
         XCTAssertThrowsError(
-            try client.execute(statement: statement, pageSize: Int32(0), on: nil).wait()
+            try paginated.wait()
         ) { error in
             self.assertBadParams(error, "pageSize 0 over a statement already set to 10")
         }

--- a/Tests/CassandraClientTests/TestLogCapture.swift
+++ b/Tests/CassandraClientTests/TestLogCapture.swift
@@ -14,10 +14,11 @@
 
 import Foundation
 import Logging
+import NIOConcurrencyHelpers
 
 /// Test-only capturing `LogHandler` — records emitted entries into a lock-protected buffer so tests can
 /// assert on level / message / metadata. Shared by the request-logging unit and integration tests.
-final class TestLogCapture: @unchecked Sendable {
+final class TestLogCapture: Sendable {
     struct Entry {
         let level: Logger.Level
         let message: String
@@ -26,25 +27,18 @@ final class TestLogCapture: @unchecked Sendable {
         let error: String?
     }
 
-    private let lock = NSLock()
-    private var entries: [Entry] = []
+    private let entries = NIOLockedValueBox<[Entry]>([])
 
     func append(_ entry: Entry) {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.entries.append(entry)
+        self.entries.withLockedValue { $0.append(entry) }
     }
 
     var all: [Entry] {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.entries
+        self.entries.withLockedValue { $0 }
     }
 
     func clear() {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.entries.removeAll()
+        self.entries.withLockedValue { $0.removeAll() }
     }
 }
 

--- a/Tests/CassandraClientTests/TracingSupport.swift
+++ b/Tests/CassandraClientTests/TracingSupport.swift
@@ -72,7 +72,8 @@ enum SharedTestTracer {
     }
 
     /// Thin accessor around the shipped `InMemoryTracer`, exposing finished spans as `CapturedSpan`s.
-    final class Recorder {
+    /// `Sendable` because the tracer it holds is (`Tracer` refines it) and is stored immutably.
+    final class Recorder: Sendable {
         let tracer = InMemoryTracer()
         var recorded: [CapturedSpan] { self.tracer.finishedSpans.map(CapturedSpan.init) }
         func reset() { self.tracer.clearAll(includingActive: true) }

--- a/Tests/CassandraClientTests/TracingTests.swift
+++ b/Tests/CassandraClientTests/TracingTests.swift
@@ -164,6 +164,8 @@ final class TracingUnitTests: XCTestCase {
 
 // MARK: - Integration (live cluster) — CASSANDRA_HOST=<host> swift test --filter TracingIntegrationTests
 
+// The helpers below are `static` so the async test bodies never capture `self`: a test case is not
+// `Sendable`, and none of these need instance state.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 final class TracingIntegrationTests: XCTestCase {
     override func setUp() {
@@ -172,7 +174,7 @@ final class TracingIntegrationTests: XCTestCase {
         SharedTestTracer.instance.reset()
     }
 
-    private func makeConfig() -> CassandraClient.Configuration {
+    private static func makeConfig() -> CassandraClient.Configuration {
         let env = ProcessInfo.processInfo.environment
         var config = CassandraClient.Configuration(
             contactPointsProvider: { callback in
@@ -189,7 +191,7 @@ final class TracingIntegrationTests: XCTestCase {
         return config
     }
 
-    private func createKeyspaceAndTable(
+    private static func createKeyspaceAndTable(
         _ client: CassandraClient,
         keyspace: String,
         table: String,
@@ -201,31 +203,31 @@ final class TracingIntegrationTests: XCTestCase {
             )
         }
         let session = client.makeSession(keyspace: keyspace)
-        defer { try? session.shutdown() }
+        defer { XCTAssertNoThrow(try session.shutdown()) }
         try await session.run("create table \(keyspace).\(table) \(schema)")
     }
 
-    private func spans(named name: String) -> [CapturedSpan] {
+    private static func spans(named name: String) -> [CapturedSpan] {
         SharedTestTracer.instance.recorded.filter { $0.operationName == name }
     }
 
-    private var executeSpans: [CapturedSpan] { self.spans(named: "Cassandra execute") }
+    private static var executeSpans: [CapturedSpan] { Self.spans(named: "Cassandra execute") }
 
     /// V1 (+ positive control for V7) — a successful query emits exactly one `.client` "Cassandra execute"
     /// span with the frozen attributes and no error status.
     func testV1_successEmitsOneClientExecuteSpan() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
 
                 SharedTestTracer.instance.reset()
                 try await client.withSession(keyspace: .none) { session in
                     _ = try await session.query("select release_version from system.local")
                 }
 
-                XCTAssertEqual(self.executeSpans.count, 1, "exactly one execute span (delta control for V7)")
-                let span = try XCTUnwrap(self.executeSpans.first)
+                XCTAssertEqual(Self.executeSpans.count, 1, "exactly one execute span (delta control for V7)")
+                let span = try XCTUnwrap(Self.executeSpans.first)
                 XCTAssertEqual(span.kind, .client)
                 XCTAssertEqual(span.attributes["db.system.name"], "cassandra")
                 XCTAssertEqual(span.attributes["db.operation.name"], "execute")
@@ -241,8 +243,8 @@ final class TracingIntegrationTests: XCTestCase {
     func testV2b_serverErrorRecordsCategoryWithoutServerText() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
 
                 SharedTestTracer.instance.reset()
                 do {
@@ -254,7 +256,7 @@ final class TracingIntegrationTests: XCTestCase {
                     // expected
                 }
 
-                let span = try XCTUnwrap(self.executeSpans.first)
+                let span = try XCTUnwrap(Self.executeSpans.first)
                 XCTAssertEqual(span.statusCode, .error)
                 XCTAssertEqual(
                     span.attributes["cassandra.error.category"],
@@ -276,8 +278,8 @@ final class TracingIntegrationTests: XCTestCase {
     func testV3_executeSpanParentsToCallerSpan() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
 
                 SharedTestTracer.instance.reset()
                 try await withSpan("caller") { _ in
@@ -286,8 +288,8 @@ final class TracingIntegrationTests: XCTestCase {
                     }
                 }
 
-                let caller = try XCTUnwrap(self.spans(named: "caller").first)
-                let execute = try XCTUnwrap(self.executeSpans.first)
+                let caller = try XCTUnwrap(Self.spans(named: "caller").first)
+                let execute = try XCTUnwrap(Self.executeSpans.first)
                 XCTAssertEqual(execute.parentSpanID, caller.spanID, "execute span must parent to the caller span")
             },
             30.0
@@ -303,18 +305,18 @@ final class TracingIntegrationTests: XCTestCase {
     func testV5_directNextPageEmitsOneSpanPerPage() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
-                let keyspace = self.makeConfig().keyspace!
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                let keyspace = Self.makeConfig().keyspace!
                 let table = "trace_v5_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.createKeyspaceAndTable(
+                try await Self.createKeyspaceAndTable(
                     client,
                     keyspace: keyspace,
                     table: table,
                     schema: "(id int primary key)"
                 )
                 let session = client.makeSession(keyspace: keyspace)
-                defer { try? session.shutdown() }
+                defer { XCTAssertNoThrow(try session.shutdown()) }
                 for i in 0..<3 { try await session.run("insert into \(table) (id) values (\(i));") }
 
                 SharedTestTracer.instance.reset()
@@ -323,7 +325,7 @@ final class TracingIntegrationTests: XCTestCase {
                     _ = try await paginated.nextPage()
                 }
 
-                XCTAssertEqual(self.executeSpans.count, 3, "one execute span per fetched page")
+                XCTAssertEqual(Self.executeSpans.count, 3, "one execute span per fetched page")
             },
             30.0
         )
@@ -334,18 +336,18 @@ final class TracingIntegrationTests: XCTestCase {
     func testV5b_forAwaitPagesParentToCallerSpan() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
-                let keyspace = self.makeConfig().keyspace!
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                let keyspace = Self.makeConfig().keyspace!
                 let table = "trace_v5b_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.createKeyspaceAndTable(
+                try await Self.createKeyspaceAndTable(
                     client,
                     keyspace: keyspace,
                     table: table,
                     schema: "(id int primary key)"
                 )
                 let session = client.makeSession(keyspace: keyspace)
-                defer { try? session.shutdown() }
+                defer { XCTAssertNoThrow(try session.shutdown()) }
                 for i in 0..<3 { try await session.run("insert into \(table) (id) values (\(i));") }
 
                 SharedTestTracer.instance.reset()
@@ -357,8 +359,8 @@ final class TracingIntegrationTests: XCTestCase {
                     XCTAssertEqual(seen, 3)
                 }
 
-                let caller = try XCTUnwrap(self.spans(named: "caller").first)
-                let pages = self.executeSpans
+                let caller = try XCTUnwrap(Self.spans(named: "caller").first)
+                let pages = Self.executeSpans
                 XCTAssertFalse(pages.isEmpty, "for-await should fetch pages via execute spans")
                 for page in pages {
                     XCTAssertEqual(
@@ -377,25 +379,25 @@ final class TracingIntegrationTests: XCTestCase {
     func testV6_preparedExecuteShowsRealCQLAndYieldsOneSpan() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
-                let keyspace = self.makeConfig().keyspace!
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                let keyspace = Self.makeConfig().keyspace!
                 let table = "trace_v6_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.createKeyspaceAndTable(
+                try await Self.createKeyspaceAndTable(
                     client,
                     keyspace: keyspace,
                     table: table,
                     schema: "(id bigint primary key, v text)"
                 )
                 let session = client.makeSession(keyspace: keyspace)
-                defer { try? session.shutdown() }
+                defer { XCTAssertNoThrow(try session.shutdown()) }
 
                 let cql = "insert into \(table) (id, v) values (?, ?)"
 
                 // The prepare site opens a "Cassandra prepare" span carrying the real CQL, .client, no consistency.
                 SharedTestTracer.instance.reset()
                 let prepared = try await session.prepare(cql)
-                let prepareSpan = try XCTUnwrap(self.spans(named: "Cassandra prepare").first)
+                let prepareSpan = try XCTUnwrap(Self.spans(named: "Cassandra prepare").first)
                 XCTAssertEqual(prepareSpan.kind, .client)
                 XCTAssertEqual(prepareSpan.attributes["db.operation.name"], "prepare")
                 XCTAssertEqual(prepareSpan.attributes["db.query.text"], cql)
@@ -405,11 +407,11 @@ final class TracingIntegrationTests: XCTestCase {
                 SharedTestTracer.instance.reset()
                 _ = try await session.execute(prepared: prepared, parameters: [.int64(1), .string("x")])
                 XCTAssertEqual(
-                    self.executeSpans.count,
+                    Self.executeSpans.count,
                     1,
                     "execute(prepared:) delegates to execute(statement:) — one span, not two"
                 )
-                let execute = try XCTUnwrap(self.executeSpans.first)
+                let execute = try XCTUnwrap(Self.executeSpans.first)
                 XCTAssertEqual(execute.attributes["db.query.text"], cql)
                 XCTAssertNotEqual(execute.attributes["db.query.text"], "(prepared)")
             },
@@ -430,7 +432,7 @@ final class TracingIntegrationTests: XCTestCase {
                 config.keyspace = "test"
                 config.connectTimeoutMillis = 2_000
                 let client = CassandraClient(configuration: config)
-                defer { try? client.shutdown() }
+                defer { XCTAssertNoThrow(try client.shutdown()) }
 
                 SharedTestTracer.instance.reset()
                 do {
@@ -442,7 +444,7 @@ final class TracingIntegrationTests: XCTestCase {
                     // expected
                 }
 
-                XCTAssertEqual(self.executeSpans.count, 0, "span opens post-connect, so a failed connect emits none")
+                XCTAssertEqual(Self.executeSpans.count, 0, "span opens post-connect, so a failed connect emits none")
             },
             15.0
         )
@@ -453,11 +455,11 @@ final class TracingIntegrationTests: XCTestCase {
     func testA1_batchOpensBatchSpan() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
-                let keyspace = self.makeConfig().keyspace!
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                let keyspace = Self.makeConfig().keyspace!
                 let table = "trace_batch_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.createKeyspaceAndTable(
+                try await Self.createKeyspaceAndTable(
                     client,
                     keyspace: keyspace,
                     table: table,
@@ -474,7 +476,7 @@ final class TracingIntegrationTests: XCTestCase {
                     )
                 }
 
-                let batchSpans = self.spans(named: "Cassandra batch")
+                let batchSpans = Self.spans(named: "Cassandra batch")
                 XCTAssertEqual(batchSpans.count, 1)
                 let span = try XCTUnwrap(batchSpans.first)
                 XCTAssertEqual(span.kind, .client)
@@ -493,8 +495,8 @@ final class TracingIntegrationTests: XCTestCase {
     func testA4_pageSizeConstructionEmitsNoSpanUntilFetch() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
 
                 try await client.withSession(keyspace: .none) { session in
                     SharedTestTracer.instance.reset()
@@ -502,10 +504,10 @@ final class TracingIntegrationTests: XCTestCase {
                         "select release_version from system.local",
                         pageSize: Int32(100)
                     )
-                    XCTAssertEqual(self.executeSpans.count, 0, "constructing PaginatedRows opens no span")
+                    XCTAssertEqual(Self.executeSpans.count, 0, "constructing PaginatedRows opens no span")
 
                     _ = try await paginated.nextPage()
-                    XCTAssertEqual(self.executeSpans.count, 1, "the span opens when a page is fetched")
+                    XCTAssertEqual(Self.executeSpans.count, 1, "the span opens when a page is fetched")
                 }
             },
             30.0
@@ -518,10 +520,10 @@ final class TracingIntegrationTests: XCTestCase {
     func testA7_consistencyResolvedFromStatementThenConfig() {
         runAsyncAndWaitFor(
             {
-                var config = self.makeConfig()
+                var config = Self.makeConfig()
                 config.consistency = .quorum
                 let client = CassandraClient(configuration: config)
-                defer { try? client.shutdown() }
+                defer { XCTAssertNoThrow(try client.shutdown()) }
 
                 // Statement-level consistency wins over the config default.
                 SharedTestTracer.instance.reset()
@@ -530,13 +532,13 @@ final class TracingIntegrationTests: XCTestCase {
                     options: .init(consistency: .one)
                 )
                 _ = try await client.execute(statement: explicit)
-                XCTAssertEqual(self.executeSpans.first?.attributes["cassandra.consistency.level"], "one")
+                XCTAssertEqual(Self.executeSpans.first?.attributes["cassandra.consistency.level"], "one")
 
                 // No statement-level consistency -> the config default is used.
                 SharedTestTracer.instance.reset()
                 let inherited = try CassandraClient.Statement(query: "select release_version from system.local")
                 _ = try await client.execute(statement: inherited)
-                XCTAssertEqual(self.executeSpans.first?.attributes["cassandra.consistency.level"], "quorum")
+                XCTAssertEqual(Self.executeSpans.first?.attributes["cassandra.consistency.level"], "quorum")
             },
             30.0
         )
@@ -547,11 +549,11 @@ final class TracingIntegrationTests: XCTestCase {
     func testA9_preflightFailureNotTraced() {
         runAsyncAndWaitFor(
             {
-                let client = CassandraClient(configuration: self.makeConfig())
-                defer { try? client.shutdown() }
-                let keyspace = self.makeConfig().keyspace!
+                let client = CassandraClient(configuration: Self.makeConfig())
+                defer { XCTAssertNoThrow(try client.shutdown()) }
+                let keyspace = Self.makeConfig().keyspace!
                 let table = "trace_preflight_\(DispatchTime.now().uptimeNanoseconds)"
-                try await self.createKeyspaceAndTable(
+                try await Self.createKeyspaceAndTable(
                     client,
                     keyspace: keyspace,
                     table: table,
@@ -559,7 +561,7 @@ final class TracingIntegrationTests: XCTestCase {
                 )
 
                 let session = client.makeSession(keyspace: keyspace)
-                defer { try? session.shutdown() }
+                defer { XCTAssertNoThrow(try session.shutdown()) }
                 let prepared = try await session.prepare("insert into \(table) (id, v) values (?, ?)")
 
                 SharedTestTracer.instance.reset()  // ignore the prepare span
@@ -574,7 +576,7 @@ final class TracingIntegrationTests: XCTestCase {
                     // expected
                 }
 
-                XCTAssertEqual(self.executeSpans.count, 0, "preflight failure throws before the span opens")
+                XCTAssertEqual(Self.executeSpans.count, 0, "preflight failure throws before the span opens")
             },
             30.0
         )


### PR DESCRIPTION
### Motivation

The library target builds under the Swift 6 language mode. The test target opted out with `.swiftLanguageMode(.v5)`, so its data-race diagnostics were never enforced, and it carried warnings the library does not.

### Modifications

Removed the opt-out and cleared what it surfaced.

The `self`-capture errors are fixed by not capturing `self`: helpers that need no instance state are `static`, and test bodies bind the client or configuration to a local before handing work to another task. No `@unchecked Sendable` is added, and the five the target already carried are removed, so it now declares none — matching the library.

`run` takes `parameters` as `sending`, which four sites tripped. Two passed the array from inside an `XCTAssertNoThrow` autoclosure, where the capture leaves the hand-off provably non-final; the call moves out and the assertion covers `wait()`, which is the only part that can throw. Two built the array into a named local inside a loop whose futures are collected and awaited together; those now come from a helper returning a fresh array per row.

The rest: `defer { try? shutdown() }` in async tests becomes `XCTAssertNoThrow(try shutdown())`, whose autoclosure is a synchronous context, since `shutdownAsync()` is unreachable in a `defer`; concurrent fan-out collects through `NIOLockedValueBox`; three unused results are discarded explicitly; and `PaginatedRows.map` coverage moves into its own test so the deprecation suppression covers that call rather than a whole test body.

Nothing under `Sources/` changed.

### Result

Both targets build with no errors and no warnings. Teardown is the one place a test reports more than before: `try? shutdown()` discarded failures, and those sites now assert.

Local integration runs cover 190 XCTest plus the swift-testing suite, but skip the six `CustomAuthenticationIntegrationTests` gated on `CASSANDRA_REQUIRE_AUTH`; CI sets that flag, so those are covered there rather than locally.
