### PR TITLE
Allow statements to be marked idempotent to enable host failover

### DIFF
--- a/Sources/CassandraClient/Statement.swift
+++ b/Sources/CassandraClient/Statement.swift
@@ -234,6 +234,12 @@ extension CassandraClient {
             if let requestTimeout = options.requestTimeout {
                 try checkResult { cass_statement_set_request_timeout(self.rawPointer, requestTimeout) }
             }
+
+            if let isIdempotent = options.isIdempotent {
+                try checkResult {
+                    cass_statement_set_is_idempotent(self.rawPointer, isIdempotent ? cass_true : cass_false)
+                }
+            }
         }
 
         /// Encrypt plaintext and bind the result as bytes at the given parameter index.
@@ -514,6 +520,24 @@ extension CassandraClient {
             /// Sets the statement's request timeout in milliseconds. `nil` inherits
             /// ``CassandraClient/Configuration/requestTimeoutMillis``.
             public var requestTimeout: UInt64?
+            /// Whether the statement is safe to run more than once.
+            ///
+            /// A statement left unset is treated as unsafe to replay, which holds the driver back
+            /// from two recovery behaviors:
+            ///
+            /// - When a coordinator reports that it is overloaded, shutting down, or hit an internal
+            ///   error, the driver hands the request to the next host in its query plan instead of
+            ///   failing the call. Without this, a single node draining during a rolling restart
+            ///   surfaces as an error even though the rest of the cluster can serve the request.
+            /// - Speculative execution, configured by
+            ///   ``CassandraClient/Configuration/speculativeExecutionPolicy``, has no effect at all
+            ///   until a statement is marked safe to replay.
+            ///
+            /// - Important: Only mark a statement idempotent when running it twice leaves the same
+            ///   result as running it once. Counter updates, lightweight transactions, and appends to
+            ///   collections are not idempotent, and replaying one corrupts the value it touches.
+            ///   Plain reads, and writes that set fixed values, are.
+            public var isIdempotent: Bool?
 
             /// Type-erased backing store for ``encryptionContextBuilder``.
             private var _encryptionContextBuilder: (any Sendable)?
@@ -562,16 +586,31 @@ extension CassandraClient {
                 self._encryptionContextBuilder != nil || self._encryptionTable != nil
             }
 
-            public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {
+            public init(
+                consistency: CassandraClient.Consistency? = nil,
+                requestTimeout: UInt64? = nil,
+                isIdempotent: Bool?
+            ) {
                 self.consistency = consistency
                 self.requestTimeout = requestTimeout
+                self.isIdempotent = isIdempotent
+            }
+
+            /// Creates options that leave ``isIdempotent`` unset, so the driver keeps treating the
+            /// statement as unsafe to replay.
+            ///
+            /// `isIdempotent` is required rather than defaulted on the initializer that takes it, so
+            /// that passing it selects that initializer and omitting it selects this one.
+            public init(consistency: CassandraClient.Consistency? = nil, requestTimeout: UInt64? = nil) {
+                self.init(consistency: consistency, requestTimeout: requestTimeout, isIdempotent: nil)
             }
 
             public var description: String {
                 """
                 Options {
                 consistency: \(String(describing: self.consistency)),
-                requestTimeout: \(String(describing: self.requestTimeout))
+                requestTimeout: \(String(describing: self.requestTimeout)),
+                isIdempotent: \(String(describing: self.isIdempotent))
                 }
                 """
             }

--- a/Tests/CassandraClientTests/StatementIdempotencyTests.swift
+++ b/Tests/CassandraClientTests/StatementIdempotencyTests.swift
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cassandra Client open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Cassandra Client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Cassandra Client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CassandraClient
+import XCTest
+
+/// Unit tests for ``CassandraClient/Statement/Options/isIdempotent``. Marking a statement idempotent
+/// is what lets the driver replay it on another coordinator, so the option has to survive the trip
+/// from `Options` into the statement the driver executes.
+///
+/// The driver offers no way to read the flag back: the setter always reports success, and the
+/// declaration that holds the value is private to the C++ sources. So the failover this unlocks is
+/// only observable against a cluster with a node actually refusing requests, which is beyond what
+/// this suite can stand up. What is pinned here is the option's contract: its default, that it
+/// reaches statement construction for both plain and parameterized queries, and that it is carried
+/// rather than dropped.
+///
+/// - Note: Imported without `@testable` (unlike the rest of the suite) so that the file stops
+///   compiling if the option loses its `public` access level.
+final class StatementIdempotencyTests: XCTestCase {
+    /// Unset by default, so the driver keeps treating statements as non-idempotent. Anything else
+    /// would silently make every existing caller's writes replayable.
+    func testDefaultsToUnset() {
+        XCTAssertNil(CassandraClient.Statement.Options().isIdempotent)
+        XCTAssertNil(CassandraClient.Statement.Options(consistency: .quorum).isIdempotent)
+    }
+
+    /// `nil` and `false` are distinct inputs that reach the driver differently (one leaves the
+    /// default in place, the other sets it), so the option keeps them apart instead of collapsing
+    /// to a plain `Bool`.
+    func testCarriesEachSetting() {
+        for setting in [true, false] {
+            var options = CassandraClient.Statement.Options()
+            options.isIdempotent = setting
+            XCTAssertEqual(options.isIdempotent, setting)
+        }
+    }
+
+    func testInitializerAcceptsIdempotency() {
+        let options = CassandraClient.Statement.Options(
+            consistency: .quorum,
+            requestTimeout: 1000,
+            isIdempotent: true
+        )
+        XCTAssertEqual(options.isIdempotent, true)
+        XCTAssertEqual(options.consistency, .quorum)
+        XCTAssertEqual(options.requestTimeout, 1000)
+    }
+
+    /// The initializer that predates the idempotency option stays available as its own overload, so
+    /// existing callers keep resolving it. Referencing both without applying them pins that: an
+    /// unapplied initializer drops its default arguments, so each annotation below only type-checks
+    /// against an initializer that really takes those parameters.
+    func testBothInitializersRemainAvailable() {
+        typealias Options = CassandraClient.Statement.Options
+        typealias Consistency = CassandraClient.Consistency
+
+        let withoutIdempotency: (Consistency?, UInt64?) -> Options = Options.init
+        let withIdempotency: (Consistency?, UInt64?, Bool?) -> Options = Options.init
+
+        XCTAssertNil(withoutIdempotency(.quorum, 1000).isIdempotent)
+        XCTAssertEqual(withIdempotency(.quorum, 1000, true).isIdempotent, true)
+    }
+
+    /// The shorter initializer has to keep leaving idempotency unset rather than picking a value, so
+    /// that callers written before the option existed still get the driver's default.
+    func testOriginalInitializerLeavesIdempotencyUnset() {
+        XCTAssertNil(CassandraClient.Statement.Options(consistency: .quorum, requestTimeout: 1000).isIdempotent)
+    }
+
+    /// The option is applied while the statement is being built, alongside consistency and the
+    /// request timeout. Building one for each setting pins that the apply step accepts them all
+    /// rather than rejecting a value the driver is fine with.
+    func testStatementConstructionAcceptsEachSetting() throws {
+        for setting in [nil, true, false] as [Bool?] {
+            var options = CassandraClient.Statement.Options()
+            options.isIdempotent = setting
+            XCTAssertNoThrow(
+                try CassandraClient.Statement(query: "select id from test;", options: options),
+                "isIdempotent \(String(describing: setting)) should be accepted"
+            )
+        }
+    }
+
+    /// Parameterized statements bind their values before the options are applied, so they exercise
+    /// a longer path to the same apply step.
+    func testParameterizedStatementConstructionAcceptsIdempotency() throws {
+        let options = CassandraClient.Statement.Options(isIdempotent: true)
+        XCTAssertNoThrow(
+            try CassandraClient.Statement(
+                query: "select id from test where id = ?;",
+                parameters: [.int32(1)],
+                options: options
+            )
+        )
+    }
+
+    /// `Options` is printed when a query is logged or traced, and a replayable statement is worth
+    /// seeing there.
+    func testDescriptionReportsIdempotency() {
+        XCTAssertTrue(
+            CassandraClient.Statement.Options(isIdempotent: true).description.contains("isIdempotent"),
+            "description should report the idempotency setting"
+        )
+    }
+}


### PR DESCRIPTION
Adds an `isIdempotent` option to `Statement.Options`, which the bundled driver requires before it will retry a statement on another host or execute it speculatively.

### Motivation:

When a C* node drains during a rolling restart, it returns `OVERLOADED` state, this is handled gracefully in the vendored DataStax driver by connecting to the next host, but the Swift client never marks statements idempotent, so it skips the retry policy entirely. The caller gets a hard `serverOverloaded` while the rest of the cluster is healthy, and can lead to service crashing.

### Modifications:

- Added `isIdempotent: Bool?` to `Statement.Options`, mirroring the existing `Batch.Configuration.isIdempotent`. Keeping it optional preserves the distinction between leaving the driver default alone and explicitly setting it, which are different calls into the driver.
- Applied it through `cass_statement_set_is_idempotent` in the step that already applies `consistency` and `requestTimeout`. Both the plain and the prepared-statement initializers run that step, so both paths pick it up.
- Added an initializer that takes the new option. The original `init(consistency:requestTimeout:)` is kept with its signature and default arguments unchanged, forwarding to the new one. `isIdempotent` is deliberately required rather than defaulted on the initializer that accepts it, because if both overloads defaulted every shared parameter then `Options()` would be ambiguous. Its presence or absence now selects the overload.
- Included the setting in `Options.description`.
- Added `Tests/CassandraClientTests/StatementIdempotencyTests.swift`.

### Result:

Callers can mark a statement safe to replay:

```swift
let options = CassandraClient.Statement.Options(isIdempotent: true)
let statement = try CassandraClient.Statement(query: "SELECT id FROM test;", options: options)
```

When they do, an `OVERLOADED` or `SERVER_ERROR` response makes the driver hand the request to the next host in its query plan instead of failing the call, and a configured `speculativeExecutionPolicy` starts taking effect. Write timeouts also reach the retry policy, though the default policy still only retries batch-log writes.

### Tests

The flag was verified as reaching the driver by temporarily exposing Statement::is_idempotent() through a local C shim and reading it back off the request object. isIdempotent: true produces true, unset and false produce false, and disabling the setter as a negative control flips the positive assertions to failing. That scaffolding isn't part of this PR, since it needs a getter the public C API doesn't provide. The committed tests therefore pin the option's contract rather than the driver round-trip, and the failover it unlocks still needs a multi-node cluster with a draining node to observe end to end.
